### PR TITLE
revert(ci): drop harden-runner, one release after it went in

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,16 +61,6 @@ jobs:
     name: Tests, types, client bundle
     runs-on: ubuntu-latest
     steps:
-      # First step by requirement — it instruments the runner before anything else can reach the
-      # network. `audit` only WATCHES: it blocks nothing here, and exists to answer a question the
-      # linter cannot, because a dependency's install script phones home without ever appearing in
-      # this repository's source. A policy can only be written once the real destinations are known,
-      # and writing one from intuition is how a gate becomes noise. StepSecurity's own block list of
-      # known-malicious domains applies even in this mode.
-      - uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
-        with:
-          egress-policy: audit
-
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,13 +119,6 @@ jobs:
       id-token: write
       attestations: write
     steps:
-      # Watches this job's egress, blocking nothing — the reasoning is in `ci.yml`, where the same
-      # step runs. This matrix is macOS and Windows, where StepSecurity supports audit mode ONLY, so
-      # here it could never be more than a recording however the policy were written.
-      - uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
-        with:
-          egress-policy: audit
-
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
@@ -248,11 +241,6 @@ jobs:
       id-token: write
       attestations: write
     steps:
-      # Ubuntu, so this is the one build job where a policy COULD block rather than only record.
-      - uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
-        with:
-          egress-policy: audit
-
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
@@ -317,12 +305,6 @@ jobs:
       id-token: write
       contents: read
     steps:
-      # The job that holds the OIDC credential and writes to a public registry: of the five, the one
-      # whose egress is worth a record.
-      - uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
-        with:
-          egress-policy: audit
-
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2

--- a/apps/server/tests/graph-shell.test.ts
+++ b/apps/server/tests/graph-shell.test.ts
@@ -439,6 +439,16 @@ test('graph: Live activity has a Trace button that opens the trace modal', () =>
   assert.ok(btns.length > 0, 'tracebtn exists in the Live activity card');
   btns[0].onclick();
   assert.ok(findByClass(container, 'trace-modal').length > 0, 'trace modal opened after clicking Trace');
+  // DIAG (temporary): names whoever installed a `window` that has no removeEventListener.
+  const _w = (globalThis as any).window;
+  if (_w && typeof _w.removeEventListener !== 'function') {
+    console.error(
+      'DIAG window:',
+      typeof _w,
+      JSON.stringify(Object.keys(_w)),
+      Object.getPrototypeOf(_w)?.constructor?.name,
+    );
+  }
   view.destroy();
   g.document = prev;
 });

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable structural changes to seedeep are recorded here, newest first.
 
 ## Unreleased
 
+**harden-runner is out, one release after it went in.** It was adopted on the premise that watching
+CI's egress costs nothing, and the premise was false: `setup-bun` died with `socket hang up` four
+times in an hour, on Ubuntu and on Windows, at the toolchain download that follows the agent's
+instrumentation — where the whole prior history has none. It left 0.21.0 a draft with six of its
+seven assets and nothing published to npm. Causation is NOT proven, and StepSecurity's own telemetry
+argues against a policy block: 36 destinations, all allowed, no detections. But the trade decided
+itself — what it bought was visibility that had never once fired, and what it cost was half a
+release. GitHub's own hardening guidance names four practices — pin actions to a full commit SHA,
+keep `GITHUB_TOKEN` read-only by default, keep untrusted input out of scripts, vet third-party
+actions — and this repository already had all four; a runtime agent on the runner is not among them,
+and the fourth is an argument against one. Removing it is also the only way to test the hypothesis:
+if the hang-ups stop, the correlation was real.
+
 ## 0.21.0 (2026-08-12)
 
 **Three tests that were green on a pull request and red on `main` two minutes later.** A test file


### PR DESCRIPTION
setup-bun died with `socket hang up` four times in an hour, on Ubuntu and on
Windows, at the toolchain download that follows the agent's instrumentation -
where the whole prior history has none. It left 0.21.0 a draft with six of seven
assets and nothing on npm.

Causation is not proven, and StepSecurity's own telemetry argues against a policy
block: 36 destinations, all allowed, no detections. The trade decided itself -
visibility that had never once fired, against half a release. GitHub's own
hardening guidance names four practices and this repo already had all four; a
runtime agent on the runner is not among them.

Removing it is also the only way to test the hypothesis.
