### PR TITLE
0.22.1

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable structural changes to seedeep are recorded here, newest first.
 
 ## Unreleased
 
+## 0.22.1 (2026-08-13)
+
 **The tray icon was soft, and the cause was its buffer rather than its drawing.** `tray-icon` pins
 the image with `nsimage.setSize(18)` — a size in POINTS — so on a retina screen AppKit has 36
 physical pixels to fill and the 26-pixel buffer was being enlarged 1.38× and interpolated. Every

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "seedeep",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "private": true,
   "type": "module",
   "description": "Live context & subagent visualizer for Claude Code",


### PR DESCRIPTION
Version bump and the changelog cut in one diff, as the release procedure requires: `## Unreleased`
becomes `## 0.22.1 (2026-08-13)` with a fresh empty `Unreleased` above it.

One entry, and a patch release is the right size for it: the tray icon was being enlarged 1.38× by
AppKit and read soft in the menu bar (#11). The buffer is now 36×36 — 18 points at 2× — with the
strokes taken up to match. Nothing else changed; the browser icons and the social card are
untouched.

Tagging this is what puts the sharp icon in a DMG that can actually be installed.