### PR TITLE
fix(tests): the window stub is faithful to the contract the client uses

### DIFF
--- a/apps/server/tests/cards-view.test.ts
+++ b/apps/server/tests/cards-view.test.ts
@@ -32,7 +32,20 @@ function mount(cards: SessionCard[] | null): { host: any; opened: string[]; expa
   const doc: any = fakeDoc();
   (globalThis as any).document = doc;
   const opened: string[] = [];
-  (globalThis as any).window = { open: (u: string) => opened.push(u) };
+  // A fixture may be synthetic in content and must be faithful in SHAPE, and a `window` is no
+  // exception: this one is installed on the GLOBAL and only restored in `after()`, so for the whole
+  // length of this file any other file's test that runs in between sees it. With `open` alone,
+  // `trace.ts`'s `destroy()` — which calls `window.removeEventListener` — died with
+  // "is not a function", nondeterministically, depending on where node:test happened to interleave
+  // the two files. Green here, green on a pull request, red on main two minutes later.
+  // These four members are the entire `window` contract `src/client` uses (measured); a fifth one
+  // appearing there without appearing here is the same bug again.
+  (globalThis as any).window = {
+    open: (u: string) => opened.push(u),
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    location: { href: '' },
+  };
   const host = doc.createElement('div');
   const state = { expanded: 0 };
   renderCardsCard(host, cards === null ? null : { cards }, () => {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable structural changes to seedeep are recorded here, newest first.
 
 ## Unreleased
 
+**Three tests that were green on a pull request and red on `main` two minutes later.** A test file
+installs a stub `window` on the GLOBAL and only restores it in `after()`, so for the whole length of
+that file any other file's test that node:test happens to interleave sees it — and the stub carried
+`open` alone, where `trace.ts`'s `destroy()` calls `window.removeEventListener`. The failure was
+therefore a matter of scheduling, invisible locally and reproducible nowhere on demand: it took a CI
+stack trace to name it. The stub now carries the whole four-member contract `src/client` actually
+uses (`open`, `addEventListener`, `removeEventListener`, `location`), because the rule fixtures live
+by — synthetic in content, faithful in SHAPE — is not suspended for a `window`.
+
 **The network is a named capability now, and the linter is what names it.** seedeep's claim is that
 session content does not leave the machine, and until now nothing checked it: a pull request adding
 an outbound call would have passed every gate. The first attempt at a check was a bespoke test that


### PR DESCRIPTION
Three graph tests were green on the pull request and red on main two minutes
later. cards-view.test.ts installs a stub window on the global and restores it
only in after(), so for the length of that file any other file's test that
node:test interleaves sees it - and the stub carried `open` alone, where
trace.ts's destroy() calls window.removeEventListener.

Nondeterministic by construction, so it reproduces nowhere on demand; the CI
stack trace is what named it. The stub now carries the four members src/client
actually uses, measured rather than guessed.
