### PR TITLE
Bring a resumed session's tab back to life without a refresh

### DIFF
--- a/apps/server/public/lib/app.js
+++ b/apps/server/public/lib/app.js
@@ -3648,6 +3648,13 @@ function createTabBar(container, { onSwitch, onClose }) {
       t.el.title = titleFor(t.label, true);
       t.busy.classList.remove("on");
     },
+    clearEnded(sessionId) {
+      const t = tabs.get(sessionId);
+      if (!t)
+        return;
+      t.el.classList.remove("ended");
+      t.el.title = titleFor(t.label, false, t.waiting, t.failed);
+    },
     setBusy(sessionId, busy) {
       const t = tabs.get(sessionId);
       if (t)
@@ -9739,6 +9746,16 @@ last event: ` + c.lastEvent : c.sentence ?? c.command;
       }
       refreshOutput();
     },
+    setLive() {
+      if (!ended2)
+        return;
+      ended2 = false;
+      root.classList.remove("ended");
+      scheduleRender();
+      if (live && !commitsTimer)
+        commitsTimer = setInterval(refreshOutput, COMMITS_REFRESH_MS);
+      refreshOutput();
+    },
     destroy() {
       destroyed = true;
       off();
@@ -9789,6 +9806,10 @@ function createView(container, treeState, opts = {}) {
     setEnded() {
       ended2 = true;
       graph.setEnded();
+    },
+    setLive() {
+      ended2 = false;
+      graph.setLive();
     },
     setWaiting(kind, since) {
       if (ended2)
@@ -9901,12 +9922,17 @@ var endGuard = createEndGuard({
     t.ended = true;
     tabBar.setEnded(sessionId);
     t.view.setEnded();
-    if (t.stopReplay) {
-      t.stopReplay.stop();
-      t.stopReplay = null;
-    }
   }
 });
+function revive(sessionId) {
+  const t = openTabs.get(sessionId);
+  if (!t || !t.ended)
+    return;
+  t.ended = false;
+  tabBar.clearEnded(sessionId);
+  t.view.setLive();
+  t.stopReplay.resync();
+}
 var tabStore = createTabStore((() => {
   try {
     return globalThis.localStorage ?? null;
@@ -9971,8 +9997,7 @@ function closeTab(sessionId) {
   if (!t)
     return;
   endGuard.cancel(sessionId);
-  if (t.stopReplay)
-    t.stopReplay.stop();
+  t.stopReplay.stop();
   t.view.destroy();
   t.panel.remove();
   tabBar.remove(sessionId);
@@ -10024,7 +10049,11 @@ function openTab(record, { activate = true } = {}) {
   view.setBusy(open ? isModelBusy(record) : false);
   treeState.onChange(() => tabBar.setFailed(sessionId, treeState.currentError() !== null));
   const onLive = () => view.onReplayEnd();
-  const stopReplay = startReplay(sessionId, (e) => treeState.apply(e), open ? { stream, EventSourceImpl: AuthEventSource, onLive } : { EventSourceImpl: AuthEventSource, onLive });
+  const stopReplay = startReplay(sessionId, (e) => treeState.apply(e), {
+    stream,
+    EventSourceImpl: AuthEventSource,
+    onLive
+  });
   openTabs.set(sessionId, { view, panel, stopReplay, ended: !open, label: tabLabel(record) });
   known.add(sessionId);
   syncPins();
@@ -10081,7 +10110,7 @@ stream.onStatus((s) => {
   showConnection("resync");
   for (const t of openTabs.values())
     if (!t.ended)
-      t.stopReplay?.resync();
+      t.stopReplay.resync();
 });
 roster.onChange((rows) => {
   dropdown.update(rows);
@@ -10094,6 +10123,8 @@ roster.onChange((rows) => {
       endGuard.gone(row.sessionId);
     if (open)
       endGuard.cancel(row.sessionId);
+    if (t.ended && open)
+      revive(row.sessionId);
     if (!t.ended) {
       tabBar.setBusy(row.sessionId, isWorking(row));
       t.view.setBusy(isModelBusy(row));

--- a/apps/server/src/client/app.ts
+++ b/apps/server/src/client/app.ts
@@ -72,7 +72,9 @@ if (typeof (document.body as unknown as Record<string, unknown>)['append'] === '
 interface OpenTab {
   view: ReturnType<typeof createView>;
   panel: HTMLElement;
-  stopReplay: ReturnType<typeof startReplay> | null;
+  // Never null: a tab always has its reader, and it outlives the SESSION ending (see `end`).
+  // Only `closeTab` retires it, because only closing the tab retires the tab.
+  stopReplay: ReturnType<typeof startReplay>;
   ended: boolean;
   label: string;
 }
@@ -117,8 +119,9 @@ const roster = createRoster({
   fetchLive: (signal) => authFetch('/api/live', { signal }).then((r) => r.json()),
   pollMs: ROSTER_POLL_MS,
 });
-// Committing "this session is over": one-way, so it happens only once a reading taken a full
-// poll later still agrees. `stillGone` reads roster.current(), which is refreshed on EVERY
+// Committing "this session is over": it costs the tab its live presentation, so it happens only
+// once a reading taken a full poll later still agrees. `revive` can undo it — but late, and after
+// the chrome has already gone quiet, so the confirmation still has to be worth spending. `stillGone` reads roster.current(), which is refreshed on EVERY
 // poll (onChange fires only on identity change, so counting notifications would never confirm
 // a session that really closed — its key stops moving after the first transition). What the
 // guard counts instead is `readings()`: a poll whose fetch FAILED serves the previous rows
@@ -136,12 +139,36 @@ const endGuard = createEndGuard({
     t.ended = true;
     tabBar.setEnded(sessionId);
     t.view.setEnded(); // the graph freezes into its ended presentation
-    if (t.stopReplay) {
-      t.stopReplay.stop();
-      t.stopReplay = null;
-    }
+    // The replay is deliberately NOT stopped: `stop()` means the TAB is gone, and this tab is
+    // still here. A session can come back (`claude --resume`, same id — see `revive`), and its
+    // reader is what lets it: stopping it left the tab with no subscription and no way to build
+    // one, so it stayed frozen for the life of the page while Claude Code worked on. A read
+    // still in flight also gets to finish its history, which the old stop() cut short.
+    //
+    // The one thing that got slower, stated because it is a real trade and not an oversight: a
+    // replay connection cut in SILENCE (no error frame) used to be finished by this `stop()`, so
+    // the loader fell within the confirmation window; now it waits out the read's own 30s silence
+    // verdict. Forcing the handoff here would buy that back at the price of truncating the
+    // history of every session that dies mid-replay — the common case against the rare one.
   },
 });
+
+/**
+ * The session behind an ended tab is running again — `claude --resume` continues the SAME
+ * session id, so this tab is the only one that session will ever get: nothing auto-opens it
+ * (`sessionsToAutoOpen` excludes both `known` and the ids already on screen) and picking it from
+ * the dropdown only switches to it. Undoes `end` in the same order, then pulls the tail the tab
+ * missed while it was frozen — the watcher tails LIVE sessions only, so whatever was written in
+ * between (a background command's notification, a resumed subagent) never came down the stream.
+ */
+function revive(sessionId: string) {
+  const t = openTabs.get(sessionId);
+  if (!t || !t.ended) return;
+  t.ended = false;
+  tabBar.clearEnded(sessionId);
+  t.view.setLive();
+  t.stopReplay.resync();
+}
 
 // Merely READING localStorage throws when storage is disabled, so the access is guarded
 // here, not just its calls; the store then degrades to "nothing saved" (see tab-store.ts).
@@ -259,7 +286,7 @@ function closeTab(sessionId: string) {
   const t = openTabs.get(sessionId);
   if (!t) return;
   endGuard.cancel(sessionId); // no tab left to end when its window would close
-  if (t.stopReplay) t.stopReplay.stop(); // unsubscribes live + closes replay ES
+  t.stopReplay.stop(); // unsubscribes live + closes replay ES
   t.view.destroy();
   t.panel.remove();
   tabBar.remove(sessionId);
@@ -355,13 +382,18 @@ function openTab(record: SessionRecord, { activate = true }: { activate?: boolea
   // background one, which gets no frames at all. The replay pass sets it for free: a session that
   // was already failing when its tab opened arrives red, like the pending-prompt seed above.
   treeState.onChange(() => tabBar.setFailed(sessionId, treeState.currentError() !== null));
-  // Open: replay-from-start then live. Closed: pure replay (no live stream).
+  // Replay-from-start, then live — for an ENDED session too, and that is not a waste: the
+  // multiplexed stream is one connection the page holds anyway, this adds a handler to a map, and
+  // nothing is ever delivered for a session nobody is tailing. What it buys is the case that has
+  // no other answer: a session opened from the picker long after it died, then resumed. Without a
+  // subscription taken at open, `revive` would have nothing to reattach — and a tab cannot grow
+  // one later, since the reducer already holds the file and a second reader would double it.
   const onLive = () => view.onReplayEnd(); // history is in: drop the loader, paint, arm toasts
-  const stopReplay = startReplay(
-    sessionId,
-    (e) => treeState.apply(e),
-    open ? { stream, EventSourceImpl: AuthEventSource, onLive } : { EventSourceImpl: AuthEventSource, onLive },
-  );
+  const stopReplay = startReplay(sessionId, (e) => treeState.apply(e), {
+    stream,
+    EventSourceImpl: AuthEventSource,
+    onLive,
+  });
   openTabs.set(sessionId, { view, panel, stopReplay, ended: !open, label: tabLabel(record) });
   // Handing out a tab IS the offer, whoever asked for it — auto, picker or restore. Recorded
   // here so the rule can never re-offer something the user has already seen and closed.
@@ -441,7 +473,7 @@ stream.onStatus((s) => {
   // Each live tab pulls the lines it missed while the feed was down — the tail only, folded
   // into the reducer it already has. Ended tabs hold history the stream cannot change, so
   // they have nothing to catch up on.
-  for (const t of openTabs.values()) if (!t.ended) t.stopReplay?.resync();
+  for (const t of openTabs.values()) if (!t.ended) t.stopReplay.resync();
 });
 
 roster.onChange((rows) => {
@@ -450,16 +482,19 @@ roster.onChange((rows) => {
     const t = openTabs.get(row.sessionId);
     if (!t) continue;
     const open = isLive(row);
-    // An open tab whose session CLOSED (its PID file is gone): drop the live
-    // subscription and freeze on the last state. Not a 60s silence timer — an
-    // open-but-idle session stays live. A session that reopens is NOT re-opened
-    // automatically; it reappears in the dropdown for the user to pick.
+    // An open tab whose session CLOSED (its PID file is gone): freeze on the last state. Not a
+    // 60s silence timer — an open-but-idle session stays live.
     //
     // Never on the FIRST reading, though: the PID file is rewritten on every status change
-    // and a read that catches it mid-rewrite loses the session for one poll. Ending is
-    // one-way, so it waits for a second, independent reading to agree (see end-guard.ts).
+    // and a read that catches it mid-rewrite loses the session for one poll. Freezing costs
+    // the tab its live presentation, so it waits for a second, independent reading to agree
+    // (see end-guard.ts).
     if (!t.ended && !open) endGuard.gone(row.sessionId);
     if (open) endGuard.cancel(row.sessionId); // it is back — whatever we were about to believe, don't
+    // And the reverse: the session is running again, which for `--resume` means this very tab
+    // (same session id). Before the block below, so the poll that reports it back also restores
+    // the busy/waiting/label state it carries.
+    if (t.ended && open) revive(row.sessionId);
     if (!t.ended) {
       // Two different questions, deliberately two readings: the tab dot means "this session is
       // busy" (`shell` included — a background command IS the session working), the panel means

--- a/apps/server/src/client/end-guard.ts
+++ b/apps/server/src/client/end-guard.ts
@@ -25,11 +25,15 @@ export interface EndGuardDeps {
  *
  * Why the wait exists: `isOpen` comes from a PID file Claude Code REWRITES on every status
  * change, and `listOpenSessions` skips a file it catches mid-rewrite — so a running session
- * can be absent from exactly one poll. Ending a tab is one-way (it drops the live
- * subscription and freezes the graph into its ended presentation), so a single reading is
- * not enough evidence to spend it on: that blink froze healthy sessions until the page was
- * reloaded. The same JSDoc reasoning already protects `known` in sessions.ts; this is the
- * other consumer that had not caught up.
+ * can be absent from exactly one poll. Ending a tab freezes the graph into its ended
+ * presentation, so a single reading is not enough evidence to spend it on: that blink froze
+ * healthy sessions until the page was reloaded. The same JSDoc reasoning already protects
+ * `known` in sessions.ts; this is the other consumer that had not caught up.
+ *
+ * The freeze is undone by `revive` (app.ts) when the session comes back, so a blink now costs a
+ * few seconds of wrong presentation rather than the tab — but that is a repair, not a licence to
+ * end on one reading: it happens seconds late, drops the live chrome in between, and sends the tab
+ * back to the server for a tail it never lost.
  */
 export function createEndGuard(deps: EndGuardDeps) {
   const schedule =

--- a/apps/server/src/client/graph.ts
+++ b/apps/server/src/client/graph.ts
@@ -317,6 +317,7 @@ export function createGraph(
 ): {
   goLive(): void;
   setEnded(): void;
+  setLive(): void;
   setWaiting(kind: PendingKind | null, since: number | null): void;
   setBusy(working: boolean): void;
   destroy(): void;
@@ -326,9 +327,10 @@ export function createGraph(
   const root = E('div', 'graph-root');
 
   // Ended = the session's process is gone (its PID file dropped), so nothing here can
-  // ever grow again: the subagent monitor collapses, the LIVE badge yields to "ended",
-  // and the feed is height-capped (all via renders/CSS keyed on this flag). One-way:
-  // a session that reopens comes back as a NEW tab (see app.ts), never by un-ending.
+  // grow while it lasts: the subagent monitor collapses, the LIVE badge yields to "ended",
+  // and the feed is height-capped (all via renders/CSS keyed on this flag). REVERSIBLE, via
+  // `setLive`: `claude --resume` continues the same session id, so a reopened session comes back
+  // to THIS graph — it can never be handed a new tab (see app.ts).
   let ended = opts.ended ?? false;
   // Whether Claude Code's own process says it is working RIGHT NOW (`isModelBusy` — `busy` only,
   // never `shell`, which names a turn that is already over; fed from the
@@ -4785,7 +4787,7 @@ export function createGraph(
       scheduleRender();
     },
     // The session's process is gone (app.ts watches the roster): freeze into the ended
-    // presentation. One-way by design — a reopened session arrives as a new tab.
+    // presentation. Reversed by `setLive` when the same session comes back (`--resume`).
     setBusy(working: boolean) {
       if (working === busy) return;
       busy = working;
@@ -4805,6 +4807,21 @@ export function createGraph(
         commitsTimer = null;
       }
       refreshOutput();
+    },
+    /**
+     * The session is running again — `claude --resume` continues the SAME session id, so this is
+     * the exact reverse of `setEnded` rather than a new graph. Everything keyed on the flag is
+     * read at render time, so one repaint restores all of it; the commits poll is the one thing
+     * `setEnded` stopped outright, and it comes back only if this graph is already painting
+     * (`goLive` arms it otherwise).
+     */
+    setLive() {
+      if (!ended) return;
+      ended = false;
+      root.classList.remove('ended');
+      scheduleRender();
+      if (live && !commitsTimer) commitsTimer = setInterval(refreshOutput, COMMITS_REFRESH_MS);
+      refreshOutput(); // a resumed session may have committed while the tab was frozen
     },
     destroy() {
       // FIRST, before anything is unwired: what cannot be cancelled has to be told to do nothing.

--- a/apps/server/src/client/replay.ts
+++ b/apps/server/src/client/replay.ts
@@ -181,10 +181,10 @@ export function startReplay(
   // still looks healthy.
   //
   // LIMIT: handing off early leaves the tab's history SHORT, with nothing on screen saying so.
-  // For a live session the next resync fills it from the mark this read did reach; for an ENDED
-  // one there is no resync path at all, so the gap lasts until the tab is reopened. It is still
-  // the cheaper wrong — buffering forever has no exit — and at 30s against a measured worst gap
-  // of 6ms it should never trigger on a read that is merely slow.
+  // The next resync fills it from the mark this read did reach — for an ENDED session that is the
+  // one `revive` performs if it is resumed (app.ts), and failing that the gap lasts until the tab
+  // is reopened. It is still the cheaper wrong — buffering forever has no exit — and at 30s
+  // against a measured worst gap of 6ms it should never trigger on a read that is merely slow.
   function watchSilence(): void {
     if (stopped || !inFlight) return;
     if (now() - lastFrameAt < staleMs) return;

--- a/apps/server/src/client/tab-bar.ts
+++ b/apps/server/src/client/tab-bar.ts
@@ -6,7 +6,8 @@
 //   dot AMBER  → it stopped and is waiting for YOU (an approval, or an answer)
 //   dot RED    → its last model call FAILED and nothing has succeeded since
 //   tab dimmed → ended; everything in it is frozen history, which is a property of the
-//                whole tab, not a badge to hang off it
+//                whole tab, not a badge to hang off it. It lifts again if the session is
+//                resumed (`clearEnded`) — the same session id comes back to the same tab.
 //
 // Waiting and failed reuse the busy dot rather than adding a second marker: they are the
 // same question ("what is this session doing?"), and two dots would make the strip a
@@ -90,6 +91,17 @@ export function createTabBar(
       t.el.classList.add('ended');
       t.el.title = titleFor(t.label, true);
       t.busy.classList.remove('on'); // a closed session is never busy
+    },
+    /**
+     * The session is running again (`claude --resume`, same id — see app.ts). Undoes `setEnded`
+     * and nothing else: the dot's own states are the roster's to restore on the very poll that
+     * reported the session back, so re-lighting anything here would be guessing.
+     */
+    clearEnded(sessionId: string) {
+      const t = tabs.get(sessionId);
+      if (!t) return;
+      t.el.classList.remove('ended');
+      t.el.title = titleFor(t.label, false, t.waiting, t.failed);
     },
     setBusy(sessionId: string, busy: boolean) {
       const t = tabs.get(sessionId);

--- a/apps/server/src/client/view.ts
+++ b/apps/server/src/client/view.ts
@@ -18,7 +18,7 @@ export type ViewOpts = Pick<
 /**
  * A tab's view: the loading skeleton until the session's history is in, then the Graph.
  * Owns the replay→live handoff for its panel (`onReplayEnd`) and forwards the tab's
- * lifecycle signals (`setEnded`, `setWaiting`, `setBusy`) to the Graph.
+ * lifecycle signals (`setEnded`, `setLive`, `setWaiting`, `setBusy`) to the Graph.
  *
  * Built with DOM nodes + textContent (never innerHTML) so session-derived values
  * (model name, etc.) can never inject markup.
@@ -67,6 +67,13 @@ export function createView(container: HTMLElement, treeState: SessionTree, opts:
     setEnded() {
       ended = true;
       graph.setEnded();
+    },
+    // The session is running again — `claude --resume` on the same id (roster watch in app.ts).
+    // Lifting the flag is what re-opens the two setters below: their guard exists because a DEAD
+    // session can never clear a flag it set, and a resumed one can.
+    setLive() {
+      ended = false;
+      graph.setLive();
     },
     // The session is blocked on the user (roster watch in app.ts). Ignored once the session
     // has ended: its PID file is gone, so nothing would ever clear the flag again.

--- a/apps/server/tests/app-shell.test.ts
+++ b/apps/server/tests/app-shell.test.ts
@@ -29,6 +29,17 @@ class FakeES {
 }
 const sources: FakeES[] = [];
 
+// Wait for a condition the app reaches through its OWN timers, instead of sleeping for a
+// guessed duration: the sequence under test (roster poll → end-guard window → poll) is three
+// timers deep, and a fixed sleep would either be flaky or the slowest test in the suite.
+async function until(what: string, cond: () => boolean, budgetMs = 2000): Promise<void> {
+  const deadline = Date.now() + budgetMs;
+  while (!cond()) {
+    if (Date.now() > deadline) throw new Error(`app-shell: timed out waiting for ${what}`);
+    await new Promise((r) => setTimeout(r, 5));
+  }
+}
+
 const openId = 'aaaaaaaa-1111-2222-3333-000000000001';
 const closedId = 'bbbbbbbb-1111-2222-3333-000000000002';
 const roster = [
@@ -40,7 +51,20 @@ test('app boot: auto-opens open sessions, opens ended tabs from the dropdown, cl
   const g = globalThis as any;
   // Restore the real globals afterwards — the suite shares one process, and a leaked
   // fake fetch breaks every later test that talks to a real local server.
-  const prev = { document: g.document, EventSource: g.EventSource, fetch: g.fetch };
+  const prev = {
+    document: g.document,
+    EventSource: g.EventSource,
+    fetch: g.fetch,
+    setTimeout: g.setTimeout,
+  };
+  // The two multi-second waits this test has to live through are the roster poll (3s) and the
+  // end-of-session confirmation window (poll + 1s) — neither is injectable, since app.ts IS the
+  // composition root and owns both. So the clock is shortened for that band only: everything
+  // outside it (the stream's 45s staleness verdict, the replay's 30s one, the 60s commits
+  // refresh) keeps its real value, because a stream that declares itself dead every few
+  // milliseconds is a different test than this one, running by accident.
+  g.setTimeout = ((fn: any, ms?: number, ...rest: any[]) =>
+    prev.setTimeout(fn, typeof ms === 'number' && ms >= 2500 && ms <= 5000 ? 5 : ms, ...rest)) as any;
   const doc: any = fakeDoc();
   g.document = doc;
   g.EventSource = FakeES;
@@ -110,7 +134,10 @@ test('app boot: auto-opens open sessions, opens ended tabs from the dropdown, cl
     });
     replayES!.fire('replay-end'); // history handed off to live — must not throw
 
-    // Dropdown: picking the CLOSED session opens a second, ended tab with no live stream.
+    // Dropdown: picking the CLOSED session opens a second tab, ended. It replays its file like any
+    // other and — unlike before — subscribes to the live stream too, which is what lets it come
+    // back if that session is ever resumed (see `revive`); nothing is delivered for a session no
+    // watcher is tailing, so the subscription is inert until then.
     const dropdownEl = doc.getElementById('dropdown');
     dropdownEl.children[0].onclick(); // trigger → open → render rows
     const row = findByClass(dropdownEl, 'pk-row').find((r: any) => textOf(r).includes('old work'));
@@ -122,7 +149,7 @@ test('app boot: auto-opens open sessions, opens ended tabs from the dropdown, cl
     assert.ok(tabs[1].classList.contains('ended'), 'ended is the tab going quiet, not a word in the label');
     assert.ok(
       sources.some((s) => s.url.includes(closedId)),
-      'pure replay opened for the ended session',
+      'the ended session is read from its file',
     );
 
     // The stream breaks and comes back. Nothing re-sends what was emitted while it
@@ -143,8 +170,47 @@ test('app boot: auto-opens open sessions, opens ended tabs from the dropdown, cl
     const resync = sources.filter((s) => s.url.includes(openId)).at(-1)!;
     assert.match(resync.url, /[?&]from=/, 'it asks for the TAIL, not the whole session again');
     assert.equal(replaysOf(closedId), endedReplays, 'an ended tab has no hole to close');
+    resync.fire('replay-end'); // that read lands — a later resync is DEFERRED while one is in flight
     assert.equal(connEl.textContent, 'Reconnected — re-reading');
     assert.equal(findByClass(tabsEl, 'tab').length, 2, 'rebuilding keeps the strip as it was');
+
+    // You quit Claude Code and come back with `--resume`. That is the SAME session id — the
+    // transcript is appended to, same file, same inode (measured) — so the tab it froze is the
+    // only tab that session will ever get: nothing auto-opens it (`known` + `openIds` both hold
+    // it) and picking it from the dropdown only switches to it. Before this, the tab stayed
+    // frozen for the life of the page while Claude Code worked on, and only a browser refresh
+    // brought it back.
+    const liveTab = () => findByClass(tabsEl, 'tab')[0];
+    const live = roster[0]!;
+    live.isOpen = false; // its PID file is gone: Claude Code exited
+    live.status = null;
+    await until('the tab to be marked ended', () => liveTab().classList.contains('ended'));
+    const replaysBeforeResume = replaysOf(openId);
+
+    live.isOpen = true; // `claude --resume <id>`: same session, new process
+    live.status = 'busy';
+    await until('the tab to come back to life', () => !liveTab().classList.contains('ended'));
+    assert.equal(liveTab().title, 'projA · live work', 'the hover text stops saying ended too');
+    assert.equal(replaysOf(openId), replaysBeforeResume + 1, 'it goes back for what was written meanwhile');
+    const revived = sources.filter((s) => s.url.includes(openId)).at(-1)!;
+    assert.match(revived.url, /[?&]from=/, 'the TAIL, from the last line the tab holds whole');
+    revived.fire('replay-end'); // the read lands: buffered live events are flushed and the feed is through
+
+    // The invariant the frozen tab broke: an event arriving now REACHES this tab. A failed API
+    // call is the one the strip must repaint for, and it is driven by the reducer, so the assert
+    // proves the whole chain — live subscription → reducer → strip — and not just a class.
+    liveES.emit('usage', {
+      type: 'usage',
+      sessionId: openId,
+      root: 'cli',
+      timestamp: '2026-01-01T00:05:00.000Z',
+      seq: 50,
+      agentId: null,
+      delta: { input: 1, output: 0, cacheRead: 0, cacheCreation: 0 },
+      fill: 200,
+      apiError: { status: 529, message: 'overloaded' },
+    });
+    await until('the resumed session to reach the strip', () => liveTab().children[0].classList.contains('err'));
 
     // Close both via ×: panels and tabs drop with them.
     for (const t of [...tabs]) t.children[2].onclick({ stopPropagation: () => {} });
@@ -153,14 +219,18 @@ test('app boot: auto-opens open sessions, opens ended tabs from the dropdown, cl
   } finally {
     g.document = prev.document;
     g.EventSource = prev.EventSource;
-    // app.js exposes no way to stop its 3s roster poll, and the leaked timer chain
-    // reads the GLOBAL fetch on every tick: restoring the real fetch outright would
-    // hand later tests phantom '/api/sessions' calls. Scoped shim instead — empty
-    // roster for the leaked poll, the real fetch for everything else.
+    // Before the fetch shim, and for the same reason it exists: the leaked poll re-arms itself
+    // through the GLOBAL setTimeout on every tick, so leaving the shortened clock in place would
+    // hand the rest of the suite a roster polling every 5 ms.
+    g.setTimeout = prev.setTimeout;
+    // app.js exposes no way to stop its 3s roster poll, and the leaked timer chain reads the
+    // GLOBAL fetch on every tick: restoring the real fetch outright would hand later tests
+    // phantom '/api/sessions' calls. Scoped shim instead — and it REFUSES rather than answers,
+    // because an answer is what repaints: `refresh()` bails on the catch it already has (keeping
+    // its last good roster, notifying nobody), while an empty roster read as a change, refreshed
+    // Home, and threw from inside a surface whose fake DOM this block had just taken away.
     g.fetch = (input: any, ...rest: any[]) => {
-      if (input === '/api/sessions') return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
-      if (input === '/api/live')
-        return Promise.resolve({ ok: true, json: () => Promise.resolve({ total: 0, sessions: [], pidVisible: true }) });
+      if (String(input).startsWith('/api/')) return Promise.reject(new Error('app-shell: the page is gone'));
       return prev.fetch(input, ...rest);
     };
   }

--- a/apps/server/tests/graph-shell.test.ts
+++ b/apps/server/tests/graph-shell.test.ts
@@ -2657,6 +2657,32 @@ test('setEnded flips a live graph into the ended presentation', async () => {
   g.document = prevDoc;
 });
 
+test('setLive flips an ended graph back — a resumed session is not a new session', async () => {
+  // `claude --resume` continues the SAME session id, so the ended presentation must be
+  // reversible: the tab it froze is the only tab that session will ever get.
+  const g = globalThis as any;
+  const prevDoc = g.document;
+  g.document = fakeDoc();
+  const container = g.document.createElement();
+  const snap = baseSnapshot();
+  const view = createGraph(
+    container,
+    { snapshot: () => snap, onChange: () => () => {}, onEvent: () => () => {} },
+    { ended: true },
+  );
+  assert.ok(container.children[0].classList.contains('ended'), 'built ended: the root carries the flag');
+
+  view.setLive();
+  await new Promise((r) => setTimeout(r, 1)); // the repaint is coalesced (scheduleRender)
+  assert.equal(container.children[0].classList.contains('ended'), false, 'the root flag is gone');
+  const monitor = findByClass(container, 'sublivecard')[0];
+  assert.ok(!monitor.className.split(' ').includes('fulllist'), 'the subagent monitor is a live monitor again');
+  assert.ok(!findByClass(container, 'live')[0].classList.contains('hidden'), 'the LIVE badge is back');
+
+  view.destroy();
+  g.document = prevDoc;
+});
+
 test('Session card: footer carries whole-session turn KPIs and the Explore toggle', () => {
   const g = globalThis as any;
   const prevDoc = g.document;

--- a/apps/server/tests/tab-bar.test.ts
+++ b/apps/server/tests/tab-bar.test.ts
@@ -86,6 +86,27 @@ test('setEnded never touches the label — no marker may creep back into the tex
   assert.equal(tab.title, 'extended-api — ended', 'the state still reaches a reader who cannot see the dim');
 });
 
+test('clearEnded brings a resumed session back, dot and title included', () => {
+  // `claude --resume` reopens the SAME session id, so the strip has to be able to un-dim a tab:
+  // the alternative was a tab frozen for the life of the page while the session worked on.
+  const { container, bar } = mountBar();
+  bar.add('s1', { label: 'a', ended: false, busy: true });
+  bar.setEnded('s1');
+  bar.clearEnded('s1');
+  const tab = findByClass(container, 'tab')[0];
+  assert.equal(tab.classList.contains('ended'), false, 'the dim is what says ended — it has to go');
+  assert.equal(tab.title, 'a', 'and so does the word a reader who cannot see the dim relies on');
+  // The setters the ended class had locked out answer again — the busy dot and the amber one
+  // are driven by the roster poll, which is exactly what has just said the session is back.
+  bar.setBusy('s1', true);
+  assert.equal(tab.children[0].classList.contains('on'), true);
+  bar.setWaiting('s1', 'permission');
+  assert.equal(tab.children[0].classList.contains('wait'), true);
+  assert.equal(tab.title, 'a — waiting for your approval');
+  bar.clearEnded('s1'); // idempotent: a second live poll must not undo what the first restored
+  assert.equal(tab.title, 'a — waiting for your approval');
+});
+
 // The strip holds SESSIONS only — the fixed surfaces moved to the header menu — so it is
 // handed ids it has no tab for (Home, Compare, Search) on every switch to one of them.
 test('setActive with a foreign id lights nothing, and leaves the strip untouched', () => {

--- a/apps/server/tests/view-shell.test.ts
+++ b/apps/server/tests/view-shell.test.ts
@@ -81,6 +81,27 @@ test('the tab shows a loader until the replay ends, then the view', () => {
   g.document = prevDoc;
 });
 
+test('setLive lets a resumed session speak again — the ended guards are lifted', async () => {
+  // The mirror of the test below: those guards exist because a DEAD session can never clear a
+  // flag it sets. A resumed one can, so the guards must lift with the ended state — otherwise
+  // the tab stays mute about the very turn that has just started.
+  const g = globalThis as any;
+  const prevDoc = g.document;
+  g.document = fakeDoc();
+  const container = g.document.createElement();
+  const { treeState } = stubs();
+
+  const view = createView(container, treeState, { ended: true });
+  view.onReplayEnd();
+  view.setLive();
+  view.setWaiting('permission', null);
+  await new Promise((r) => setTimeout(r, 1));
+  assert.equal(findByClass(container, 'nowpanel')[0].classList.contains('waiting'), true);
+
+  view.destroy();
+  g.document = prevDoc;
+});
+
 test('a session that ended can never be left showing a pending prompt', async () => {
   // The PID file is gone, so nothing will ever clear the flag: an amber panel on a dead
   // tab would keep claiming a prompt that no longer exists.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable structural changes to seedeep are recorded here, newest first.
 
 ## Unreleased
 
+**A session you came back to with `--resume` was tracked again only after a browser refresh, and
+the tab was the reason.** When Claude Code exits, its PID file goes and the tab freezes into the
+ended presentation — correct, and confirmed by a second reading (`end-guard.ts`). What was wrong is
+that the freeze also RETIRED the tab's reader, and nothing could ever build it another: `--resume`
+continues the SAME session id (0 of 519 local transcripts carry a foreign one), so the resumed
+session can never be handed a new tab — nothing auto-opens it, and picking it from the dropdown
+only switches to it. Two comments claimed otherwise ("it reappears in the dropdown for the user to
+pick", "comes back as a NEW tab") and both described a path that could not run. The tab stayed dim
+and frozen for the life of the page while the session worked on.
+
+The freeze is now reversible. `graph.setLive` / `view.setLive` / `tabBar.clearEnded` undo it in the
+order `end` applied it, and the poll that sees the session live again calls `revive`, which then
+asks the replay endpoint for the TAIL the tab missed — the watcher tails LIVE sessions only, so
+whatever was written in between never came down the stream. Two invariants make that possible: the
+tab's reader now outlives the SESSION (`stop()` means the tab is gone, and the tab is still here —
+a read still in flight also gets to finish its history, which the old `stop()` cut short), and a
+tab subscribes to the live stream even when it opens onto a session that is already dead, because a
+subscription cannot be added afterwards without a second reader double-counting the file.
+
+Verified both ways, twice: the shell test drives roster → freeze → resume and asserts the resumed
+session's events reach the strip, and it goes red with either half of the fix removed; and a live
+check drives a real server and a real Chrome against a synthetic session store, where the turn
+written after the resume appears with no reload — and times out without the fix.
+
 ## 0.22.2 (2026-08-13)
 
 **The tray mark is drawn on a pixel grid now, and it is the reason it stopped looking blurred.** The

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -317,9 +317,9 @@ already grown once.
 
 **One reading of `isOpen` is not proof it closed.** Claude Code REWRITES the PID file on every
 status change, and `listOpenSessions` skips a file it catches mid-rewrite — so a running
-session can be missing from exactly one poll. Anything IRREVERSIBLE must therefore wait for a
-second reading: `known` in `sessions.ts` is never pruned on a blink, and ending a tab (one-way:
-it drops the live subscription and freezes the graph into its ended presentation) goes through
+session can be missing from exactly one poll. Anything COSTLY must therefore wait for a
+second reading: `known` in `sessions.ts` is never pruned on a blink, and ending a tab (it
+freezes the graph into its ended presentation) goes through
 `end-guard.ts`, which re-reads the roster a full poll later and commits only if it still
 agrees. Counting notifications cannot do this job — `onChange` fires on identity CHANGE, so a
 session that really closed notifies once and then never again; the confirmation reads
@@ -332,6 +332,18 @@ be ended on a single reading. The guard therefore requires that counter to have 
 when it has not it re-arms instead of giving up: dropping the question would leave a session
 that really ended live for the life of the page, since `gone` is driven by an identity change
 that has already happened.
+
+Ending a tab is **reversible**, and has to be: `claude --resume` continues the SAME session id,
+so a resumed session can never be handed a new tab — nothing auto-opens it
+(`sessionsToAutoOpen` excludes both `known` and the ids on screen) and picking it from the
+dropdown only switches to it. So the poll that reports it live again calls `revive` (`app.ts`),
+which undoes the freeze and asks the replay endpoint for the tail the tab missed. What makes
+that possible is that the tab's READER outlives the session: `end` no longer stops it —
+`stop()` means the tab is gone — and a tab subscribes to the live stream even when it opens
+onto a session that is already dead, since a subscription cannot be added later without a
+second reader double-counting the file. Reversibility does not soften the confirmation above:
+the repair arrives seconds late, drops the live chrome in between, and spends a request on a
+tail the tab never lost.
 
 **A session blocked on the user.** Claude Code writes `status: "waiting"` into the PID
 file the moment it raises a dialog, with a `waitingFor` label saying which one, and

--- a/docs/features.md
+++ b/docs/features.md
@@ -402,7 +402,10 @@ drawer**; drill-down clicks (e.g. a tool inside a subagent's drawer) show a
 
 The view reconstructs identically live and in replay; an **ended** session drops
 the live chrome — the monitor collapses to a one-line summary, and the LIVE badge
-yields to a quiet "ended".
+yields to a quiet "ended". That state is not final: `claude --resume` continues the
+SAME session, so when its process comes back the tab you already have **goes live
+again by itself** — the dim lifts, the badge returns, and the tab reads the lines
+written while it was frozen. Nothing has to be reopened, and no refresh is needed.
 
 ## The turn as a lens
 


### PR DESCRIPTION
## The bug

Quit Claude Code, come back with `--resume`, and seedeep stopped tracking the session until the browser was refreshed.

When Claude Code exits its PID file goes, and the tab freezes into the ended presentation — correct, and confirmed by a second reading (`end-guard.ts`). What was wrong is that the freeze also **retired the tab's reader**, and nothing could ever build it another: `--resume` continues the **same** session id (0 of 519 local transcripts carry a foreign one), so the resumed session can never be handed a new tab — nothing auto-opens it, and picking it from the dropdown only switches to it. Two comments claimed otherwise ("it reappears in the dropdown for the user to pick", "comes back as a NEW tab"); both described a path that could not run.

## The fix

The freeze is now reversible. `graph.setLive` / `view.setLive` / `tabBar.clearEnded` undo it in the order `end` applied it, and the poll that sees the session live again calls `revive`, which asks the replay endpoint for the **tail** the tab missed — the watcher tails live sessions only, so whatever was written in between never came down the stream.

Two invariants make that possible:

- the tab's reader outlives the **session** (`stop()` means the tab is gone, and the tab is still here — a read still in flight also gets to finish its history, which the old `stop()` cut short);
- a tab subscribes to the live stream even when it opens onto a session that is already dead, because a subscription cannot be added afterwards without a second reader double-counting the file.

## Verification

- The shell test drives roster → freeze → resume and asserts the resumed session's events reach the strip. It goes **red with either half of the fix removed** (no trigger → the tab never revives; old `stop()` → no tail is fetched).
- A live check drives a real server and a real Chrome against a synthetic session store: the turn written after the resume appears with **no reload**, and the same script times out without the fix.
- 1650 tests pass, typecheck clean, lint unchanged.

No doc figure was re-cut: `doc-shots:check` names 17 because `graph.ts` was touched, but none of them photographs this transition and the ended/live presentation is unchanged.