### PR TITLE
The test notification closes the popover before it posts

### DIFF
--- a/apps/tray/src-tauri/src/main.rs
+++ b/apps/tray/src-tauri/src/main.rs
@@ -8,6 +8,7 @@ mod store;
 mod update;
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use client::{Conn, Status};
 use local::LocalServer;
@@ -54,7 +55,7 @@ const LOCATE_PROBE: &str = "locate-probe";
 /// The ONE variable that decides which seedeep this process belongs to.
 ///
 /// Set, it is a development world: the server keeps its state there (`bun run dev`) and the tray
-/// keeps `connection.json` and `settings.json` in `<it>/tray`. Unset, it is the installed world —
+/// keeps `connection.json` in `<it>/tray`. Unset, it is the installed world —
 /// `~/.seedeep` and the app's own config directory.
 ///
 /// One variable and not two, which is what it was. The tray had a `SEEDEEP_TRAY_HOME` of its own,
@@ -79,6 +80,20 @@ const PANEL_MARGIN: f64 = 6.0;
 /// collapse the window to nothing, and a popover with no height cannot be clicked to recover.
 const PANEL_MIN_H: f64 = 90.0;
 
+/// The beat between the popover going away and the test banner being posted.
+///
+/// macOS does not PRESENT a notification posted by the frontmost app — Apple's own
+/// `NSUserNotification.h` says so on `shouldPresentNotification:` ("the Notification Center has
+/// decided not to present your notification, for example when your application is front most"), and
+/// that callback is the only way to override it. `mac-notification-sys` does not implement it, so
+/// there is nothing of ours to answer YES with: the tray has to stop being frontmost instead.
+///
+/// Hiding the popover is what does that, and the activation it hands back is the window server's to
+/// perform — it lands on a later turn of the run loop than the click that asked for it. Posting in
+/// the same breath posts while the rule still applies, which is the whole bug. Generous on purpose:
+/// nobody is waiting on a banner they asked to see with the panel out of the way.
+const NOTIFY_SETTLE: Duration = Duration::from_millis(400);
+
 /// The height the popover should take to show `content`, given where its top edge is and how much
 /// screen there is below it.
 ///
@@ -96,8 +111,8 @@ fn panel_height(content: f64, top: f64, available_bottom: f64) -> f64 {
     content.min(room).max(PANEL_MIN_H)
 }
 
-/// Where the tray keeps `connection.json` and `settings.json`: under {@link SEEDEEP_HOME} when that
-/// is set to something, the app's own config directory otherwise.
+/// Where the tray keeps `connection.json`: under {@link SEEDEEP_HOME} when that is set to something,
+/// the app's own config directory otherwise.
 ///
 /// A `tray` subdirectory rather than the home itself, so one variable names one world and the two
 /// apps inside it do not write over each other's files.
@@ -369,21 +384,43 @@ fn resize(height: f64, app: AppHandle) -> Result<f64, String> {
     Ok(fitted)
 }
 
-/// Send one notification now, on purpose.
+/// Put the popover away, then post one notification.
 ///
 /// This is the ONLY honest way to surface the platform's own silence. The plugin's
 /// `permission_state()` is a hardcoded `Granted` on desktop (verified in
 /// tauri-plugin-notification 2.3.3, `desktop.rs`), and `show()` returns `Ok(())` even when nothing
 /// is delivered — so neither can tell the user whether notifications reach them. A banner they look
-/// for can. `Ok` here means "sent", never "seen", and the panel says exactly that.
+/// for can.
+///
+/// **The popover closing is not a courtesy, it is the test.** Clicking this button is the one moment
+/// the tray is the frontmost app — the panel took focus when it opened (`toggle_panel`) — and that
+/// is precisely the case macOS refuses to draw a banner for ({@link NOTIFY_SETTLE}). Real banners
+/// arrive while the user is somewhere else, so the check has to reproduce that condition rather than
+/// report a delivery the window server dropped on the floor.
+///
+/// Nothing is returned, and nothing could be: the post happens after this call has already answered,
+/// and `show()` cannot tell delivered from dropped anyway. The banner is the receipt — the same rule
+/// the stop already follows, where the screen that comes next IS the answer.
 #[tauri::command]
-fn test_notification(app: AppHandle) -> Result<(), String> {
-    app.notification()
-        .builder()
-        .title("Notifications are working")
-        .body("This is what a session stopping on a question looks like.")
-        .show()
-        .map_err(|e| format!("The notification could not be sent: {e}"))
+fn test_notification(app: AppHandle) {
+    if let Some(win) = app.get_webview_window(PANEL) {
+        let _ = win.hide();
+        // Not left to the focus-loss handler: hiding a window that is not key raises no focus event,
+        // and the poll would keep the open cadence for a panel nobody is looking at.
+        set_panel_open(&app, false);
+    }
+    tauri::async_runtime::spawn(async move {
+        tokio::time::sleep(NOTIFY_SETTLE).await;
+        // Discarded like every other send here, and for the reason `poll.rs` gives: `show` returns
+        // Ok(()) in the case where nothing is delivered at all. By now there is no surface left to
+        // report on either — the panel is the thing that just went away.
+        let _ = app
+            .notification()
+            .builder()
+            .title("Notifications are working")
+            .body("This is what a session stopping on a question looks like.")
+            .show();
+    });
 }
 
 fn main() {

--- a/apps/tray/src-tauri/src/store.rs
+++ b/apps/tray/src-tauri/src/store.rs
@@ -1,15 +1,14 @@
-//! The tray's two files on disk, written so that nothing can read half of one.
+//! The tray's file on disk, written so that nothing can read half of it.
 //!
-//! `connection.json` and `settings.json` are both per-user state in the app's config directory, and
-//! the properties they need are the same — which is why the write lives here once instead of twice.
-//! Two of those properties are not obvious: the mode is set **at creation** rather than after the
-//! bytes are there (one of the files holds a token, which must never exist in a world-readable file
-//! even for an instant), and the file is renamed into place, so a crash mid-write leaves the previous
-//! version rather than a truncated one.
+//! `connection.json` is per-user state in the app's config directory. It shared this module with a
+//! `settings.json` until the notification switches moved to the server's config, and the write stays
+//! a function of its own because the two properties it needs are not obvious: the mode is set **at
+//! creation** rather than after the bytes are there (the file holds a token, which must never exist
+//! in a world-readable file even for an instant), and the file is renamed into place, so a crash
+//! mid-write leaves the previous version rather than a truncated one.
 //!
 //! A file nobody can parse reads as ABSENT. Refusing to start over a file the user cannot edit by
-//! hand would not be a recovery; asking for the URL again, or falling back to the default settings,
-//! is one.
+//! hand would not be a recovery; asking for the URL again is one.
 
 use std::fs;
 use std::io::{self, Write};

--- a/apps/tray/tests/notify-when-hidden.test.ts
+++ b/apps/tray/tests/notify-when-hidden.test.ts
@@ -1,0 +1,49 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { test } from 'node:test';
+
+/**
+ * The test banner is posted AFTER the popover is hidden, and nothing else can catch it if it is not.
+ *
+ * macOS does not present a notification posted by the frontmost app (Apple's `NSUserNotification.h`,
+ * on `shouldPresentNotification:`), and clicking the button in the settings view is the one moment
+ * the tray is frontmost — the panel took focus when it opened. Posting first was the shipped bug: the
+ * command returned `Ok`, the panel said "Sent.", and the user saw nothing, while every real banner
+ * kept arriving because those are posted while the user is somewhere else.
+ *
+ * No runtime test reaches this. The command needs an `AppHandle`, the platform's refusal is silent by
+ * construction, and a view test can only see that a handler ran. So the invariant is asserted where
+ * it is written — as source text, the way the name contract already is (`invoke-contract.test.ts`) —
+ * and what it guards against is a later simplification that posts the banner in the same breath as
+ * the click.
+ */
+const main = new URL('../src-tauri/src/main.rs', import.meta.url).pathname;
+
+/** The body of `fn test_notification`, from its signature to the closing brace in column 0. */
+function command(): string {
+  const src = readFileSync(main, 'utf8');
+  const start = src.indexOf('fn test_notification');
+  assert.notEqual(start, -1, 'main.rs still defines the test notification command');
+  const end = src.indexOf('\n}\n', start);
+  assert.notEqual(end, -1, 'and the definition is closed');
+  return src.slice(start, end);
+}
+
+test('the popover is put away before the test banner is posted', () => {
+  const body = command();
+  const hidden = body.indexOf('.hide()');
+  const posted = body.indexOf('.notification()');
+
+  assert.notEqual(hidden, -1, 'the command hides the popover itself');
+  assert.notEqual(posted, -1, 'and posts the banner');
+  assert.ok(hidden < posted, 'a banner posted while the panel is up is one macOS never draws');
+});
+
+// The hide only starts the handover; the window server performs it on a later turn of the run loop,
+// so a post that does not wait is still a post from the frontmost app. The wait is what makes the
+// order above mean anything.
+test('and it waits for the handover before posting', () => {
+  const body = command();
+
+  assert.match(body, /sleep\(NOTIFY_SETTLE\)/, 'the settle is awaited between the two');
+});

--- a/apps/tray/tests/settings-view.test.ts
+++ b/apps/tray/tests/settings-view.test.ts
@@ -177,10 +177,19 @@ test('a test notification can be sent, and the caveat is on the surface', () => 
   assert.match(all(node), /the only proof/);
 });
 
-// One slot, two tones: a receipt and a failure must not look alike, or "Sent." and "could not be
+// The click makes this very screen disappear — macOS draws no banner for the app in front, so the
+// test cannot work with the panel up. Unannounced, that reads as a popover that crashed; and it is
+// the surface's job to say it, because after the click there is no surface left to say anything.
+test('the surface warns that the panel closes as it sends', () => {
+  const { node } = mount(REMOTE);
+
+  assert.match(all(node), /panel closes as it sends/);
+});
+
+// One slot, two tones: a message and a failure must not look alike, or a receipt and "could not be
 // saved" would read the same at a glance.
 test('a receipt and a failure are told apart', () => {
-  const sent = mount(REMOTE, { text: 'Sent.' });
+  const sent = mount(REMOTE, { text: 'Done.' });
   const failed = mount(REMOTE, { text: 'Could not be saved', bad: true });
 
   assert.ok(find(sent.node, 'set-said').length, 'a receipt is an ordinary line');
@@ -192,7 +201,7 @@ test('a receipt and a failure are told apart', () => {
 // Above everything, not under the control that produced it: this surface is taller than the popover
 // and every render starts it at the top, so a message at the end is one nobody sees.
 test('a message is the first thing on the surface', () => {
-  const { node } = mount(REMOTE, { text: 'Sent.' });
+  const { node } = mount(REMOTE, { text: 'Done.' });
   const main = find(node, 'set-main')[0] as { children: Array<{ className: string } | undefined> };
 
   assert.equal(main.children[0]?.className, 'set-said');

--- a/apps/tray/ui/panel.ts
+++ b/apps/tray/ui/panel.ts
@@ -466,20 +466,6 @@ async function openSettings(): Promise<void> {
   }
 }
 
-/**
- * Send one notification. The receipt says SENT, never delivered: the platform reports success even
- * when it shows nothing (`docs/tray.md`), so the only proof is the banner the user is looking for.
- */
-async function sendTest(): Promise<void> {
-  try {
-    await invoke('test_notification');
-    note = { text: 'Sent. If no banner appeared, the system is hiding them.' };
-  } catch (e) {
-    note = { text: String(e), bad: true };
-  }
-  show();
-}
-
 const settings: SettingsActions = {
   back: () => {
     view = 'live';
@@ -489,7 +475,13 @@ const settings: SettingsActions = {
   // The same command the connection screen sends, so a server changed from here goes through the
   // same trust and mismatch screens rather than a second, laxer path.
   connect: (url) => void run('connect', { url }, 'Connecting…'),
-  test: () => void sendTest(),
+  // No receipt is drawn, because Rust puts this very panel away before it posts: macOS shows no
+  // banner from the frontmost app, and while the settings are being read that is the tray. The
+  // banner is the answer, and the caveat about a system that hides them is on the surface BEFORE the
+  // click — which is where it is useful, since the screen that would have carried it afterwards is
+  // gone by then. Only the call itself can still fail, and a button that does nothing when clicked
+  // is the panel looking broken, so that one is shown.
+  test: () => void invoke('test_notification').catch((e: unknown) => show(String(e))),
   stop: () => void stopServer(),
 };
 

--- a/apps/tray/ui/settings.ts
+++ b/apps/tray/ui/settings.ts
@@ -140,6 +140,12 @@ function serverSection(
  * arrive — the plugin's permission state is a hardcoded `Granted` on desktop and sending one returns
  * success even when nothing is shown (`docs/tray.md`) — so the only check that exists is to send one
  * and look.
+ *
+ * It also warns that the panel goes away, which it must: macOS draws no banner for the app in front,
+ * so the test has to close this surface to work at all (`test_notification`). A popover vanishing on
+ * a click reads as a glitch unless the button said it would. And the caveat is worth more here than
+ * in the receipt it replaces — read while deciding to click, not after the screen that would have
+ * carried it has already closed.
  */
 function notificationSection(actions: SettingsActions): HTMLElement {
   const node = section('Notifications');
@@ -159,7 +165,7 @@ function notificationSection(actions: SettingsActions): HTMLElement {
     el(
       'p',
       'set-note',
-      'A banner is the only proof — the system can hide them silently. The menu-bar icon is never silenced.',
+      'The panel closes as it sends — in front of you, the tray sees no banner of its own. A banner is the only proof: none means the system is hiding them. The menu-bar icon is never silenced.',
     ),
   );
   return node;

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,35 @@ All notable structural changes to seedeep are recorded here, newest first.
 
 ## Unreleased
 
+**The tray's test notification sent a banner macOS was never going to draw.** Every real banner
+arrived — a session stopping on a question, a call that failed — and the one the button posts never
+did, which is the shape that made it look like a broken command. It was not: macOS refuses to
+PRESENT a notification posted by the app that is frontmost (Apple's `NSUserNotification.h`, on
+`shouldPresentNotification:`), and clicking that button is the one moment the tray is frontmost —
+the popover takes focus when it opens. The real banners are posted while the user is somewhere
+else, so they were never subject to the rule. The override Apple documents is a delegate callback
+`mac-notification-sys` does not implement, so there was nothing of ours to answer YES with; the
+receipt said "Sent." because `show()` returns `Ok(())` even when nothing is delivered, which is the
+degradation the button was built to expose in the first place.
+
+The test now reproduces the condition a real banner arrives in: `test_notification` puts the
+popover away, waits for the window server to hand activation back, and posts. There is no receipt
+any more — the banner IS the receipt, the same rule the stop already follows — and the caveat about
+a system that hides them moved onto the button's own note, where it is read while deciding to
+click rather than on a screen that has since closed. The note also says the panel will close, since
+a popover that vanishes unannounced reads as a crash.
+
+**`docs/tray.md` was describing a tray that had stopped existing.** The audit came out of the fix
+above and covers everything it touched: the file map listed a `src/settings.rs` that is gone and
+omitted `local.rs` and `update.rs`; the command list named four `read_settings` / `set_notify*`
+commands the app does not register; the config directory was said to hold two files when the tray
+writes one; the notification rules were credited to `Watch` in `poll.rs` two paragraphs after the
+same page said they had moved to the server; and the settings surface was documented with four
+switches it has not carried since they moved to the portal — including a rule about how their
+toggles redraw. `docs/features.md` had two of its own: the tray's switches described as edited from
+the tray, and a finish banner still carrying "the agent's last words", which it has not since the
+body became one line.
+
 **A session you came back to with `--resume` was tracked again only after a browser refresh, and
 the tab was the reason.** When Claude Code exits, its PID file goes and the tab freezes into the
 ended presentation — correct, and confirmed by a second reading (`end-guard.ts`). What was wrong is

--- a/docs/features.md
+++ b/docs/features.md
@@ -727,8 +727,8 @@ the thing you can act on is the thing that holds still, and a session whose call
 failed outranks one merely waiting, because an approval resumes the instant you
 answer it and a failed call does not resume at all.
 
-A notification when either happens, and optionally one when a session finishes,
-with the agent's last words. A click opens a small panel of your live sessions
+A notification when either happens, and optionally one when a session finishes —
+one title and one line, never the detail. A click opens a small panel of your live sessions
 ordered by urgency — **Broken**, *Needs you*, *Working*, *Idle*: what each one is
 asking for or what failed, what it says it is doing, its newest call, how full its
 context is. Only the sessions a person is actually in — headless `claude -p` runs
@@ -821,8 +821,10 @@ row it belongs to can never describe one event in two ways.
 
 Each **delivery channel has its own switches**. The same moment can be worth a
 banner on the machine you are sitting at and not worth a push somewhere else, and
-one shared set cannot say that. The tray's four are edited from its own panel; the
-webhook's from the portal's Settings.
+one shared set cannot say that. Both sets are edited from the portal's Settings —
+the tray's four under *Tray notifies you when*, the webhook's three beside its
+URL — because the server is what holds them, and a second place to answer one
+question is one place too many.
 
 The **webhook** is off until it has a URL, and it is the only thing in seedeep
 that sends session data off the machine (see `install.md`). It POSTs to any

--- a/docs/tray.md
+++ b/docs/tray.md
@@ -44,8 +44,9 @@ apps/tray/
     ├── src/poll.rs        the clock: 1s open / 5s closed, the icon's state, the notification
     ├── src/pin.rs         the rustls verifier that pins one leaf certificate
     ├── src/connection.rs  what is remembered, and how a pasted URL becomes it
-    ├── src/settings.rs    the three notification switches, and where they are remembered
-    ├── src/store.rs       the private, atomic write both files share
+    ├── src/local.rs       the server on THIS machine: finding it, starting it, stopping it
+    ├── src/update.rs      the release banner, and which versions this run has announced
+    ├── src/store.rs       the private, atomic write
     ├── tests/fixtures/    a synthetic certificate, for hashing without a network
     ├── icons/             the BUNDLE's icons (Finder, DMG, installer) — not the tray's
     └── capabilities/      what the webview is allowed to call
@@ -751,9 +752,12 @@ Everything the tray knows arrives through one Rust module and one endpoint. **Th
 fetches**, and that is not a style choice: Tauri's JS HTTP API can only *disable* certificate
 verification (`acceptInvalidCerts`), never pin — and disabling it would void the reason the server
 has TLS at all. So `src/client.rs` owns the client, `src/pin.rs` owns the verifier, and the panel
-reaches all of it through commands: `tick` for a reading, `connect` and `trust` for the two answers
-only a user can give, `open_session` to hand a session to the browser, and `read_settings` /
-`set_notify` / `set_notify_failed` / `set_notify_finished` / `test_notification` for the settings surface.
+reaches all of it through commands: `tick` for a reading, `look_again` to re-run discovery, `connect`
+and `trust` for the two answers only a user can give, `open_session` and `open_portal` to hand a
+session or the portal to the browser, `server_version` / `restart_pending` / `update_view` /
+`start_server` / `stop_server` for what the settings surface shows and does, and `test_notification`
+for the one check that has to leave the app. No command reads or writes a notification switch: those
+are the server's, and the panel that sets them is the portal's ([Notifications](#notifications)).
 
 ### The three cases, and the one that is not obvious
 
@@ -888,12 +892,13 @@ the domain `seedeep.app`. The same string is the macOS bundle ID, so **changing 
 application** to both operating systems: the old install stays alongside the new one and its stored
 connection is abandoned, not migrated. It is an identity, not a setting.
 
-Two files in it — or in `<SEEDEEP_HOME>/tray` when a dev run sets that
-([Running it](#running-it)) — both mode **0600**, both written and read by Rust only:
-`connection.json` (below) — `settings.json` no longer holds the notification switches, which moved
-to the server's own config (see
-[Settings](#settings)). The write is one function, `src/store.rs`: a preference and a token need the
-same atomicity, and a file nobody can parse reads as absent in both cases.
+**One file in it** — or in `<SEEDEEP_HOME>/tray` when a dev run sets that
+([Running it](#running-it)) — mode **0600**, written and read by Rust only: `connection.json`
+(below). It used to be two: `settings.json` held the notification switches until they moved to the
+server's own config ([Notifications](#notifications)), and nothing replaced it, because the only
+other thing the tray remembers — which releases it has announced — is deliberately kept in memory
+for the life of the process. The write is still one function, `src/store.rs`: a token needs
+atomicity, and a file nobody can parse reads as absent.
 
 The connection is:
 
@@ -1148,18 +1153,29 @@ SEEDEEP_TRAY_PROBE_START=1 cargo test -- --ignored --nocapture a_real_server_sta
 
 ## Notifications
 
-**Four triggers, four switches.** A session entering `waiting`, a session whose API call FAILED,
-a session finishing a turn (off unless it is asked for) — and a newer seedeep having been published.
-Nothing else notifies: not a subagent finishing, not a tool error. A tray that notifies about
-everything is a tray you mute. Notifications are sent from Rust, where the digest is
-read; the webview never needs the permission, which is why the notification permission is absent
-from `capabilities/default.json`.
+**Four triggers, four switches — and three of the four are the SERVER's.** A session entering
+`waiting`, a session whose API call FAILED, a session finishing a turn (off unless it is asked for)
+— and a newer seedeep having been published. Nothing else notifies: not a subagent finishing, not a
+tool error. A tray that notifies about everything is a tray you mute.
+
+The first three are decided, worded and switched in the server (`notify-watch.ts`), which announces
+them on its event stream; the tray subscribes and posts what arrives, composing no title and no
+verdict (`stream_notifications` in `client.rs`, posted from `poll.rs`). The fourth is the tray's own,
+because it is about the machine this tray is running on (`update.rs`). Posting is Rust's either way:
+the webview never needs the permission, which is why the notification permission is absent from
+`capabilities/default.json`.
+
+**The switches are edited in the portal's Settings**, under *Tray notifies you when* — not on this
+app's own surface, which carries none (see [Settings](#settings)). They live in
+`notifications.tray` in `~/.seedeep/config.json`, beside a second set governing the webhook channel:
+the same moment can be worth a banner on the machine you are sitting at and not worth a push
+somewhere else, and one shared set cannot say that.
 
 | Trigger | Setting | Default | What the banner says |
 | -- | -- | -- | -- |
 | A session stops on the human (`waiting`, and only the two labels below) | *A session needs you* | **on** | `project — subject` / `Waiting for your approval — Bash` |
 | A session's model call fails (`error` becomes non-null) | *A session fails* | **on** | `project — subject` / `The last API call failed` — or `A subagent's API call failed` |
-| A session that was `busy` becomes `idle`, having called the model at least once | *A session finishes* | **off** | `project — subject` / `Turn finished` |
+| A session that was `busy` becomes `idle`, having called the model at least once | *A session finishes a turn* | **off** | `project — subject` / `Turn finished` |
 | The connected SERVER is behind npm (`standing`, from `/api/update`) | *A new server version is out* | **on** | `seedeep <latest> is available` / `The server is running <its version>.` |
 
 **Why one switch per trigger, and not one reason for one switch.** The events are not the same bargain: a
@@ -1234,10 +1250,10 @@ and telling them what they just did is how a notification earns a mute. The dige
 banners saying opposite things on one moment; and a session that simply LEAVES the digest was closed
 by the user, who does not need to be told.
 
-**It fires on the TRANSITION, never on the state.** `Watch` in `poll.rs` remembers which sessions
-were stopped on the human, and which were at work, last time it could see; it announces only what
-was not there before. Three rules follow, and each of them is a way of not lying about when
-something happened:
+**It fires on the TRANSITION, never on the state.** The watch (`notify-watch.ts`, in the server)
+remembers which sessions were stopped on the human, which were at work and which had broken, last
+time it could see; it announces only what was not there before. Three rules follow, and each of them
+is a way of not lying about when something happened:
 
 - **A turn that never called the model did not finish.** Esc pressed BEFORE the first reply leaves
   nothing in the transcript — no marker, no `interruptedMessageId`, no assistant line — so the turn
@@ -1248,13 +1264,14 @@ something happened:
   sessions: 24 turns of 2526 (1.0%) are the silent shape. The other zero-call turns are local slash
   commands (264, 10.5%), which never make a session look busy, so no finish was ever in flight for
   them.
-- **A session already waiting — or already idle — when the tray connects is not an event.** The
-  first digest after a start, or after a reconnect, SEEDS both sets and announces nothing. Without
-  that, every restart would replay every open prompt as if it had just happened.
+- **A session already waiting — or already idle — when the tray arrives is not an event.** The first
+  digest SEEDS the sets and announces nothing, and the sets are forgotten again the moment the last
+  listener leaves, so whoever subscribes next also starts from a seed. Without that, opening the tray
+  would replay every open prompt as if it had just happened — including one raised half an hour ago.
 - **The sets are per session, not counts.** One prompt answered and another raised in the same
   interval leaves the count at one, and that is exactly the moment worth an interruption.
-- LIMIT: a session that enters a wait, or finishes, during a stretch the tray could not read is
-  **never** announced — the next reading seeds it. The tray does not know when it happened, and the
+- LIMIT: a session that enters a wait, or finishes, during a stretch that could not be read is
+  **never** announced — the next reading seeds it. There is no way to know when it happened, and the
   icon and the panel are what say where it now stands.
 
 **A banner is one title and one line, and never the detail** (decided 2026-08-11). The line names
@@ -1273,23 +1290,16 @@ A finished turn with nothing on record notifies the same as any other — the ev
 becoming yours again, not the text. The title is the session (`project — subject`), because the
 banner already carries the app's name.
 
-**A toggle silences its banner, not the bookkeeping.** With notifications off the transitions are
-still tracked, so turning them back on does not then announce every session that had been waiting all
-along. The menu-bar icon is not covered by either setting: it is peripheral information that
-costs nothing to ignore, and a user who silenced the interruption has not asked to be blinded.
+**A switch silences its banner, not the bookkeeping.** The switches filter the OUTPUT of the watch
+and never its input (`notify-engine.ts`), so with one off the transitions are still tracked and
+turning it back on announces what happens next rather than the backlog. The menu-bar icon is not
+covered by any of them: it is peripheral information that costs nothing to ignore, and a user who
+silenced the interruption has not asked to be blinded.
 
-**None of the above is decided HERE any more.** The rules on this page are still the rules — they
-just live in the server (`notify-watch.ts`, `notify-engine.ts`), which already held the state and
-the words. The tray subscribes to `/api/stream` and shows the `notification` events it receives; it
-composes no title, no body, and no verdict about what counts as an event. Two implementations of one
-rule were free to diverge, which is how a phone and a menu bar end up disagreeing about one session.
-
-**The four switches live in the server's config**, under `notifications.tray` in
-`~/.seedeep/config.json`, alongside a second set for the webhook channel. Moving one is therefore a
-request that can fail: the toggle draws what the server answered, not what was clicked, and a
-failure leaves it where it was under **`Not saved — seedeep is not running`** — the same words the
-panel already uses for a server that is not there. The webhook's own set is edited from the portal,
-not from here: the tray's panel governs the tray.
+**Why none of it is decided here.** The rules above are the tray's rules and it obeys every one of
+them, but it implements none: two implementations of one rule are free to diverge, which is how a
+phone and a menu bar end up disagreeing about one session. The server already held the state and the
+words, so it kept them.
 
 **Verified end to end from the bundled app** (2026-07-30, macOS 26.5.2, unsigned `.app`), because
 `docs/tray.md`'s own rule says a dev run cannot confirm this feature. A stub digest was flipped from
@@ -1298,8 +1308,8 @@ holds the record: `titl` = `atlas — add a retry to the uploader`, `body` = `Wa
 — Bash` (the command followed it on a second line until 2026-08-11, when the body became one line —
 what that run PROVED, a single record per transition, is unaffected). **One** record across five
 consecutive waiting readings, which is the
-transition rule proven rather than argued. Repeated with `settings.json` at `notify: false`: the same
-flip, no record at all.
+transition rule proven rather than argued. Repeated with the switch off: the same flip, no record at
+all — that run flipped it in the tray's own `settings.json`, which is where it lived at the time.
 
 ### What an unsigned build can actually deliver
 
@@ -1342,7 +1352,9 @@ used, or break it and leave the app with two competing surfaces.
 DEFAULT was chosen — a design rationale, which is what this document is for. Measured at the real
 392×560 (2026-08-05): 991px of content in a 514px viewport, so two of the four switches and the
 whole About section sat below the fold, and "the server is behind" was ~990px down. Cut to labels
-only, the same view is 606px and effectively fits. Two sentences survived the cut because they
+only, the same view is 606px and effectively fits. The switches themselves left later, for the
+server's own panel, and what stands here now is one line saying where they are. Two sentences
+survived the cut because they
 prevent a MISREADING rather than justify a default — the menu-bar icon is never silenced by a
 toggle, and quitting the tray does not stop the server — and one because it is the only honest thing
 that can be said about delivery: a banner is the only proof. The interruption rule stays OFF the
@@ -1356,8 +1368,7 @@ Five things, which is the whole surface:
 | -- | -- |
 | **The server** | Its address, and what identifies it: the pinned certificate whole, all 32 bytes, through the same renderer the trust screen uses |
 | **One field** | The URL the portal's Settings → Remote access copies — the same `connect` command as the connection screen, so a server changed from here goes through the same trust and mismatch screens |
-| **Four notification switches** | Under the heading *Notify me when*, which each row completes: *A session needs you* (on), *A session fails* (on), *A session finishes* (off), *A new server version is out* (on) — in that order: the app's own urgency, then the one switch that is not about a session — see [Notifications](#notifications) |
-| **A test notification** | One banner, on demand |
+| **Notifications** | No switch: one line saying they are configured in seedeep's settings, in the browser — the server owns them, and two places to answer one question is one place too many (see [Notifications](#notifications)). Under it, a test banner on demand: the panel closes as it sends, because macOS draws nothing for the app in front |
 | **Stop seedeep** | Only when the server is on this machine and Rust can name exactly one process for it — see [A stop is aimed at the connection](#a-stop-is-aimed-at-the-connection) |
 | **About** | Both builds — `seedeep tray <version>` from `getVersion()`, and `seedeep server <version>` from `GET /api/config`, read when this view opens and never on the poll. Whichever is behind npm carries `— <latest> available` **on its own line**, so which install needs updating is never left to the reader; nothing is added when neither is |
 
@@ -1391,16 +1402,35 @@ Rules that are not preferences:
   or "plain HTTP, so there is nothing to pin", or — for `http://127.0.0.1:44842` — "the tray found
   this one by itself". An empty space where a fingerprint would be reads as *not checked yet* rather
   than as *nothing to check*.
-- **A toggle draws what came back from the app, never what the click intended.** Each command answers
-  with the WHOLE settings, so neither switch can be left showing a value the file does not hold; a
-  write that fails leaves the switch where the disk is and says why. It is a `<button role="switch">` rather than a
-  checkbox: `onclick` is this codebase's client idiom and `aria-checked` is a state a test can read.
+- **Nothing on this surface writes a setting**, which is why none of it can be left showing a value
+  the disk does not hold. The four switches were here once, as `<button role="switch">` toggles that
+  drew what the app answered rather than what the click intended; they left for the server's panel,
+  and the rule left with them. What is here now either states a fact (the server, the versions) or
+  performs an act (connect, test, stop) whose answer is the next screen.
 
 **Why a test button exists at all.** There is no way to ASK whether notifications will arrive: the
 plugin's `permission_state()` is a hardcoded `Granted` on desktop (verified in
 tauri-plugin-notification 2.3.3, `desktop.rs`), and `show()` returns `Ok(())` even when nothing is
 delivered. So the honest surfacing of that degradation is the only check that exists — send one and
-look — and the receipt says **Sent**, never *delivered*.
+look.
+
+**The popover closes as it sends, and that is the test, not a courtesy.** macOS does not PRESENT a
+notification posted by the app that is FRONTMOST — Apple says so on `shouldPresentNotification:`
+("the Notification Center has decided not to present your notification, for example when your
+application is front most", `NSUserNotification.h`) — and clicking this button is the one moment the
+tray is frontmost, because the popover takes focus when it opens. So the button posted a banner
+macOS was never going to draw, while every real one kept arriving: those are posted while the user
+is somewhere else. The delegate callback Apple documents as the override is not implemented by
+`mac-notification-sys`, so there is nothing of ours to answer YES with — the tray has to stop being
+frontmost instead. `test_notification` therefore hides the panel, waits out `NOTIFY_SETTLE` (the
+handover is the window server's and lands on a later turn of the run loop, so posting in the same
+breath posts while the rule still applies), and only then sends.
+
+**There is no receipt, and there must not be**: the surface that would carry it is the one being put
+away. The banner IS the answer — the same rule the stop follows, where the screen that comes next is
+the receipt — and the caveat that a system can hide them silently sits on the button's own note,
+read while deciding to click. The note also says the panel will close: a popover that vanishes
+unannounced reads as a crash.
 
 ## Platforms
 
@@ -1564,7 +1594,7 @@ first-run than the DMG rather than a better one.
 
 **What survives an uninstall is the app config dir, on purpose.**
 [Where the connection lives](#where-the-connection-lives) is keyed on the bundle identifier, so a
-reinstall of the same app finds its pinned server and its switches where it left them — the same
+reinstall of the same app finds its pinned server where it left it — the same
 property that carried them through the `productName` rename. On macOS nothing removes it and the
 README names the path. On Windows the NSIS uninstaller draws a **Delete app data** checkbox on its
 confirm page, **created unchecked** — Tauri's `installer.nsi` creates the box and never sends it a


### PR DESCRIPTION
### The bug

Every real banner arrived — a session stopping on a question, a call that failed — and the one **Send a test notification** posts never did.

Not a broken command. macOS refuses to PRESENT a notification posted by the app that is **frontmost**, and clicking that button is the one moment the tray is frontmost: the popover takes focus when it opens. Apple states it on `shouldPresentNotification:` (`NSUserNotification.h`):

> Sent to the delegate when the Notification Center has decided not to present your notification, **for example when your application is front most**. If you want the notification to be displayed anyway, return YES.

`mac-notification-sys` does not implement that callback, so there is nothing of ours to answer YES with. Real banners are posted while the user is somewhere else, which is why they were never subject to the rule. The receipt said "Sent." because `show()` returns `Ok(())` even when nothing is delivered — the exact degradation the button exists to expose.

### The fix

`test_notification` puts the popover away, waits out `NOTIFY_SETTLE` (the handover is the window server's and lands on a later turn of the run loop), and posts. The banner is the receipt now — the same rule the stop already follows — and the caveat about a system that hides them moved onto the button's own note, where it is read while deciding to click rather than on a screen that has since closed. That note also says the panel will close: a popover that vanishes unannounced reads as a crash.

### The doc audit that came out of it

`docs/tray.md` was describing a tray that had stopped existing: a `src/settings.rs` that is gone (and no `local.rs` / `update.rs`), four `read_settings` / `set_notify*` commands the app does not register, two files in the config dir where the tray writes one, the notification rules credited to `Watch` in `poll.rs` two paragraphs after the same page said they had moved to the server, and a settings surface documented with four switches it has not carried since they left for the portal. `docs/features.md` had two of its own.

### Verification

- `bun run test` 1650 pass, `cargo test` 92 pass, lint and typecheck clean.
- New guard `apps/tray/tests/notify-when-hidden.test.ts` asserts the popover is hidden before the post — confirmed red with the fix removed.
- **The platform behaviour itself still needs a human**: no test can see whether macOS drew a banner. Run the built app, click the button, look.