### PR TITLE
Document Linux arm64 as used, add glibc requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,9 @@ seedeep                   # watch, serve, and open the browser
 [the latest release](../../releases/latest) — macOS arm64/x64, Linux x64/arm64,
 Windows x64 — and run it. **That file is not an installer, it is the program**: it
 carries its own runtime and the whole browser GUI inside, installs nothing, and
-leaves behind only `~/.seedeep/`.
+leaves behind only `~/.seedeep/`. The Linux builds require **glibc** (Debian,
+Ubuntu, Fedora and derivatives) — Alpine and other musl-based distributions are
+not supported.
 
 The **menu-bar tray** is a separate, optional download from the same release: a
 universal `.dmg` for macOS, a `-setup.exe` for Windows. It is a pure client — the
@@ -182,7 +184,7 @@ a person on that machine.
 
 | | macOS | Windows | Linux |
 | -- | -- | -- | -- |
-| **Server** — download or npm | Used daily; every claim above was checked here | **Started on every release, never used.** CI runs the `.exe` on a Windows runner and checks it serves the GUI; nobody has worked in it | **Started on every release, never used.** Same check on x64 and arm64 runners, and the suite runs on Linux on every push |
+| **Server** — download or npm | Used daily; every claim above was checked here | **Started on every release, never used.** CI runs the `.exe` on a Windows runner and checks it serves the GUI; nobody has worked in it | **arm64: used on Ubuntu 24 in a VM** (2026-08-14) — GUI opened against a real Claude Code session, lifecycle and `install-command` confirmed. **x64: started on every release, never used** — version-checked in CI and on Docker, never run in front of a person. Both builds require glibc; Alpine/musl is not supported. |
 | **Tray** | Used daily on a real menu bar | **Never run.** The installer is built on every tag and nothing has opened it — a menu-bar app needs a desktop, and CI runners have none | **Not a target**, deliberately: Tauri emits no tray click event on Linux, so the panel could not open — see [`docs/tray.md`](docs/tray.md) |
 
 Concretely: on Windows and on Linux **you are the first to use it**. A defect there

--- a/docs/install.md
+++ b/docs/install.md
@@ -4,10 +4,11 @@
 a page in your browser — one process, no daemon, stopped with Ctrl-C. Two channels
 ship the same executable; a third runs it from a clone.
 
-> **Neither the Windows nor the Linux build has ever been run on its own system** —
-> they are built by CI and downloaded by you first. [Which platforms have actually
-> been run](../README.md#which-platforms-have-actually-been-run) says exactly what
-> that covers.
+> **The Windows build has never been run on its own system** — it is built by CI
+> and downloaded by you first. The Linux arm64 build was used on Ubuntu 24 in a VM
+> (2026-08-14); the x64 build has been started but never used in front of a person.
+> [Which platforms have actually been run](../README.md#which-platforms-have-actually-been-run)
+> says exactly what that covers.
 
 ## From npm — Node or Bun
 


### PR DESCRIPTION
## Summary

- README platform table: Linux arm64 marked as used on Ubuntu 24 in a VM (2026-08-14) — GUI opened against a real Claude Code session, lifecycle and `install-command` confirmed; x64 remains started-never-used; both note glibc/musl requirement
- README install section: glibc note added next to the Linux binary list
- `docs/install.md`: opening callout updated — Windows still never run, Linux arm64 now used, x64 started but not used in front of a person

## Test plan

- [ ] README platform table reflects the actual state of Linux testing
- [ ] glibc/musl note present in README install section
- [ ] `docs/install.md` callout no longer says "neither Linux nor Windows has ever been run"

🤖 Generated with [Claude Code](https://claude.com/claude-code)