### PR TITLE
The banner needs the app to stop being active, not just its window

### DIFF
--- a/apps/tray/src-tauri/src/main.rs
+++ b/apps/tray/src-tauri/src/main.rs
@@ -88,10 +88,14 @@ const PANEL_MIN_H: f64 = 90.0;
 /// that callback is the only way to override it. `mac-notification-sys` does not implement it, so
 /// there is nothing of ours to answer YES with: the tray has to stop being frontmost instead.
 ///
-/// Hiding the popover is what does that, and the activation it hands back is the window server's to
-/// perform — it lands on a later turn of the run loop than the click that asked for it. Posting in
-/// the same breath posts while the rule still applies, which is the whole bug. Generous on purpose:
-/// nobody is waiting on a banner they asked to see with the panel out of the way.
+/// Hiding the APP is what does that, and the handover is AppKit's — it lands on a later turn of the
+/// run loop than the click that asked for it. Posting in the same breath posts while the rule still
+/// applies, which is the whole bug.
+///
+/// Measured, not chosen (2026-08-13, `NSApplication.isActive` sampled on a clock after the hide):
+/// still `true` at the instant of the call, `false` by +0.3 s and every sample after. 400 ms is that
+/// number with room, and nobody is waiting on a banner they asked to see with the panel out of the
+/// way.
 const NOTIFY_SETTLE: Duration = Duration::from_millis(400);
 
 /// The height the popover should take to show `content`, given where its top edge is and how much
@@ -149,6 +153,17 @@ fn toggle_panel(app: &AppHandle, rect: Rect) {
     let Some(win) = app.get_webview_window(PANEL) else { return };
     if win.is_visible().unwrap_or(false) {
         let _ = win.hide();
+        // The app goes with the window, for the reason `test_notification` measures: hiding the only
+        // window of an `Accessory` app leaves it ACTIVE with nothing on screen, and macOS draws no
+        // banner for the active app. Dismissing from the icon would otherwise put the tray in a state
+        // where the REAL banners are dropped too — a session stopping on a question, announced to
+        // nobody, until the user happened to click on something else.
+        //
+        // It also makes the two dismissals agree. Losing focus (`on_window_event`) already ends the
+        // activation, because ending it is what the user just did by clicking elsewhere; this one had
+        // no such effect, so the same gesture left two different states behind.
+        #[cfg(target_os = "macos")]
+        let _ = app.hide();
         set_panel_open(app, false);
         return;
     }
@@ -179,6 +194,18 @@ fn toggle_panel(app: &AppHandle, rect: Rect) {
         };
         let _ = win.set_position(PhysicalPosition::new(x, anchor.y + icon.height));
     }
+    // Before the window, and harmless in every other case: the test notification hides the whole APP
+    // to stop being frontmost (`test_notification`), and every window of a hidden app stays down
+    // until it is unhidden. Without this the click after a test would open nothing.
+    //
+    // Deliberately says nothing about whether it also ACTIVATES: this is `NSApplication.unhide:`
+    // (`AppHandle::show` → tao 0.35.3), and Apple's own page contradicts itself on that — the
+    // abstract says it "makes the receiver active", the discussion says it invokes
+    // `unhideWithoutActivation`. Nothing here depends on the answer, because `set_focus` decides the
+    // activation two lines down, as it always did. A comment stating the unmeasured half would be
+    // read as a fact about the platform by whoever next wonders if this call is safe elsewhere.
+    #[cfg(target_os = "macos")]
+    let _ = app.show();
     let _ = win.show();
     let _ = win.set_focus();
 }
@@ -398,6 +425,13 @@ fn resize(height: f64, app: AppHandle) -> Result<f64, String> {
 /// arrive while the user is somewhere else, so the check has to reproduce that condition rather than
 /// report a delivery the window server dropped on the floor.
 ///
+/// **Hiding the window is not enough, and that was measured** (2026-08-13, on the first fix): the
+/// popover went away and the banner still landed in Notification Center without ever being drawn,
+/// while every real banner on the same machine and the same build appeared. An `Accessory` app owns
+/// no other window to fall back to, so it stays the ACTIVE app with nothing on screen. The state this
+/// is about is activation, not visibility — and hiding the APP is what ends it, for the reason
+/// measured below.
+///
 /// Nothing is returned, and nothing could be: the post happens after this call has already answered,
 /// and `show()` cannot tell delivered from dropped anyway. The banner is the receipt — the same rule
 /// the stop already follows, where the screen that comes next IS the answer.
@@ -409,6 +443,22 @@ fn test_notification(app: AppHandle) {
         // and the poll would keep the open cadence for a panel nobody is looking at.
         set_panel_open(&app, false);
     }
+    // `hide`, which is `NSApp.hide:`, and the one call MEASURED to work (2026-08-13):
+    // `deactivate` — which reads as the exact intent — leaves `isActive` TRUE, sampled at +0.3 s,
+    // +1 s and +3 s. An `Accessory` app owns no other window to fall back to, so nothing takes the
+    // activation from it and the request has nowhere to hand it. `hide` flips it by +0.3 s.
+    //
+    // Its cost is the HIDDEN state, which `toggle_panel` undoes on the next click. The window
+    // reports `is_visible() == false` while the app is hidden (measured in the same run), so the
+    // toggle still takes the branch that opens it rather than the one that dismisses it.
+    #[cfg(target_os = "macos")]
+    let _ = app.hide();
+    // LIMIT: reopening the panel inside the settle re-activates the app, and the post that lands a
+    // moment later is dropped by the same rule this works around — a test that reports nothing, which
+    // is the false negative the button exists to avoid. Nothing cancels it, on purpose: the window is
+    // 400 ms after a click that just closed the panel, so it takes a second click almost on top of
+    // the first, and every alternative (cancelling the post, or deferring it until the panel closes
+    // again) answers a rarer case with a state machine.
     tauri::async_runtime::spawn(async move {
         tokio::time::sleep(NOTIFY_SETTLE).await;
         // Discarded like every other send here, and for the reason `poll.rs` gives: `show` returns

--- a/apps/tray/tests/notify-when-hidden.test.ts
+++ b/apps/tray/tests/notify-when-hidden.test.ts
@@ -31,7 +31,7 @@ function command(): string {
 
 test('the popover is put away before the test banner is posted', () => {
   const body = command();
-  const hidden = body.indexOf('.hide()');
+  const hidden = body.indexOf('win.hide()');
   const posted = body.indexOf('.notification()');
 
   assert.notEqual(hidden, -1, 'the command hides the popover itself');
@@ -46,4 +46,51 @@ test('and it waits for the handover before posting', () => {
   const body = command();
 
   assert.match(body, /sleep\(NOTIFY_SETTLE\)/, 'the settle is awaited between the two');
+});
+
+// Measured on the first fix (2026-08-13): with the popover hidden and nothing else changed, the
+// banner still went straight to Notification Center undrawn, while real banners from the same build
+// appeared. An `Accessory` app has no second window to fall back to, so hiding one leaves it the
+// ACTIVE app with nothing on screen — and active is the state macOS refuses to draw a banner for.
+// `deactivate` was the second attempt and does not work either: `isActive` stayed true at +0.3s,
+// +1s and +3s. Hiding the APP flips it by +0.3s, which is why that is the call here — and why
+// deleting it restores a bug no runtime test can see.
+test('and it hides the APP, not just the window, which is what ends the activation', () => {
+  const body = command();
+  const window = body.indexOf('win.hide()');
+  const application = body.indexOf('app.hide()');
+
+  assert.notEqual(application, -1, 'the command hides the application itself');
+  assert.ok(window < application, 'after the window is down, so nothing is left holding focus');
+});
+
+/** The body of `fn toggle_panel`, from its signature to the closing brace in column 0. */
+function toggle(): string {
+  const src = readFileSync(main, 'utf8');
+  const start = src.indexOf('fn toggle_panel');
+  assert.notEqual(start, -1, 'main.rs still defines the panel toggle');
+  return src.slice(start, src.indexOf('\n}\n', start));
+}
+
+// The cost of hiding the APP: every window of a hidden app stays down until something unhides it.
+// The menu-bar click is what has to undo it, and if it does not, the test notification is a button
+// that breaks the panel until the tray is restarted.
+test('and the click that reopens the panel unhides the app first', () => {
+  const body = toggle();
+
+  assert.match(body, /app\.show\(\)/, 'toggle_panel brings the application back');
+  assert.ok(body.indexOf('app.show()') < body.indexOf('win.show()'), 'before it shows the window');
+});
+
+// The same rule on the other gesture, and the reason it is here rather than in a test about the
+// popover: dismissing from the icon used to hide the window and stop, which left the tray ACTIVE
+// with nothing on screen — the exact state in which macOS drops a banner. The REAL ones were being
+// dropped there too, silently, and no test could see it. Losing focus needs no such call: clicking
+// elsewhere is itself the activation ending.
+test('dismissing from the icon hides the app too, or the real banners are dropped as well', () => {
+  const body = toggle();
+  const dismiss = body.slice(0, body.indexOf('set_panel_open(app, true)'));
+
+  assert.match(dismiss, /win\.hide\(\)/, 'the dismissal puts the window away');
+  assert.match(dismiss, /app\.hide\(\)/, 'and ends the activation with it');
 });

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable structural changes to seedeep are recorded here, newest first.
 
 ## Unreleased
 
+**Closing the panel from the menu-bar icon was dropping the REAL banners too**, and nothing had ever
+noticed. It hid the window and stopped there, which for an `Accessory` app — no other window to fall
+back to — leaves it the ACTIVE app with nothing on screen, the one state macOS draws no banner for.
+So after opening and dismissing the panel from the icon, a session stopping on a question announced
+itself to nobody until the user happened to click on something else. Dismissing by clicking
+elsewhere never had the problem: that click is itself the activation ending. Both gestures now leave
+the same state. Found while fixing the test notification below — same rule, other gesture, and the
+one nobody was looking for.
+
+**The test notification needed the app to stop being ACTIVE, not just to put its window away.** The
+fix in 0.23.0 hid the popover and posted; the popover went away and the banner still landed in
+Notification Center without ever being drawn, while real banners on the same machine and the same
+build kept appearing. The missing half: an `Accessory` app owns no other window to fall back to, so
+hiding its only one leaves it the frontmost app with nothing on screen — and frontmost is the state
+macOS refuses to draw a banner for. `test_notification` now hides the APP after hiding the panel.
+
+**`NSApplication.deactivate` was tried first and does nothing here**, which is worth recording
+because it reads like the exact intent. Sampled on a clock, `isActive` was still `true` at +0.3 s,
++1 s and +3 s after the call: with no other window of ours to fall back to, nothing takes the
+activation and the request has nowhere to hand it. `NSApp.hide:` hands it to the next app in line and
+`isActive` is `false` by +0.3 s — the same measurement `NOTIFY_SETTLE`'s 400 ms now comes from. The
+cost is the HIDDEN state, so the menu-bar click unhides the app before showing the panel; a window of
+a hidden app reports itself invisible, so the toggle still takes the branch that opens it.
+
 ## 0.23.0 (2026-08-13)
 
 **The tray's test notification sent a banner macOS was never going to draw.** Every real banner

--- a/docs/tray.md
+++ b/docs/tray.md
@@ -383,6 +383,15 @@ it hangs off the edge of the screen.
 It also closes when it loses focus. A window with no title bar has no close button, so clicking
 anywhere else *is* the dismissal — the way a menu behaves.
 
+**Both dismissals end the app's ACTIVATION, and the one from the icon has to do it by hand.**
+Clicking elsewhere ends it by definition — the click activated something else. Clicking the icon
+does not: an `Accessory` app owns no other window to fall back to, so hiding the popover leaves it
+the active app with nothing on screen, and macOS draws no banner for the active app
+([Notifications](#notifications)). Dismissing from the icon therefore hides the APP, not only the
+window. Until it did (2026-08-13), the tray sat in that state for as long as the user did not click
+on something else — and every REAL banner raised meanwhile, a session stopping on a question
+included, was dropped in silence. The next click on the icon unhides it before showing the panel.
+
 Right-click opens a one-item menu: **Quit seedeep**. That is not decoration. The app has no Dock tile
 and no app-switcher entry (macOS `ActivationPolicy::Accessory`, which is also what stops it
 stealing focus at launch), so without that menu it could not be quit except from Activity
@@ -1422,9 +1431,28 @@ tray is frontmost, because the popover takes focus when it opens. So the button 
 macOS was never going to draw, while every real one kept arriving: those are posted while the user
 is somewhere else. The delegate callback Apple documents as the override is not implemented by
 `mac-notification-sys`, so there is nothing of ours to answer YES with — the tray has to stop being
-frontmost instead. `test_notification` therefore hides the panel, waits out `NOTIFY_SETTLE` (the
-handover is the window server's and lands on a later turn of the run loop, so posting in the same
-breath posts while the rule still applies), and only then sends.
+frontmost instead. `test_notification` therefore hides the panel, **hides the app**, waits out
+`NOTIFY_SETTLE`, and only then sends.
+
+**Hiding the WINDOW does not do it, and neither does asking to deactivate.** Both were shipped and
+both failed, which is why the mechanism is written down here with what was measured rather than with
+what it reads like. An `Accessory` app owns no other window to fall back to, so hiding its only one
+leaves it the ACTIVE app with nothing on screen — the state that matters is activation, not
+visibility. `NSApplication.deactivate` says exactly that intent and does nothing: sampled on a clock
+(2026-08-13), `isActive` was still `true` at +0.3 s, +1 s and +3 s. Nothing was there to take the
+activation, so the request had nowhere to hand it. `NSApp.hide:` — Tauri's `AppHandle::hide` — hands
+it to the next app in line, and `isActive` is `false` by +0.3 s. That measurement is also where
+`NOTIFY_SETTLE`'s 400 ms comes from.
+
+**Its cost is the HIDDEN state, and `toggle_panel` is what pays it**: every window of a hidden app
+stays down until something unhides it, so the click after a test would otherwise open nothing. It
+calls `AppHandle::show` before showing the window, which is harmless in every other case. The branch
+above it stays correct on its own: a window of a hidden app reports `is_visible() == false` (measured
+in the same run), so the click takes the path that opens the panel rather than the one that dismisses
+it. Whether `show` also ACTIVATES is left unstated here and in the code, because it cannot be
+settled from the documentation — `AppHandle::show` is `NSApplication.unhide:`, whose Apple page says
+"makes the receiver active" in the abstract and "invokes `unhideWithoutActivation`" in the
+discussion. Nothing depends on it: `set_focus` decides the activation on the next line.
 
 **There is no receipt, and there must not be**: the surface that would carry it is the one being put
 away. The banner IS the answer — the same rule the stop follows, where the screen that comes next is


### PR DESCRIPTION
Follow-up to #18, which fixed half of it. The popover closed and the banner still never appeared — confirmed on a real machine, where every real banner from the same build kept working.

### What was missing

macOS draws no banner for the app that is **frontmost**. An `Accessory` app owns no other window to fall back to, so hiding its only one leaves it **ACTIVE with nothing on screen**. Hiding the popover is not what ends the activation.

### Why `deactivate` is not the answer, measured

It reads like the exact intent. It does nothing here. `NSApplication.isActive`, sampled on a clock after the call:

| Call | +0.3s | +1s | +3s |
| -- | -- | -- | -- |
| `NSApplication.deactivate` | `true` | `true` | `true` |
| `NSApp.hide:` (`AppHandle::hide`) | **`false`** | `false` | `false` |

Nothing was there to take the activation, so the request had nowhere to hand it. `hide:` hands it to the next app in line. That measurement is also where `NOTIFY_SETTLE`'s 400 ms comes from — it used to be a guess.

Its cost is the HIDDEN state, so the menu-bar click unhides before showing the panel. The branch above it stays correct on its own: a window of a hidden app reports `is_visible() == false` (measured in the same run), so the click opens the panel rather than dismissing it. No new dependencies — `hide`/`show` are already on `AppHandle`.

### The bug this uncovered, which is the bigger one

**Dismissing the panel from the menu-bar icon was dropping the REAL banners too.** It hid the window and stopped, leaving the tray active with nothing on screen — so after opening and closing the panel from the icon, a session stopping on a question announced itself to nobody until the user happened to click elsewhere. Dismissing by clicking elsewhere never had the problem: that click is itself the activation ending. Both gestures now leave the same state.

Not a regression from this branch — it has always been there, and no test could see it.

### Review

`/code-review` raised three findings; two survived verification.

- **The dismissal path above** — accepted, and it is why this PR is bigger than the button.
- **Reopening the panel inside the 400 ms settle** re-activates the app and the pending post is dropped — a false negative from the button that exists to prevent them. Recorded as a `// LIMIT:` at the site, not fixed: it takes a second click almost on top of the first, and every alternative answers a rarer case with a state machine.
- **A comment claiming `AppHandle::show` does not focus the app** — the finding said Apple documents the opposite. Both were wrong: `show` is `NSApplication.unhide:`, whose Apple page says *"makes the receiver active"* in the abstract and *"Invokes `unhideWithoutActivation()`"* in the discussion. It cannot be settled from the docs, so neither the comment nor `docs/tray.md` claims it now — and nothing depends on it, because `set_focus` decides the activation on the next line.

### Verification

- 1656 JS tests, 92 Rust tests, lint and typecheck clean.
- The guard grew to 6 assertions; the new one — dismissing from the icon hides the app — was confirmed **red** with the call removed and green with it back.
- Behaviour confirmed by hand on the built app: the test banner appears, and the panel reopens after it. The dismissal path's hide → unhide → show cycle is measured, not yet clicked.