### PR TITLE
0.24.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,12 +173,19 @@ developed on. **It has never been installed on a Windows or a Linux box** — th
 neither here. Building for three systems is not the same as having used three, and
 this section is that difference written down rather than left for you to find.
 
+Since 0.24.0 there is a middle ground worth naming: **started is not used**. Every
+release now runs each server binary on a runner of its own operating system before
+anything is published — it must report its version, answer on its API and serve the
+browser GUI, or the release stays a draft. That rules out the download that dies at
+startup. It says nothing about whether the thing is pleasant, or correct, in front of
+a person on that machine.
+
 | | macOS | Windows | Linux |
 | -- | -- | -- | -- |
-| **Server** — download or npm | Used daily; every claim above was checked here | **Never run.** The `.exe` is built by CI on every tag and nothing has opened it | **Never run.** The suite does run on Linux in CI on every push, so the logic is exercised there — the compiled binary never has been |
-| **Tray** | Used daily on a real menu bar | **Never run.** The installer is built on every tag and nothing has opened it | **Not a target**, deliberately: Tauri emits no tray click event on Linux, so the panel could not open — see [`docs/tray.md`](docs/tray.md) |
+| **Server** — download or npm | Used daily; every claim above was checked here | **Started on every release, never used.** CI runs the `.exe` on a Windows runner and checks it serves the GUI; nobody has worked in it | **Started on every release, never used.** Same check on x64 and arm64 runners, and the suite runs on Linux on every push |
+| **Tray** | Used daily on a real menu bar | **Never run.** The installer is built on every tag and nothing has opened it — a menu-bar app needs a desktop, and CI runners have none | **Not a target**, deliberately: Tauri emits no tray click event on Linux, so the panel could not open — see [`docs/tray.md`](docs/tray.md) |
 
-Concretely: on Windows and on Linux **you are the first to run it**. A defect there
+Concretely: on Windows and on Linux **you are the first to use it**. A defect there
 is expected rather than surprising, and [an issue](../../issues) saying what you saw
 is the most useful thing you can send. If you use Windows,
 [`CONTRIBUTING.md`](CONTRIBUTING.md#running-it-on-windows) lists the six things one

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable structural changes to seedeep are recorded here, newest first.
 
 ## Unreleased
 
+## 0.24.0 (2026-08-14)
+
 **No release publishes until every executable in it has actually been STARTED.** All five server
 binaries are cross-compiled on one `ubuntu-latest` runner, so the Windows binary and both Linux ARM
 binaries had never been executed on any machine, ever — the shape of the v0.6.0 failure, five green

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "seedeep",
-  "version": "0.23.1",
+  "version": "0.24.0",
   "private": true,
   "type": "module",
   "description": "Live context & subagent visualizer for Claude Code",


### PR DESCRIPTION
Version bump and the changelog cut **in the same diff**, which is the rule this repo broke three releases in a row (0.18.0, 0.19.0, 0.20.0): `## Unreleased` becomes `## 0.24.0 (2026-08-14)` with a fresh empty one above it. By 2026-08-12 `Unreleased` held 16 entries that had already shipped, and a reader could not tell which of them was in their build — the one job a changelog has.

## What is in it

- **The release gate**: every server binary is started on a runner of its own OS before anything publishes (#22).
- **`API calls` / `tool calls`**, one name per number, with a hover that says what the count leaves out (#23).
- **The empty Home** opens with the reason it is empty, and the page counts in the singular (#26).

## The README correction this forced

The platform table said the Windows and Linux server binaries had **never been run**. As of this release that is false — the gate runs them. It now reads `Started on every release, never used`, and the paragraph below says *"you are the first to **use** it"*.

The distinction is the point, not pedantry: a binary that starts proves the download is not dead, and says nothing about whether the thing is pleasant or correct in front of a person on that machine. The tray's Windows cell keeps `Never run`, with its reason — a menu-bar app needs a desktop, and CI runners have none.

Suite 1669 pass / 0 fail.