### PR TITLE
chore(tests): remove the temporary window diagnostic

### DIFF
--- a/apps/server/tests/graph-shell.test.ts
+++ b/apps/server/tests/graph-shell.test.ts
@@ -439,16 +439,6 @@ test('graph: Live activity has a Trace button that opens the trace modal', () =>
   assert.ok(btns.length > 0, 'tracebtn exists in the Live activity card');
   btns[0].onclick();
   assert.ok(findByClass(container, 'trace-modal').length > 0, 'trace modal opened after clicking Trace');
-  // DIAG (temporary): names whoever installed a `window` that has no removeEventListener.
-  const _w = (globalThis as any).window;
-  if (_w && typeof _w.removeEventListener !== 'function') {
-    console.error(
-      'DIAG window:',
-      typeof _w,
-      JSON.stringify(Object.keys(_w)),
-      Object.getPrototypeOf(_w)?.constructor?.name,
-    );
-  }
   view.destroy();
   g.document = prev;
 });


### PR DESCRIPTION
It never fired - the run carrying it was green - and auto-merge landed it on main
before the cleanup commit was checked. The flake it was meant to name is
intermittent and remains unexplained.
