### PR TITLE
fix(tests): one definition of a fake window, so a stub cannot crash another file

### DIFF
--- a/apps/server/tests/cards-view.test.ts
+++ b/apps/server/tests/cards-view.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import { after, test } from 'node:test';
 import { CARD_ROWS, cardsList, renderCardsCard } from '../src/client/cards-view.ts';
 import type { SessionCard } from '../src/core/tracker-cards.ts';
-import { fakeDoc, findByClass, textOf } from './fake-dom.ts';
+import { fakeDoc, fakeWindow, findByClass, textOf } from './fake-dom.ts';
 
 // What a plausible bug here looks like: the card inviting a click when no row can open (the exact
 // failure the Commits card already had), the `read` chip missing so a card the session only looked
@@ -32,20 +32,9 @@ function mount(cards: SessionCard[] | null): { host: any; opened: string[]; expa
   const doc: any = fakeDoc();
   (globalThis as any).document = doc;
   const opened: string[] = [];
-  // A fixture may be synthetic in content and must be faithful in SHAPE, and a `window` is no
-  // exception: this one is installed on the GLOBAL and only restored in `after()`, so for the whole
-  // length of this file any other file's test that runs in between sees it. With `open` alone,
-  // `trace.ts`'s `destroy()` — which calls `window.removeEventListener` — died with
-  // "is not a function", nondeterministically, depending on where node:test happened to interleave
-  // the two files. Green here, green on a pull request, red on main two minutes later.
-  // These four members are the entire `window` contract `src/client` uses (measured); a fifth one
-  // appearing there without appearing here is the same bug again.
-  (globalThis as any).window = {
-    open: (u: string) => opened.push(u),
-    addEventListener: () => {},
-    removeEventListener: () => {},
-    location: { href: '' },
-  };
+  // The stub goes on the GLOBAL and comes down only in `after()`, so every other file's tests see
+  // it while this one runs. `fakeWindow()` is the one definition of what such a stub must carry.
+  (globalThis as any).window = fakeWindow({ open: (u: string) => opened.push(u) });
   const host = doc.createElement('div');
   const state = { expanded: 0 };
   renderCardsCard(host, cards === null ? null : { cards }, () => {

--- a/apps/server/tests/fake-dom.ts
+++ b/apps/server/tests/fake-dom.ts
@@ -174,6 +174,30 @@ export function fakeDoc() {
   };
 }
 
+/**
+ * A fake `window` carrying the WHOLE contract the code under test may reach for, whatever the
+ * caller happens to need.
+ *
+ * It exists because a `window` goes on the GLOBAL, and a global installed by one test file is seen
+ * by every other file in the run — `bun test` shares one process and `node:test` interleaves.
+ * A stub that carries only what its own file needs therefore crashes somebody else's code, on a
+ * schedule nobody controls: `panel-tick.test.ts` installed `{ addEventListener }` at module scope
+ * and never took it down, and three graph tests died in `trace.ts`'s `destroy()` on
+ * `window.removeEventListener` — green locally, red on CI, and green again on a re-run of the same
+ * commit. One definition, so a third file cannot get it wrong.
+ *
+ * Pass `over` to observe a member (a test that wants to see what `open` was called with).
+ */
+export function fakeWindow(over: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    open: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    location: { href: '' },
+    ...over,
+  };
+}
+
 /** The text a user would read in a fake-DOM subtree: leaf textContent, children joined in order. */
 export function textOf(n: any): string {
   const own = n.children?.length ? '' : (n.textContent ?? '');

--- a/apps/tray/tests/panel-tick.test.ts
+++ b/apps/tray/tests/panel-tick.test.ts
@@ -6,7 +6,7 @@
 import { mock } from 'bun:test';
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
-import { fakeDoc, findByClass, textOf } from '../../server/tests/fake-dom.ts';
+import { fakeDoc, fakeWindow, findByClass, textOf } from '../../server/tests/fake-dom.ts';
 import type { Local, Status } from '../ui/connection.ts';
 
 const doc = fakeDoc();
@@ -18,7 +18,10 @@ const root = doc.getElementById('panel') as ReturnType<typeof fakeDoc>['getEleme
 // a constant — the height is not what this file is about, and a missing method would throw inside
 // every render.
 root.getBoundingClientRect = () => ({ height: 200 });
-(globalThis as { window?: unknown }).window = { addEventListener() {} };
+// `panel.ts` only reaches for `addEventListener` — but this goes on the GLOBAL at module scope and
+// is never taken down, so every other file in the run sees it. `fakeWindow()` is what stops a stub
+// sized for one file from crashing another: three graph tests died on `removeEventListener` here.
+(globalThis as { window?: unknown }).window = fakeWindow();
 
 /** Every reading the panel is handed, in order — the tick channel Rust owns. */
 let deliver: ((event: { payload: unknown }) => void) | undefined;

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable structural changes to seedeep are recorded here, newest first.
 
 ## Unreleased
 
+**The intermittent CI failure had a cause, and it was in the other app.** Three graph tests died in
+`trace.ts`'s `destroy()` on `window.removeEventListener`, green locally and red on CI on the same
+commit. The installer was `apps/tray/tests/panel-tick.test.ts`, which put
+`{ addEventListener }` on the GLOBAL at module scope — everything `panel.ts` needs, nothing anybody
+else does — and never took it down. `bun test` shares one process and `node:test` interleaves files,
+so whether that module was evaluated before or after another file's teardown decided the run. It was
+never found by reading, over four rounds of it: the searches covered `apps/server`, and the two apps
+share one suite. What found it was a **setter trap** — `defineProperty` on `globalThis.window`
+printing the shape and the stack of whoever assigns it — which names the installer on every run
+rather than only when the failure fires, and named this one on the first try. There is now one
+definition of a fake window, `fakeWindow()` in `tests/fake-dom.ts`, carrying the whole contract and
+used by both stubs, so a stub sized for one file can no longer crash another.
+
 **harden-runner is out, one release after it went in.** It was adopted on the premise that watching
 CI's egress costs nothing, and the premise was false: `setup-bun` died with `socket hang up` four
 times in an hour, on Ubuntu and on Windows, at the toolchain download that follows the agent's


### PR DESCRIPTION
The intermittent CI failure had a cause, and it was in the other app.
panel-tick.test.ts put { addEventListener } on the GLOBAL at module scope -
everything panel.ts needs, nothing anybody else does - and never took it down.
bun test shares one process and node:test interleaves files, so whether that
module was evaluated before or after another file's teardown decided whether
trace.ts's destroy() found a removeEventListener.

Four rounds of reading missed it: the searches covered apps/server, and the two
apps share one suite. A setter trap on globalThis.window - printing the shape and
the stack of whoever assigns it - named it on the first run.

fakeWindow() in fake-dom.ts is now the single definition, carrying the whole
contract, used by both stubs.
