### PR TITLE
0.22.2

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable structural changes to seedeep are recorded here, newest first.
 
 ## Unreleased
 
+## 0.22.2 (2026-08-13)
+
 **The tray mark is drawn on a pixel grid now, and it is the reason it stopped looking blurred.** The
 screen it was judged on is 1×, so 18 points are **18 pixels for the whole icon** — the glass leaves
 about 13 inside itself, and three bars with their gaps want more than that. Written in fractions of

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "seedeep",
-  "version": "0.22.1",
+  "version": "0.22.2",
   "private": true,
   "type": "module",
   "description": "Live context & subagent visualizer for Claude Code",


### PR DESCRIPTION
Version bump and the changelog cut in one diff, as the release procedure requires: `## Unreleased`
becomes `## 0.22.2 (2026-08-13)` with a fresh empty `Unreleased` above it.

Two entries, both about the same report — the tray icon read blurred in a real menu bar:

- The mark is now drawn on an **18×18 pixel grid** instead of a unit square, which is what stops the
  edges falling half-way across a pixel, and the working state turns a gap around the glass (#14).
- The notification figure was re-cut with the lens mark, which needed the system icon cache cleared
  before macOS would draw it (rode in with #14).

Tagging this is what puts the sharp icon in an installable DMG.