### PR TITLE
The tray icon was soft because of its buffer, not its drawing

### DIFF
--- a/apps/tray/src-tauri/src/icon.rs
+++ b/apps/tray/src-tauri/src/icon.rs
@@ -30,11 +30,17 @@ pub const TRAY_ID: &str = "seedeep";
 /// buffer around a mark wider than tall left the old eye filling 55% of the height — drawn at
 /// ~10 pt in an 18 pt slot, visibly lighter than every neighbouring icon.
 ///
-/// The lens is a circle, so the buffer is SQUARE — the first version of this icon that is, and the
-/// smallest it has been: 26×26 against the eye's 36×26 and the print's 25×26. Both numbers are
-/// DERIVED from the geometry below — see `COL_LEFT`.
-const W: u32 = 26;
-const H: u32 = 26;
+/// The lens is a circle, so the buffer is SQUARE — the first version of this icon that is.
+///
+/// **36, not 26, and this is the number that decides whether the icon looks sharp.** `tray-icon`
+/// pins the image to 18 POINTS tall (`nsimage.setSize`, macos/mod.rs), which on a retina screen is
+/// 36 physical pixels. A buffer smaller than that is ENLARGED by AppKit and every stroke arrives
+/// interpolated: at 26 the mark was blown up 1.38x and read soft in the bar, which is exactly what
+/// it was reported as. At 36 one buffer pixel lands on one screen pixel, and on a 1x screen the
+/// halving back to 18 is exact. The cost is the rasterised spin — 24 x 5.2 KB instead of
+/// 24 x 2.7 KB, which is nothing against work that would otherwise never stop.
+const W: u32 = 36;
+const H: u32 = 36;
 
 /// The mark is designed in the unit square; these map the buffer onto the slice of that square
 /// which carries ink, so only the framing moved. The window has to hold every state at once — the
@@ -55,13 +61,15 @@ const SS: u32 = 4;
 /// The glass: one thick ring, drawn in every state and never animated. It is this mark's outline,
 /// which is what `the_mark_is_the_same_size_in_every_state` measures.
 ///
-/// Drawn at exactly the weight of a span, which is the maintainer's call made on four renders at
-/// 18 pt. The ring started half again as heavy as the trace it sits over — a mismatch with no
-/// reason behind it — and the two ways to settle it are to meet in the middle or to bring the ring
-/// down to the bars. This is the second: a lighter mark, at the cost of some of the ink that
-/// keeps a lens from reading as a plain thin circle.
+/// Drawn at exactly the weight of a span — the ring had been half again as heavy as the trace it
+/// sits over, a mismatch with no reason behind it.
+///
+/// **Heavier than the browser mark's, deliberately.** `generate-favicon.ts` draws the same geometry
+/// at 0.075, and the two are not meant to match here: an icon 18 pt tall in a menu bar is an
+/// optical size, the same way the 16 px ICO is, and thin strokes are the first thing to dissolve at
+/// it. Both weights were rendered at 36 px before this one was chosen.
 const GLASS_R: f64 = 0.37;
-const GLASS_STROKE: f64 = 0.075;
+const GLASS_STROKE: f64 = 0.095;
 /// Inside the glass: where the trace is drawn.
 const INNER_R: f64 = GLASS_R - GLASS_STROKE;
 
@@ -73,12 +81,15 @@ const INNER_R: f64 = GLASS_R - GLASS_STROKE;
 /// half done, which is what a nested span looks like on a real trace.
 ///
 /// How far they run from the glass is a LOOK, and it was picked by rendering three clearances: the
-/// bars first reached to within 0.4 px of the ring at 18 pt, which reads as crowding rather than as
-/// a trace. These leave about 1.7 px.
+/// bars first reached to within 0.4 px of the ring, which reads as crowding rather than as a trace.
+///
+/// The rows sit wider apart than the browser mark's for the same reason the strokes are heavier: at
+/// this weight, waiting's thickened bars would otherwise have a quarter of a pixel between them and
+/// would weld into a block.
 const SPANS: [(f64, f64, f64); 3] = [
-    (0.34, 0.50, 0.38),
+    (0.34, 0.50, 0.36),
     (0.40, 0.58, 0.50),
-    (0.45, 0.63, 0.62),
+    (0.45, 0.63, 0.64),
 ];
 /// How thick a span is drawn, and how thick it gets when a session is waiting.
 ///
@@ -86,8 +97,8 @@ const SPANS: [(f64, f64, f64); 3] = [
 /// nowhere to add a mark that is not already spoken for — so what changes is the trace's mass:
 /// the same three spans, thicker. At 18 pt that is the difference between a third of the circle
 /// inked and most of it.
-const SPAN_H: f64 = 0.075;
-const SPAN_H_FULL: f64 = 0.095;
+const SPAN_H: f64 = 0.095;
+const SPAN_H_FULL: f64 = 0.12;
 
 /// Transparent gap around the slash. Without it the slash merges into the arcs it crosses at
 /// 18 pt and the icon turns into a blob.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable structural changes to seedeep are recorded here, newest first.
 
 ## Unreleased
 
+**The tray icon was soft, and the cause was its buffer rather than its drawing.** `tray-icon` pins
+the image with `nsimage.setSize(18)` — a size in POINTS — so on a retina screen AppKit has 36
+physical pixels to fill and the 26-pixel buffer was being enlarged 1.38× and interpolated. Every
+stroke arrived blurred, which no amount of redrawing could have fixed. The buffer is now 36×36: one
+buffer pixel per screen pixel on retina, an exact halving on a 1× screen. It costs 24 × 5.2 KB of
+rasterised frames instead of 24 × 2.7 KB.
+
+With the pixels landing true, the strokes were also taken up from 0.075 to 0.095, and the trace's
+rows spread wider to keep waiting's thickened bars from welding together. **The browser mark keeps
+0.075 and is not meant to match**: 18 points in a menu bar is an optical size, exactly as the 16 px
+ICO already is.
+
 ## 0.22.0 (2026-08-13)
 
 **The mark is a lens, not an eye.** The eye was drawn for the name — seedeep, *see* — and said the

--- a/docs/tray.md
+++ b/docs/tray.md
@@ -144,10 +144,14 @@ the check the print failed and this one had to pass: not "is it distinct from a 
 Three things about it are load-bearing. **No handle**: it was the source of both objections to a
 magnifier, being a diagonal that fought the unreachable slash and the stroke that makes the glyph
 read as *search*, which seedeep already spends a tab of its own on. **One stroke weight**: the ring
-and the bars are drawn at exactly the same thickness, settled by rendering four pairings at 18 pt —
-the ring had been half again as heavy as the trace it sits over, a mismatch with nothing behind it.
-And the spans **step right** rather than lining up: three bars of equal start and length would be a
-list, and a list inside a circle reads as a menu button.
+and the bars are drawn at exactly the same thickness — the ring had been half again as heavy as the
+trace it sits over, a mismatch with nothing behind it. And the spans **step right** rather than
+lining up: three bars of equal start and length would be a list, and a list inside a circle reads as
+a menu button.
+
+**That weight is heavier here than in the browser** (0.095 against 0.075, and the rows sit wider
+apart to match). The two are not meant to agree: an icon 18 points tall in a menu bar is an optical
+size, the same way the 16 px ICO is, and thin strokes are the first thing to dissolve at it.
 
 How far the bars run from the glass was picked the same way. They first reached to within 0.4 px of
 the ring at 18 pt, which reads as crowding rather than as a trace; they now leave about 1.7 px.
@@ -308,16 +312,22 @@ about a PNG; one geometry gives a single source of truth and lets the states be 
 every state paints something, that no two render identically, that the badge does not count,
 that the mark never changes size, and that the buffer carries no wasted margin.
 
-**The buffer is 26×26, cropped to the ink on both axes** — set by the platform, not by taste.
+**The buffer is 36×36, cropped to the ink on both axes** — set by the platform, not by taste.
 macOS scales the tray image to **18 points tall** whatever the buffer contains, so:
 
+- **36 is 18 points at 2×, and that is what makes the icon sharp.** `tray-icon` pins the image with
+  `nsimage.setSize(18)`, which is a size in POINTS; on a retina screen AppKit has 36 physical pixels
+  to fill. A buffer smaller than that gets enlarged and interpolated — at 26 the mark was blown up
+  1.38× and read soft in the bar, which is how the problem was found. At 36 one buffer pixel lands
+  on one screen pixel, and a 1× screen halves it exactly. Anything larger is thrown away twice over:
+  scaled down for retina and further for 1×.
 - **Height is the mark's entire size budget**, and every empty row spends it. A square buffer left
   the mark filling 55% of the height — drawn at ~10 pt in an 18 pt slot, visibly lighter than
   every neighbouring icon, which is what looking at a real menu bar showed.
 - **Width is not chosen at all**: height is fitted and width follows the proportions, so an
   elongated mark simply takes more of the bar than its neighbours. The eye this mark replaced was
   1.77 wide for 1 tall (36×26), then 1.38 (27×26); a lens is a circle, so this is the first version
-  that is **square** — 26×26, badge and slash included, because both are placed inside the ring
+  that is **square** — 36×36, badge and slash included, because both are placed inside the ring
   rather than beside it.
 
 Two consequences worth knowing before touching `GLASS_R`. The crop constants


### PR DESCRIPTION
Reported from a real menu bar: the mark reads blurred at 18 pt. The cause is not the drawing.

`tray-icon` pins the image with `nsimage.setSize(18)` — a size in **points**. On a retina screen
AppKit therefore has 36 physical pixels to fill, and the buffer we shipped was 26: it was being
enlarged 1.38× and interpolated, so every stroke arrived soft. Redrawing the mark could not have
fixed it.

**The buffer is now 36×36.** One buffer pixel per screen pixel on retina; an exact halving on a 1×
screen. Anything larger would be scaled down twice over and come back interpolated anyway. The cost
is the rasterised spin: 24 × 5.2 KB instead of 24 × 2.7 KB.

With the pixels landing true, two adjustments followed:

- **Strokes from 0.075 to 0.095.** Thin strokes are the first thing to dissolve at this size, and
  the earlier weight had been chosen looking at crisp SVG previews that did not reproduce the
  enlargement — so the comparison was never fair.
- **Rows from 0.12 to 0.14 apart.** At the heavier weight, waiting's thickened bars would have had a
  quarter of a pixel between them and welded into a block, costing that state the shape that keeps
  it apart from broken.

**The browser mark stays at 0.075 and is not meant to match.** 18 points in a menu bar is an optical
size, exactly as the 16 px ICO already is; both files now say so, so the difference does not read as
an oversight. The app icons, favicon and social card are untouched — they derive from the SVG, which
has not changed.

Tests: 92 Rust, 1647 TypeScript, lint and typecheck clean.