### PR TITLE
0.23.0

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable structural changes to seedeep are recorded here, newest first.
 
 ## Unreleased
 
+## 0.23.0 (2026-08-13)
+
 **The tray's test notification sent a banner macOS was never going to draw.** Every real banner
 arrived — a session stopping on a question, a call that failed — and the one the button posts never
 did, which is the shape that made it look like a broken command. It was not: macOS refuses to

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "seedeep",
-  "version": "0.22.2",
+  "version": "0.23.0",
   "private": true,
   "type": "module",
   "description": "Live context & subagent visualizer for Claude Code",


### PR DESCRIPTION
Version bump and the changelog cut, in one diff as the release rule requires.

`## Unreleased` becomes `## 0.23.0 (2026-08-13)` with a fresh empty `Unreleased` above it. The section carries the two entries that were sitting in it: the resumed session's tab coming back to life without a refresh, and the tray's test notification closing the popover before it posts (plus the `docs/tray.md` audit that came out of it).

The favicon change also in this release is comment-only — it corrects a stale claim about constants shared with the tray — so it gets no entry.

Tag follows the merge.