### PR TITLE
Run every released binary on its own OS before anything publishes it

### DIFF
--- a/.github/scripts/smoke-server.sh
+++ b/.github/scripts/smoke-server.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+#
+# Does a built server executable actually RUN — on a machine that did not build it?
+#
+# All five executables are cross-compiled from one `ubuntu-latest` runner, so until this ran, the
+# Windows binary and both Linux ARM binaries had never been EXECUTED anywhere, ever. That is the
+# 0.6.0 shape: green artefacts, dead at startup on every machine but the builder's.
+#
+#   .github/scripts/smoke-server.sh <binary> <expected-version> [port]
+#
+# It asserts three things, in the order they can break:
+#
+#   1. `--version` prints the expected number — the binary loads and its embedded version is the
+#      one being released (a forgotten bump fails here, not on someone's machine).
+#   2. `GET /api/config` answers 200 — the one endpoint that needs no auth token and no session on
+#      disk, so it is a true "the server is up" and nothing else.
+#   3. `GET /`, `/lib/app.js` and `/css/chrome.css` answer 200 — the GUI is really inside the
+#      executable. This is not paranoia: `apps/server/src/server/assets.ts` records the measured
+#      failure where `/api/*` answered and every static path 404'd, because `bun build --compile`
+#      embeds a file only when something imports it. A smoke test that only called `/api` would
+#      have shipped that.
+#
+# `SEEDEEP_HOME` and `CLAUDE_CONFIG_DIR` are pointed at a temporary directory, so a run touches
+# neither the config nor the sessions of the machine it runs on — which is what makes it safe to
+# run on a laptop and not only on a throwaway runner.
+#
+# Bash on every platform, never PowerShell: v0.6.0 uploaded no Windows installer because `"$TAG"`
+# in PowerShell is an unassigned variable that expands to nothing. One shell, one script, five
+# platforms.
+
+set -euo pipefail
+
+BIN=${1:?usage: smoke-server.sh <binary> <expected-version> [port]}
+EXPECTED=${2:?usage: smoke-server.sh <binary> <expected-version> [port]}
+# Not the default 44842: a smoke test must never talk to a seedeep the machine is already running,
+# nor make one adopt its throwaway config.
+PORT=${3:-44899}
+# Seconds to wait for the first answer. Overridable so the test suite can drive the failure paths
+# without waiting out a real startup budget.
+TIMEOUT_S=${SMOKE_TIMEOUT_S:-60}
+
+BASE="http://127.0.0.1:$PORT"
+WORK=$(mktemp -d)
+export SEEDEEP_HOME="$WORK/seedeep"
+export CLAUDE_CONFIG_DIR="$WORK/claude"
+mkdir -p "$CLAUDE_CONFIG_DIR/projects"
+
+PID=""
+cleanup() {
+  if [ -n "$PID" ]; then kill "$PID" 2>/dev/null || true; fi
+  rm -rf "$WORK"
+}
+trap cleanup EXIT
+
+fail() {
+  echo "smoke: FAIL — $1" >&2
+  exit 1
+}
+
+[ -f "$BIN" ] || fail "no such file: $BIN"
+chmod +x "$BIN" 2>/dev/null || true
+
+# 1. The binary loads at all, and knows which version it is.
+# `tr -d '\r'` because Git Bash on Windows reads a native program's output verbatim, CR included.
+version=$("$BIN" --version 2>"$WORK/version.err" | tr -d '\r') || {
+  cat "$WORK/version.err" >&2
+  fail "\`$BIN --version\` did not exit 0 — the executable does not start on this machine"
+}
+[ "$version" = "$EXPECTED" ] || fail "--version printed '$version', expected '$EXPECTED'"
+
+# 2. It serves. `--no-open` because a runner has no browser, and opening one would be the only
+# step here that needs a desktop.
+"$BIN" serve --port "$PORT" --no-open >"$WORK/serve.log" 2>&1 &
+PID=$!
+
+waited=0
+until [ "$(curl -s -o "$WORK/config.json" -w '%{http_code}' "$BASE/api/config" || true)" = 200 ]; do
+  kill -0 "$PID" 2>/dev/null || {
+    cat "$WORK/serve.log" >&2
+    fail "the server exited before answering — see its output above"
+  }
+  waited=$((waited + 1))
+  [ "$waited" -lt "$TIMEOUT_S" ] || {
+    cat "$WORK/serve.log" >&2
+    fail "no answer on $BASE/api/config after ${TIMEOUT_S}s"
+  }
+  sleep 1
+done
+
+grep -q '"port"' "$WORK/config.json" || fail "/api/config answered 200 but its body is not the config"
+
+# 3. The GUI is in there. One file per kind — the HTML the browser asks for at `/`, the script
+# bundle, one stylesheet — because they are all embedded by the same `with { type: 'file' }`
+# mechanism and it fails for all of them at once.
+for path in / /lib/app.js /css/chrome.css; do
+  code=$(curl -s -o "$WORK/asset" -w '%{http_code}' "$BASE$path" || true)
+  [ "$code" = 200 ] || fail "GET $path answered $code — the browser GUI is not inside this executable"
+  [ -s "$WORK/asset" ] || fail "GET $path answered 200 with an empty body"
+done
+
+echo "smoke: OK — $BIN $version starts, serves /api/config, and carries the GUI"

--- a/.github/scripts/smoke-server.test.ts
+++ b/.github/scripts/smoke-server.test.ts
@@ -1,0 +1,112 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { test } from 'node:test';
+
+// The smoke script is the gate that decides whether a release is publishable, and a gate that
+// cannot go red is worse than no gate: it would sign off the exact failure it was written for.
+// So it is tested by its FAILURE paths, against fake executables that break one thing each. The
+// green case is here too, for the same reason — a script that is red on everything proves nothing
+// about the four that are red on purpose.
+//
+// The fakes are `bash` + `bun`, so this runs where the suite runs (Linux and macOS). The Windows
+// half of the matrix is proven by the workflow itself, which is the only place a Windows binary
+// exists.
+
+const SCRIPT = join(import.meta.dirname, 'smoke-server.sh');
+
+/** A Bun server standing in for the compiled executable: `--version`, then `serve --port <n>`. */
+const FAKE_SERVER = `
+const port = Number(Bun.argv[Bun.argv.indexOf('--port') + 1]);
+const assets = Bun.env.FAKE_ASSETS ?? 'ok';
+const body = Bun.env.FAKE_CONFIG_BODY ?? '{"port":' + port + '}';
+Bun.serve({
+  port,
+  fetch(req) {
+    const { pathname } = new URL(req.url);
+    if (pathname === '/api/config') return new Response(body);
+    if (assets === '404') return new Response('nope', { status: 404 });
+    return new Response('body');
+  },
+});
+`;
+
+/**
+ * Run the smoke script against a fake executable.
+ *
+ * `serve` is what the fake does with anything that is not `--version`, which is exactly the shape
+ * the real binary has — so a script that stops calling one of them is caught here.
+ */
+function runSmoke(opts: { version: string; expected: string; serves?: boolean; env?: Record<string, string> }): {
+  status: number | null;
+  output: string;
+} {
+  const dir = mkdtempSync(join(tmpdir(), 'seedeep-smoke-'));
+  try {
+    const serverPath = join(dir, 'fake-server.ts');
+    writeFileSync(serverPath, FAKE_SERVER);
+    const binPath = join(dir, 'fake-seedeep');
+    // `exec` so the fake replaces the shell: the script kills the pid it spawned, and a wrapper
+    // left in front of the server would survive that kill and hold the port.
+    writeFileSync(
+      binPath,
+      `#!/usr/bin/env bash
+if [ "$1" = "--version" ]; then echo "${opts.version}"; exit 0; fi
+${opts.serves === false ? 'sleep 30' : `exec bun "${serverPath}" "$@"`}
+`,
+    );
+    chmodSync(binPath, 0o755);
+
+    // A port per run: these tests may share a machine with a seedeep someone is actually using.
+    const port = String(45100 + Math.floor(Math.random() * 400));
+    const res = spawnSync('bash', [SCRIPT, binPath, opts.expected, port], {
+      encoding: 'utf8',
+      env: { ...process.env, SMOKE_TIMEOUT_S: '3', ...opts.env },
+    });
+    return { status: res.status, output: `${res.stdout}${res.stderr}` };
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+test('passes when the binary reports its version, serves the API and carries the GUI', () => {
+  const { status, output } = runSmoke({ version: '9.9.9', expected: '9.9.9' });
+  assert.equal(status, 0, output);
+  assert.match(output, /smoke: OK/);
+});
+
+test('fails when the binary reports a version other than the one being released', () => {
+  const { status, output } = runSmoke({ version: '9.9.8', expected: '9.9.9' });
+  assert.notEqual(status, 0);
+  assert.match(output, /--version printed '9\.9\.8'/);
+});
+
+test('fails when the server never answers', () => {
+  const { status, output } = runSmoke({ version: '9.9.9', expected: '9.9.9', serves: false });
+  assert.notEqual(status, 0);
+  assert.match(output, /no answer on/);
+});
+
+// The measured failure this script exists for, reproduced: the API is up and every static path is
+// 404, because nothing imported the GUI's files into the executable.
+test('fails when /api answers but the GUI is not embedded', () => {
+  const { status, output } = runSmoke({
+    version: '9.9.9',
+    expected: '9.9.9',
+    env: { FAKE_ASSETS: '404' },
+  });
+  assert.notEqual(status, 0);
+  assert.match(output, /the browser GUI is not inside this executable/);
+});
+
+test('fails when /api/config answers 200 with something that is not the config', () => {
+  const { status, output } = runSmoke({
+    version: '9.9.9',
+    expected: '9.9.9',
+    env: { FAKE_CONFIG_BODY: '<html>a proxy sign-in page</html>' },
+  });
+  assert.notEqual(status, 0);
+  assert.match(output, /is not the config/);
+});

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -274,6 +274,84 @@ jobs:
           REPO: ${{ github.repository }}
         run: gh release upload "$TAG" dist/* --clobber --repo "$REPO"
 
+  # Does what was built actually RUN? All five executables are cross-compiled on the ONE
+  # `ubuntu-latest` runner above, so until this job existed the Windows binary and both Linux ARM
+  # binaries had never been EXECUTED on any machine, ever. That is the 0.6.0 failure exactly - five
+  # green artifacts, dead at startup everywhere but where they were built - and it was invisible
+  # from this workflow's own checkmarks, which is why no test could have caught it: the only proof
+  # is running the file on the OS it claims to be for.
+  #
+  # It gates `publish` and `npm` rather than reporting after them. A build that does not start then
+  # never leaves the draft and never reaches a registry, where a publish cannot be taken back - the
+  # remedy is a new tag, not an explanation owed to a stranger whose download does nothing.
+  #
+  # On a tag the binary is downloaded from the release, so this also proves the UPLOAD happened -
+  # v0.6.0's Windows installer was built and never uploaded. A manual run has no release, so it
+  # takes the same files from the run's artifact: the whole matrix is provable without cutting one.
+  smoke:
+    needs: server
+    strategy:
+      # Every platform reports. Which ones start is the entire question, and stopping at the first
+      # failure would answer it for one of five.
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            asset: linux-x64
+          - runner: ubuntu-24.04-arm
+            asset: linux-arm64
+          - runner: macos-latest
+            asset: macos-arm64
+          # An x64 binary needs an x64 machine, and `macos-latest` is arm64. `macos-13` is no longer
+          # offered - the Intel runners are `macos-15-intel` and `macos-26-intel`.
+          - runner: macos-15-intel
+            asset: macos-x64
+          - runner: windows-latest
+            asset: windows-x64.exe
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      # A tag says which version it releases; a manual run has only the manifest. On a tag this is
+      # also what catches a forgotten bump: the binary prints the version `package.json` carried
+      # when it was compiled, and the smoke script requires the two to be the same string.
+      - shell: bash
+        env:
+          TAG: ${{ github.ref_name }}
+          IS_TAG: ${{ github.ref_type == 'tag' }}
+        run: |
+          if [ "$IS_TAG" = true ]; then
+            version=${TAG#v}
+          else
+            version=$(grep -m1 '"version"' package.json | sed 's/.*"version": *"\([^"]*\)".*/\1/')
+          fi
+          echo "VERSION=$version" >> "$GITHUB_ENV"
+
+      # Through the environment, never interpolated into the command, for the reason the draft job
+      # gives: a ref name is repository input.
+      - if: github.ref_type == 'tag'
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+          REPO: ${{ github.repository }}
+          ASSET: ${{ matrix.asset }}
+        run: gh release download "$TAG" --repo "$REPO" --pattern "seedeep-server_${VERSION}_${ASSET}" --dir bin
+
+      - if: github.ref_type != 'tag'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: server-binaries
+          path: bin
+
+      # `shell: bash` on every platform, Windows included: v0.6.0 uploaded no Windows installer
+      # because `"$TAG"` in PowerShell is an unassigned variable that expands to nothing. One
+      # script, five platforms, no per-OS dialect to get wrong. What it asserts is in its header.
+      - shell: bash
+        env:
+          ASSET: ${{ matrix.asset }}
+        run: .github/scripts/smoke-server.sh "bin/seedeep-server_${VERSION}_${ASSET}" "$VERSION"
+
   # The npm channel: the same five executables, each wrapped in a package npm resolves by `os`/`cpu`,
   # under one `seedeep` wrapper whose postinstall puts the binary where `bin` already points. Node is
   # needed to INSTALL, never to run. It exists because a binary that arrives through a package
@@ -283,7 +361,10 @@ jobs:
   # Deliberately NOT a dependency of `publish`: if a publish to npm fails, the release page is still
   # worth having, and the failure is red here where it can be re-run.
   npm:
-    needs: server
+    # `smoke` gates this one harder than it gates `publish`: a draft release can be deleted, an npm
+    # version cannot (unpublish is restricted after 72 hours). A binary that does not start must
+    # never reach the registry.
+    needs: [server, smoke]
     # A tag AND a switch. Publishing to npm cannot be taken back (unpublish is restricted after 72
     # hours), and the FIRST publish of a package has to be manual anyway - a trusted publisher can
     # only be configured on a package that already exists. So every tag builds these packages and
@@ -351,7 +432,9 @@ jobs:
   # release is "the most recent non-prerelease, non-draft release"). So on a public repo an
   # unpublished release means the README's download link leads nowhere - which is what this closes.
   publish:
-    needs: [tray, server]
+    # `smoke` is here so a release nobody can start stays a draft: this job is the single step that
+    # makes a build visible to strangers, and it is the last place the decision can still be undone.
+    needs: [tray, server, smoke]
     # Only a tag has a release to publish. A manual run built the same artifacts and attached them
     # to the workflow run, deliberately touching nothing in the repository.
     if: github.ref_type == 'tag'

--- a/apps/tray/tests/release-workflow.test.ts
+++ b/apps/tray/tests/release-workflow.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { test } from 'node:test';
 import { fileURLToPath } from 'node:url';
+import { TARGETS } from '../../server/scripts/targets.ts';
 
 // The release workflow is the only file in the repo that can take an irreversible action - it
 // publishes. Nothing else checks it: it runs on GitHub's machines, so a change that looks fine is
@@ -101,13 +102,41 @@ test('the draft job itself always runs; only the step that writes is conditional
 });
 
 // The whole point of publishing from a separate job. `needs` will not start it unless every matrix
-// build AND the server's job succeeded, so a Windows failure leaves a draft instead of putting half
-// a download page in front of people; and it runs once where the builds run per platform.
+// build, the server's job AND the smoke run succeeded, so a Windows failure leaves a draft instead
+// of putting half a download page in front of people; and it runs once where the builds run per
+// platform.
 test('the release is published only after both halves built', () => {
   const publish = job('publish');
-  assert.match(publish, /needs: \[tray, server\]/);
+  assert.match(publish, /needs: \[tray, server, smoke\]/);
   assert.match(publish, /if: github\.ref_type == 'tag'/);
   assert.match(publish, /gh release edit .*--draft=false/);
+});
+
+// The gate that 0.6.0 was missing: five binaries cross-compiled on one runner, none of them ever
+// executed. Both exits from the pipeline wait for it — the release page and the registry — and npm
+// is the one that cannot be taken back.
+test('nothing reaches a stranger until the binaries have been RUN', () => {
+  assert.match(job('publish'), /needs: \[tray, server, smoke\]/);
+  assert.match(job('npm'), /needs: \[server, smoke\]/);
+});
+
+// A target that is built and not smoke-tested is exactly the hole this closes, and it reopens
+// silently the day someone adds a platform to `targets.ts` — the one list both the compiler and
+// the npm packager read.
+test('the smoke matrix covers every target the server is built for', () => {
+  const smoke = job('smoke');
+  const tested = [...smoke.matchAll(/asset: (\S+)/g)].map((m) => m[1]).sort();
+  assert.deepEqual(tested, TARGETS.map((t) => t.asset).sort());
+});
+
+// One shell on five platforms. v0.6.0 uploaded no Windows installer because `"$TAG"` in PowerShell
+// is an unassigned variable that expands to nothing, and `windows-latest` defaults to PowerShell:
+// a `run:` here without `shell: bash` is that bug waiting to happen again.
+test('every command the smoke job runs is bash, Windows included', () => {
+  const smoke = job('smoke');
+  const steps = smoke.split(/\n {6}- /).filter((s) => /(^|\n)\s*run:/.test(s));
+  assert.equal(steps.length, 3, 'the version, the download on a tag, the script');
+  for (const step of steps) assert.match(step, /shell: bash/, `a step runs outside bash:\n${step}`);
 });
 
 // The rule is about the DOWNLOAD PAGE: two macOS files sharing one prefix say nothing about which

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable structural changes to seedeep are recorded here, newest first.
 
 ## Unreleased
 
+**No release publishes until every executable in it has actually been STARTED.** All five server
+binaries are cross-compiled on one `ubuntu-latest` runner, so the Windows binary and both Linux ARM
+binaries had never been executed on any machine, ever — the shape of the v0.6.0 failure, five green
+artifacts dead at startup everywhere but where they were built, invisible from the workflow's own
+checkmarks. `release.yml` now has a `smoke` job that downloads each asset onto a runner of its own OS
+and runs `.github/scripts/smoke-server.sh`: `--version` must print the version being released (which
+also catches a forgotten bump), `GET /api/config` must answer, and `/`, `/lib/app.js` and
+`/css/chrome.css` must answer too — the browser GUI is embedded by `with { type: 'file' }` imports,
+and the measured failure of a first compile was an API that answered while every static path 404'd.
+It gates both exits: `publish` (a broken build stays a draft) and `npm` (which cannot be taken back
+at all). On a tag the asset comes from the release, which also proves the upload happened; on a
+manual run from the run's artifact, so the matrix is provable without cutting a release. Every step
+is `shell: bash`, Windows included, because `"$TAG"` in PowerShell is an unassigned variable — the
+reason v0.6.0 uploaded no Windows installer.
+
 ## 0.23.1 (2026-08-14)
 
 **Closing the panel from the menu-bar icon was dropping the REAL banners too**, and nothing had ever

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -138,6 +138,20 @@ Three things about that script are decisions, not detail:
 The Linux binaries are dynamically linked against glibc, so a musl distribution (Alpine) is not a
 target either.
 
+**Every executable is STARTED before anything publishes it.** Cross-compiling from one runner means
+the Windows binary and both Linux ARM binaries are never executed by the build that produces them —
+which is exactly how v0.6.0 shipped five artifacts that died at startup on every machine but the
+builder's, with a green workflow to show for it. `release.yml`'s `smoke` job downloads each asset
+onto a runner of its own OS (`ubuntu-latest`, `ubuntu-24.04-arm`, `macos-latest`, `macos-15-intel`,
+`windows-latest`) and runs `.github/scripts/smoke-server.sh`, which asserts that `--version` prints
+the version being released, that `GET /api/config` answers, and that `/`, `/lib/app.js` and
+`/css/chrome.css` answer too — the last three because the measured failure mode of a first compile
+was an API that answered while every static path 404'd. Both exits from the pipeline wait for it:
+`publish` (so a broken build stays a draft) and `npm` (which cannot be taken back at all). On a tag
+the binary comes from the release itself, which also proves the upload happened — v0.6.0's Windows
+installer was built and never uploaded — and on a manual run it comes from the run's artifact, so
+the whole matrix is provable without cutting a release.
+
 #### The npm channel
 
 The same five executables also ship as npm packages, which is what `npm i -g seedeep` installs.

--- a/docs/tray.md
+++ b/docs/tray.md
@@ -1537,8 +1537,9 @@ the server rather than the app the user meant. The bundle IDENTIFIER did not cha
 (`app.seedeep.tray`), so the permission already granted, the config directory and the Windows
 uninstall key all survive the rename.
 
-**Publishing is a separate job, and that is what makes it safe to automate.** `needs: [tray, server]`
-will not start it unless EVERY matrix build and the server's own job succeeded, so a Windows failure
+**Publishing is a separate job, and that is what makes it safe to automate.**
+`needs: [tray, server, smoke]` will not start it unless EVERY matrix build, the server's own job and
+the smoke run of all five executables succeeded (`docs/architecture.md`, *Shipping the server*), so a Windows failure
 — or a server that would not compile — leaves a draft rather than putting half a download page in
 front of people; and it runs once, where the build job runs per platform. Publishing from a build
 job instead would put a release on the download page as soon as the FIRST runner finished — one


### PR DESCRIPTION
All five server executables are cross-compiled on one `ubuntu-latest` runner, so the Windows binary and both Linux ARM binaries had never been EXECUTED on any machine, ever. That is the v0.6.0 failure exactly — five green artifacts, dead at startup everywhere but where they were built — and it was invisible from the workflow's own checkmarks, because no test can run a file for an OS the test machine is not.

## What it adds

A `smoke` job that downloads each asset onto a runner of its own OS and runs `.github/scripts/smoke-server.sh`, which asserts what a broken binary breaks, in the order it breaks it:

1. `--version` prints the version being released — a forgotten bump fails here, not on someone's machine.
2. `GET /api/config` answers — the one endpoint needing neither an auth token nor a session on disk.
3. `/`, `/lib/app.js` and `/css/chrome.css` answer — the measured failure of a first compile was an API that answered while every static path 404'd, because `bun build --compile` embeds a file only when something imports it. A smoke test calling only `/api` would have shipped that.

It gates both exits rather than reporting after them: `publish`, so a build that does not start stays a draft, and `npm`, where a publish cannot be taken back after 72 hours. On a tag the asset comes from the release itself, which also proves the upload happened — v0.6.0 built a Windows installer and uploaded nothing. On a manual run it comes from the run's artifact, so the matrix is provable without cutting a release.

Every step is `shell: bash`, Windows included: `"$TAG"` in PowerShell is an unassigned variable that expands to nothing, which is why v0.6.0 uploaded no Windows installer at all.

## Verified, not assumed

A manual run of this workflow on this branch, verdict read from each job's log:

| Binary | Runner | Result | Time |
| -- | -- | -- | -- |
| `windows-x64.exe` | `windows-latest` | starts, serves `/api/config`, carries the GUI | 32s |
| `linux-arm64` | `ubuntu-24.04-arm` | same | 11s |
| `linux-x64` | `ubuntu-latest` | same | 9s |
| `macos-arm64` | `macos-latest` | same | 27s |
| `macos-x64` | `macos-15-intel` | same | 30s |

Nothing was broken — what the gate removes is not knowing. The five jobs run in parallel behind the 25s `server` build, so a release is delayed by about half a minute.

The script was also run against a real binary locally, and its own tests cover the failure paths: a wrong version, a server that never answers, an API that answers while the GUI is missing, and `/api/config` returning something that is not the config. Each new workflow assertion was confirmed to go red — the gate removed from `publish`, from `npm`, a target dropped from the matrix, `shell: bash` removed from a step — with a no-op control that stays green.

`macos-13` is no longer offered by GitHub; the Intel runners are `macos-15-intel` and `macos-26-intel`, and every label used here is a standard runner, free on public repositories.