### PR TITLE
0.22.0

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable structural changes to seedeep are recorded here, newest first.
 
 ## Unreleased
 
+## 0.22.0 (2026-08-13)
+
 **The mark is a lens, not an eye.** The eye was drawn for the name — seedeep, *see* — and said the
 wrong thing about a tool whose whole argument is that it only ever READS: an eye with a pupil and a
 highlight is the iconography of spyware, and it sat permanently in a menu bar. What replaces it is

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "seedeep",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "private": true,
   "type": "module",
   "description": "Live context & subagent visualizer for Claude Code",


### PR DESCRIPTION
Version bump and the changelog cut, in one diff as the release procedure requires — `## Unreleased`
becomes `## 0.22.0 (2026-08-13)` with a fresh empty `Unreleased` above it. The date is today's,
which is when the tag will be cut.

What the section carries, all already on `main`:

- **The mark is a lens over a trace, not an eye** (#9) — and one geometry now serves the tray, the
  browser icons, the app icons and the social card.
- The security and network work, and the shop windows (#3).
- Two test fixes: one definition of a fake window so a stub cannot crash another file (#8, #5), and
  the removal of the temporary diagnostic that found it (#7).
- harden-runner dropped, one release after it went in (#6).

After the tag, the release is not done until both channels are checked by hand — the release page
carrying all seven assets and not still a draft, npm holding the new version across all six
packages, and the executable started somewhere it was not built.

**One thing this release does NOT fix:** `docs/assets/notifications.png` still shows the old eye.
macOS draws banner icons from the app REGISTERED for the bundle id, so the figure can only be re-cut
once a build carrying the new mark is installed — which is what this tag produces.