### PR TITLE
Build and ship the server and tray for Windows on arm64

### DIFF
--- a/.github/scripts/smoke-server.sh
+++ b/.github/scripts/smoke-server.sh
@@ -2,7 +2,7 @@
 #
 # Does a built server executable actually RUN — on a machine that did not build it?
 #
-# All five executables are cross-compiled from one `ubuntu-latest` runner, so until this ran, the
+# All six executables are cross-compiled from one `ubuntu-latest` runner, so until this ran, the
 # Windows binary and both Linux ARM binaries had never been EXECUTED anywhere, ever. That is the
 # 0.6.0 shape: green artefacts, dead at startup on every machine but the builder's.
 #
@@ -25,7 +25,7 @@
 # run on a laptop and not only on a throwaway runner.
 #
 # Bash on every platform, never PowerShell: v0.6.0 uploaded no Windows installer because `"$TAG"`
-# in PowerShell is an unassigned variable that expands to nothing. One shell, one script, five
+# in PowerShell is an unassigned variable that expands to nothing. One shell, one script, six
 # platforms.
 
 set -euo pipefail

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,9 @@ jobs:
           under the tray.
 
           **Without a JS runtime**, download the file for your platform (`seedeep-server_…`) — it
-          carries its own runtime and installs nothing. It is a command-line program run from a
+          carries its own runtime and installs nothing. On Windows there are two: `_windows-arm64.exe`
+          on a Snapdragon or any other Windows-on-ARM machine, `_windows-x64.exe` on everything else.
+          It is a command-line program run from a
           terminal, and a downloaded file never arrives executable, so it takes one `chmod` first:
 
           ```sh
@@ -86,17 +88,18 @@ jobs:
           login password. That button is offered for about an hour after the refused attempt, so
           launch the app first and go to Settings second.
 
-          **Windows** — run the `-setup.exe`. SmartScreen shows *"Windows protected your PC"*:
-          choose **More info -> Run anyway**. It installs for the current user, so it never asks for
-          Administrator rights.
+          **Windows** — run the `-setup.exe` for your processor: `_arm64-` on a Snapdragon or any
+          other Windows-on-ARM machine, `_x64-` on everything else. SmartScreen shows *"Windows
+          protected your PC"*: choose **More info -> Run anyway**. It installs for the current user,
+          so it never asks for Administrator rights.
 
           The README has the same steps with more context.'
 
   tray:
     needs: draft
     strategy:
-      # Both platforms are reported even when one fails: a release with half its installers is a
-      # thing to know about in full, not one failure at a time.
+      # Every leg is reported even when one fails: a release with half its installers is a thing to
+      # know about in full, not one failure at a time.
       fail-fast: false
       matrix:
         include:
@@ -109,6 +112,16 @@ jobs:
           # NSIS, not MSI: its default `currentUser` install mode needs no Administrator rights, and
           # a UAC prompt for an unknown publisher is exactly where an unsigned installer loses people.
           - runner: windows-latest
+            targets: ''
+            args: --bundles nsis
+          # NATIVE, not cross-compiled from the x64 runner above - which does carry the ARM64 MSVC
+          # tools, so it could have been. Tauri documents installing those tools on the machine that
+          # builds, never a host-to-arm64 cross-build, and this leg differs from the one above by
+          # its runner alone: no `--target` to pass, nothing to get subtly right. `windows-11-arm`
+          # is GA and free on public repositories (2025-08-07) and its image already carries VS
+          # 2022, Rust and NSIS. What it produces is `…_arm64-setup.exe`: the installer itself is
+          # still x86 under emulation, by Tauri's design, and the app inside it is native arm64.
+          - runner: windows-11-arm
             targets: ''
             args: --bundles nsis
     runs-on: ${{ matrix.runner }}
@@ -194,7 +207,8 @@ jobs:
 
       # Independent of the release, so the artifacts exist whether or not this run published
       # anything - which is what a manual run is for. Named per runner: artifact names are unique
-      # within a run, and both matrix legs reach this step.
+      # within a run, and every matrix leg reaches this step - the two Windows ones included, which
+      # is why the runner and not the OS is what names them.
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: tray-${{ matrix.runner }}
@@ -229,7 +243,7 @@ jobs:
           REPO: ${{ github.repository }}
         run: gh release upload "$TAG" dist/* --clobber --repo "$REPO"
 
-  # The server's executables - one per platform, all five cross-compiled from ONE runner, which is
+  # The server's executables - one per platform, all six cross-compiled from ONE runner, which is
   # what `bun build --compile --target=…` buys and the tray cannot have (its matrix exists because
   # Tauri needs each platform's own SDK).
   server:
@@ -257,7 +271,7 @@ jobs:
           path: dist/*
           if-no-files-found: error
 
-      # The five executables, attested for the reason the tray's step spells out — and here it also
+      # The six executables, attested for the reason the tray's step spells out — and here it also
       # covers the npm channel, which carries these same files: npm attaches its own provenance to
       # the packages, this attests the binaries inside them.
       - if: github.ref_type == 'tag'
@@ -274,7 +288,7 @@ jobs:
           REPO: ${{ github.repository }}
         run: gh release upload "$TAG" dist/* --clobber --repo "$REPO"
 
-  # Does what was built actually RUN? All five executables are cross-compiled on the ONE
+  # Does what was built actually RUN? All six executables are cross-compiled on the ONE
   # `ubuntu-latest` runner above, so until this job existed the Windows binary and both Linux ARM
   # binaries had never been EXECUTED on any machine, ever. That is the 0.6.0 failure exactly - five
   # green artifacts, dead at startup everywhere but where they were built - and it was invisible
@@ -292,7 +306,7 @@ jobs:
     needs: server
     strategy:
       # Every platform reports. Which ones start is the entire question, and stopping at the first
-      # failure would answer it for one of five.
+      # failure would answer it for one of six.
       fail-fast: false
       matrix:
         include:
@@ -308,6 +322,12 @@ jobs:
             asset: macos-x64
           - runner: windows-latest
             asset: windows-x64.exe
+          # The machine this job exists for: a Snapdragon laptop runs the arm64 Node from winget,
+          # npm resolves the arm64 package, and nothing else in this workflow ever executes that
+          # binary. `windows-11-arm` is GA and free on public repositories (2025-08-07); it is the
+          # only leg here that would start costing money if this repository went private.
+          - runner: windows-11-arm
+            asset: windows-arm64.exe
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -346,13 +366,13 @@ jobs:
 
       # `shell: bash` on every platform, Windows included: v0.6.0 uploaded no Windows installer
       # because `"$TAG"` in PowerShell is an unassigned variable that expands to nothing. One
-      # script, five platforms, no per-OS dialect to get wrong. What it asserts is in its header.
+      # script, six platforms, no per-OS dialect to get wrong. What it asserts is in its header.
       - shell: bash
         env:
           ASSET: ${{ matrix.asset }}
         run: .github/scripts/smoke-server.sh "bin/seedeep-server_${VERSION}_${ASSET}" "$VERSION"
 
-  # The npm channel: the same five executables, each wrapped in a package npm resolves by `os`/`cpu`,
+  # The npm channel: the same six executables, each wrapped in a package npm resolves by `os`/`cpu`,
   # under one `seedeep` wrapper whose postinstall puts the binary where `bin` already points. Node is
   # needed to INSTALL, never to run. It exists because a binary that arrives through a package
   # manager is not quarantined - macOS sets that flag in the browser that downloads, not in npm - so
@@ -370,9 +390,14 @@ jobs:
     # only be configured on a package that already exists. So every tag builds these packages and
     # publishes none of them until the repository variable `SEEDEEP_NPM_PUBLISH` is set to `true`,
     # which is the moment the account, its 2FA and the trusted publisher are in place.
+    #
+    # That rule applies again to EVERY platform package added after the first release, one at a
+    # time: `seedeep-windows-arm64` is a name nobody owns until it is published by hand, and this
+    # job is not a dependency of `publish` - so a tag that finds it missing still produces a green
+    # release page beside a channel that did not ship.
     if: github.ref_type == 'tag' && vars.SEEDEEP_NPM_PUBLISH == 'true'
     runs-on: ubuntu-latest
-    # Named in the OIDC token, and the six trusted publishers on npmjs.com are configured to demand
+    # Named in the OIDC token, and the seven trusted publishers on npmjs.com are configured to demand
     # exactly this environment - so the two names are one setting written in two places, and a
     # rename here rejects every publish until the registry side is changed to match. It carries no
     # protection rule today: it is a claim to match, not an approval gate. Adding a required
@@ -415,11 +440,26 @@ jobs:
 
       # Platform packages FIRST, and the wrapper last: the wrapper names them at an exact version,
       # and a wrapper on the registry ahead of its binaries is an install that ends in a command
-      # which cannot run.
+      # which cannot run. The glob expands before the literal, so that order is the shell's own and
+      # not a second list to keep in step.
+      #
+      # A version already on the registry is SKIPPED, not retried - which is what makes this step
+      # re-runnable, the property `--clobber` gives the release half of the same tag.
+      # npm is immutable ("once published, a package cannot change"), so a run that died partway -
+      # a dropped connection on a 40 MB tarball, or a package added since whose trusted publisher
+      # nobody configured yet - used to leave the re-run failing on the FIRST package instead of
+      # finishing the remaining ones, with the wrapper still naming binaries at a version nobody
+      # ever published. `npm view` exits 0 only when that exact version is already there.
       - run: |
           set -euo pipefail
-          for dir in dist/npm/seedeep-*; do npm publish "$dir"; done
-          npm publish dist/npm/seedeep
+          for dir in dist/npm/seedeep-* dist/npm/seedeep; do
+            spec=$(node -p "const p = require('./$dir/package.json'); p.name + '@' + p.version")
+            if npm view "$spec" version >/dev/null 2>&1; then
+              echo "$spec is already on the registry"
+              continue
+            fi
+            npm publish "$dir"
+          done
 
   # Flips the draft to published, and is the only step in this repo that puts a binary in front of
   # a stranger. It is a job of its own for two reasons: `needs` will not start it unless EVERY

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -213,9 +213,9 @@ not be accepted.
 
 ## Running it on Windows
 
-The single most useful contribution nobody here can make: **no Windows machine exists in this
-project**, so the tray's installer is built on every tag and has never been opened, and the server's
-`.exe` has never been launched. If you have Windows, one session settles six claims the code makes
+The single most useful contribution nobody here can make: **no Windows machine is used in this
+project**, so the tray's installers are built on every tag and have never been opened, and the
+server's `.exe` has been started by CI and never used. If you have Windows, one session settles six claims the code makes
 and the docs currently only reason about. Report what you see in an issue — a "it all worked"
 is as valuable as a defect, because today neither is known.
 
@@ -237,6 +237,12 @@ is as valuable as a defect, because today neither is known.
    has been seen on a desktop whose taskbar can sit on any edge.
 6. **Trust on first use and the connection screen**, against a `seedeep` server reached over HTTPS
    on another machine, including the fingerprint comparison.
+
+All six apply on **Windows on arm64** as well — a Snapdragon laptop, or a Windows 11 ARM guest on an
+Apple Silicon Mac. That machine gets its own server binary and its own tray installer, built by the
+same tag on a native arm64 runner; the installer NSIS produces is x86 under emulation by Tauri's
+design, and the app inside it is native. Say which of the two you were on: an answer from one says
+nothing certain about the other.
 
 Where the answers go: `docs/tray.md` holds the macOS measurements in a table under *What is signed,
 and what that costs*, and Windows belongs in the same shape — what was observed, and on which

--- a/README.md
+++ b/README.md
@@ -152,14 +152,14 @@ seedeep                   # watch, serve, and open the browser
 
 **With neither**, take the file for your platform from
 [the latest release](../../releases/latest) — macOS arm64/x64, Linux x64/arm64,
-Windows x64 — and run it. **That file is not an installer, it is the program**: it
+Windows x64/arm64 — and run it. **That file is not an installer, it is the program**: it
 carries its own runtime and the whole browser GUI inside, installs nothing, and
 leaves behind only `~/.seedeep/`. The Linux builds require **glibc** (Debian,
 Ubuntu, Fedora and derivatives) — Alpine and other musl-based distributions are
 not supported.
 
 The **menu-bar tray** is a separate, optional download from the same release: a
-universal `.dmg` for macOS, a `-setup.exe` for Windows. It is a pure client — the
+universal `.dmg` for macOS, a `-setup.exe` per architecture for Windows. It is a pure client — the
 server is what has to run where Claude Code runs. **Both are unsigned**, so macOS and
 Windows each show a first-launch warning.
 
@@ -171,9 +171,10 @@ the GUI, stops the server, or reports what the current session cost.
 ## Which platforms have actually been run
 
 Everything above was checked by hand on **macOS**, on the machine `seedeep` is
-developed on. **It has never been installed on a Windows or a Linux box** — there is
-neither here. Building for three systems is not the same as having used three, and
-this section is that difference written down rather than left for you to find.
+developed on. **Linux has been used once**, in a VM, on arm64 — the table says what
+that covered. **Windows has not been used at all.** Building for three systems is not
+the same as having used three, and this section is that difference written down
+rather than left for you to find.
 
 Since 0.24.0 there is a middle ground worth naming: **started is not used**. Every
 release now runs each server binary on a runner of its own operating system before
@@ -184,10 +185,10 @@ a person on that machine.
 
 | | macOS | Windows | Linux |
 | -- | -- | -- | -- |
-| **Server** — download or npm | Used daily; every claim above was checked here | **Started on every release, never used.** CI runs the `.exe` on a Windows runner and checks it serves the GUI; nobody has worked in it | **arm64: used on Ubuntu 24 in a VM** (2026-08-14) — GUI opened against a real Claude Code session, lifecycle and `install-command` confirmed. **x64: started on every release, never used** — version-checked in CI and on Docker, never run in front of a person. Both builds require glibc; Alpine/musl is not supported. |
-| **Tray** | Used daily on a real menu bar | **Never run.** The installer is built on every tag and nothing has opened it — a menu-bar app needs a desktop, and CI runners have none | **Not a target**, deliberately: Tauri emits no tray click event on Linux, so the panel could not open — see [`docs/tray.md`](docs/tray.md) |
+| **Server** — download or npm | Used daily; every claim above was checked here | **x64 and arm64: started on every release, never used.** CI runs each `.exe` on a Windows runner of its own architecture and checks it serves the GUI; nobody has worked in either | **arm64: used on Ubuntu 24 in a VM** (2026-08-14) — GUI opened against a real Claude Code session, lifecycle and `install-command` confirmed. **x64: started on every release, never used** — version-checked in CI and on Docker, never run in front of a person. Both builds require glibc; Alpine/musl is not supported. |
+| **Tray** | Used daily on a real menu bar | **Never run.** Both installers, x64 and arm64, are built on every tag and nothing has opened either: a menu-bar app needs a desktop, and CI runners have none | **Not a target**, deliberately: Tauri emits no tray click event on Linux, so the panel could not open — see [`docs/tray.md`](docs/tray.md) |
 
-Concretely: on Windows and on Linux **you are the first to use it**. A defect there
+Concretely: on Windows **you are the first to use it**, and on Linux x64 as well. A defect there
 is expected rather than surprising, and [an issue](../../issues) saying what you saw
 is the most useful thing you can send. If you use Windows,
 [`CONTRIBUTING.md`](CONTRIBUTING.md#running-it-on-windows) lists the six things one

--- a/apps/server/npm/install.cjs
+++ b/apps/server/npm/install.cjs
@@ -84,9 +84,11 @@ function main() {
   const supported = Object.keys(manifest.optionalDependencies || {});
   const name = platformPackage(process.platform, process.arch);
 
-  // The wrapper's own `os`/`cpu` already refuse most platforms, with npm's own EBADPLATFORM. What
-  // reaches here is the combination those two lists allow as a cross product but seedeep does not
-  // build — Windows on arm64, for which Bun documents no target. Failing is the honest answer: the
+  // The wrapper's own `os`/`cpu` already refuse most platforms, with npm's own EBADPLATFORM, and
+  // every combination those two independent lists admit as a cross product is now a package that
+  // exists — so nothing reaches here today. It stays because the lists are independent: adding a
+  // platform to one of them alone reopens the hole, which is precisely what left Windows on arm64
+  // installable and unrunnable until Bun had a target for it. Failing is the honest answer — the
   // install cannot produce a runnable `seedeep`, and saying so now beats a command that is not one.
   if (!name || !supported.includes(name)) {
     console.error(`seedeep: no build for ${process.platform} ${process.arch}.`);

--- a/apps/server/scripts/build-npm.ts
+++ b/apps/server/scripts/build-npm.ts
@@ -34,7 +34,7 @@ async function main(): Promise<void> {
   const { wrapper, platforms } = npmManifests(VERSION);
 
   // Checked before anything is written: a package published without its binary is the one failure
-  // this whole channel cannot recover from, and `dist/` holding four of five is what a `--host`
+  // this whole channel cannot recover from, and `dist/` holding five of six is what a `--host`
   // build leaves behind.
   for (const target of TARGETS) {
     const binary = join(DIST, `seedeep-server_${VERSION}_${target.asset}`);

--- a/apps/server/scripts/npm-manifests.ts
+++ b/apps/server/scripts/npm-manifests.ts
@@ -1,11 +1,11 @@
 /**
  * The manifests the npm channel publishes, as data — separated from the packager that writes them
- * so they can be asserted without compiling five executables first.
+ * so they can be asserted without compiling six executables first.
  *
  * The shape is the one Claude Code itself ships with (verified on the registry, 2.1.220): a wrapper
  * whose `bin` points at a file inside itself, and one `optionalDependency` per platform carrying
  * the real executable. npm resolves those against each package's `os`/`cpu`, so a machine downloads
- * one binary, not five.
+ * one binary, not six.
  */
 
 import { TARGETS, type Target } from './targets.ts';
@@ -30,7 +30,8 @@ export const BIN_PATH = 'bin/seedeep.exe';
 const REPO = 'https://github.com/duqaXxX/seedeep';
 
 /**
- * Fields identical on all six manifests. `author` deliberately carries a name and NO email: the
+ * Fields identical on all seven manifests — the six platform packages and the wrapper. `author`
+ * deliberately carries a name and NO email: the
  * registry takes the maintainer address from the npm ACCOUNT, and a personal address in a
  * versioned file is a leak the pre-commit hook is right to refuse.
  */
@@ -109,8 +110,9 @@ export function npmManifests(version: string): {
     // publishes both. A caret here would let npm pair a wrapper with an older executable.
     optionalDependencies: Object.fromEntries(platforms.map((p) => [p.manifest.name, version])),
     // npm refuses the install outright on anything outside these — the error names the platform,
-    // which is the point. They are a cross product, so they admit one combination seedeep does not
-    // build (Windows on arm64); the postinstall is what refuses that one.
+    // which is the point. npm reads them as a cross product, so a platform present in one list and
+    // absent from the other is an install that begins and cannot finish: that was Windows on arm64
+    // until Bun had a target for it. Every combination is a package today, and a test asserts it.
     os: [...new Set(TARGETS.map((t) => t.os))],
     cpu: [...new Set(TARGETS.map((t) => t.cpu))],
     engines: { node: '>=18' },

--- a/apps/server/scripts/targets.ts
+++ b/apps/server/scripts/targets.ts
@@ -23,7 +23,6 @@ export interface Target {
   label: string;
 }
 
-// Windows arm64 is absent deliberately: Bun documents no `bun-windows-arm64` target.
 export const TARGETS: Target[] = [
   {
     bun: 'bun-darwin-arm64',
@@ -64,6 +63,14 @@ export const TARGETS: Target[] = [
     os: 'win32',
     cpu: 'x64',
     label: 'Windows on x86-64',
+  },
+  {
+    bun: 'bun-windows-arm64',
+    asset: 'windows-arm64.exe',
+    npm: 'windows-arm64',
+    os: 'win32',
+    cpu: 'arm64',
+    label: 'Windows on arm64',
   },
 ];
 

--- a/apps/server/tests/npm-package.test.ts
+++ b/apps/server/tests/npm-package.test.ts
@@ -42,15 +42,26 @@ test('a platform package is resolvable only on its own platform', () => {
   }
 });
 
-test('the one platform the os×cpu cross product admits is refused by the postinstall', () => {
-  // `os` and `cpu` are two independent lists, so npm reads them as every combination of the two —
-  // and that admits Windows on arm64, which Bun has no target for. npm lets such an install begin;
-  // what stops it is the postinstall finding no package of that name to install, and the name it
-  // computes has to be the one that is genuinely absent for the guard to fire.
-  const orphan = install.platformPackage('win32', 'arm64');
-  assert.equal(orphan, 'seedeep-windows-arm64');
-  assert.ok(!(orphan in (wrapper.optionalDependencies as Record<string, string>)));
-  assert.ok((wrapper.os as string[]).includes('win32') && (wrapper.cpu as string[]).includes('arm64'));
+test('every platform the os×cpu cross product admits has a package behind it', () => {
+  // `os` and `cpu` are two independent lists and npm reads them as every combination of the two, so
+  // a pair present in one and unbuilt in the other is an install that BEGINS and cannot finish.
+  // That pair was Windows on arm64: a Snapdragon laptop with the native Node from winget hit
+  // `no build for win32 arm64` on the very command the README puts first, and nothing in the suite
+  // could see it — the old test asserted the hole instead, as a thing that was meant to be there.
+  const deps = wrapper.optionalDependencies as Record<string, string>;
+  for (const os of wrapper.os as string[]) {
+    for (const cpu of wrapper.cpu as string[]) {
+      const name = install.platformPackage(os, cpu);
+      assert.ok(name && name in deps, `npm admits ${os} ${cpu} and no package carries it`);
+    }
+  }
+});
+
+test('the postinstall refuses a platform seedeep names no package for', () => {
+  // The guard in `install.cjs` has no reachable case left, and one nothing exercises is one that
+  // rots. FreeBSD never gets that far — npm's own `os` refuses it first — so what this pins is the
+  // postinstall's answer on a platform it does not know, which is the shape of the next hole.
+  assert.equal(install.platformPackage('freebsd', 'x64'), null);
 });
 
 test('the wrapper pins its binaries to its own exact version', () => {

--- a/apps/tray/tests/release-workflow.test.ts
+++ b/apps/tray/tests/release-workflow.test.ts
@@ -55,16 +55,22 @@ test('publishing to npm needs a tag AND a switch', () => {
   const npm = job('npm');
   assert.match(npm, /if: github\.ref_type == 'tag' && vars\.SEEDEEP_NPM_PUBLISH == 'true'/);
   // The wrapper names its binaries at an exact version: on the registry ahead of them, it is an
-  // install that ends in a command which cannot run.
-  const platforms = npm.indexOf('npm publish "$dir"');
-  const wrapper = npm.indexOf('npm publish dist/npm/seedeep\n');
-  assert.ok(platforms !== -1 && wrapper > platforms, 'the wrapper is published after its binaries');
+  // install that ends in a command which cannot run. One `for` list holds the order now — the glob
+  // expands before the literal — so the list itself is what has to be right.
+  assert.equal(
+    npm.match(/for dir in (.+); do/)?.[1],
+    'dist/npm/seedeep-* dist/npm/seedeep',
+    'the wrapper is published after its binaries',
+  );
+  // Re-runnable: a version already there is skipped rather than retried, since npm refuses to
+  // publish over one and a half-finished run would otherwise be unrecoverable.
+  assert.match(npm, /npm view "\$spec" version/);
   // OIDC is the credential. A token in this workflow would mean a long-lived secret in the repo.
   assert.match(npm, /id-token: write/);
   assert.doesNotMatch(npm, /NODE_AUTH_TOKEN|NPM_TOKEN/);
-  // The environment is part of the OIDC claim, and npmjs.com's six trusted publishers are set to
+  // The environment is part of the OIDC claim, and npmjs.com's seven trusted publishers are set to
   // require this exact name. Renaming it here is not a local change: it rejects every publish until
-  // the registry side is edited to match, six packages at a time.
+  // the registry side is edited to match, seven packages at a time.
   assert.match(npm, /\n {4}environment: npm-publish\n/);
 });
 
@@ -112,7 +118,7 @@ test('the release is published only after both halves built', () => {
   assert.match(publish, /gh release edit .*--draft=false/);
 });
 
-// The gate that 0.6.0 was missing: five binaries cross-compiled on one runner, none of them ever
+// The gate that 0.6.0 was missing: six binaries cross-compiled on one runner, none of them ever
 // executed. Both exits from the pipeline wait for it — the release page and the registry — and npm
 // is the one that cannot be taken back.
 test('nothing reaches a stranger until the binaries have been RUN', () => {
@@ -127,6 +133,29 @@ test('the smoke matrix covers every target the server is built for', () => {
   const smoke = job('smoke');
   const tested = [...smoke.matchAll(/asset: (\S+)/g)].map((m) => m[1]).sort();
   assert.deepEqual(tested, TARGETS.map((t) => t.asset).sort());
+});
+
+/**
+ * Which runner builds the tray for which Windows architecture. The tray matrix names runners and
+ * never architectures, so this is the only place the two vocabularies meet — the mapping the test
+ * below needs, and the thing to extend the day a third Windows architecture exists.
+ */
+const WINDOWS_TRAY_RUNNER: Record<string, string> = {
+  x64: 'windows-latest',
+  arm64: 'windows-11-arm',
+};
+
+// The tray follows the server onto a platform, or the machine gets a server it can run beside an
+// installer it cannot: a Snapdragon laptop is exactly that case. Nothing else in the repo states
+// that rule, and the tray matrix cannot be derived from `targets.ts` the way the smoke matrix
+// above is - so it is asserted here, and adding a Windows target without its tray leg fails.
+test('every Windows platform the server ships has a tray installer of its own', () => {
+  const legs = [...job('tray').matchAll(/- runner: (\S+)/g)].map((m) => m[1]);
+  for (const target of TARGETS.filter((t) => t.os === 'win32')) {
+    const runner = WINDOWS_TRAY_RUNNER[target.cpu];
+    assert.ok(runner, `the server ships Windows ${target.cpu} and no runner here builds the tray for it`);
+    assert.ok(legs.includes(runner), `no tray leg runs on ${runner}, so Windows ${target.cpu} gets no installer`);
+  }
 });
 
 // One shell on five platforms. v0.6.0 uploaded no Windows installer because `"$TAG"` in PowerShell

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,31 @@ All notable structural changes to seedeep are recorded here, newest first.
 
 ## Unreleased
 
+**A publish to npm that dies halfway can now be re-run.** The step published seven packages in a
+loop under `set -e`, and npm is immutable — *"once published, a package cannot change"* — so the
+re-run failed on the FIRST package instead of finishing the rest, leaving the wrapper naming
+binaries at a version nobody had published while the release page stayed green (the `npm` job is
+not a dependency of `publish`). A version already on the registry is skipped now rather than
+retried, which is the property `--clobber` gives the release half of the same tag. It takes a
+dropped connection on a 40 MB tarball to need it, or a package added since whose trusted publisher
+is not configured yet — the arm64 one was exactly that.
+
+**Windows on arm64 was an install that could begin and never finish.** `npm i -g seedeep` on a
+Snapdragon laptop — where the Node.js winget installs is the native arm64 build — died with
+`seedeep: no build for win32 arm64`, on the command the README puts first, with nothing to say the
+cause was the interpreter and not the package. The wrapper's `os` and `cpu` are two independent
+lists and npm reads them as a cross product, so `win32` × `arm64` was a pair npm accepted and no
+package carried. Bun documents a `bun-windows-arm64` target now (verified: compiled from a macOS
+host it produces a `PE32+ … Aarch64` executable), so the sixth binary is cross-compiled beside the
+other five on the same runner and `seedeep-windows-arm64` joins the npm channel. The smoke job
+gains a `windows-11-arm` leg, since nothing else in the workflow would ever EXECUTE that file. The
+tray gets an arm64 NSIS installer of its own, built natively on the same runner rather than
+cross-compiled from the x64 one: Tauri documents adding the ARM64 build tools to the machine that
+builds, never a host-to-arm64 cross-build, and the native leg differs by its runner alone. The test
+that covered this ground asserted the HOLE — that `seedeep-windows-arm64` was absent — and so
+passed happily while the channel was broken; it now walks the whole `os` × `cpu` cross product and
+demands a package behind every pair.
+
 ## 0.24.0 (2026-08-14)
 
 **No release publishes until every executable in it has actually been STARTED.** All five server

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -68,7 +68,7 @@ and two of them built from the same tag are compatible by construction — no
 compatibility matrix. It is not a convention anybody has to remember: the root
 `package.json` holds the only version number, and `apps/tray/src-tauri/tauri.conf.json`
 names that file as its `version` instead of carrying one of its own. Pushing a `v*` tag
-is what turns that number into downloads: the tray's two installers and the server's five
+is what turns that number into downloads: the tray's three installers and the server's six
 executables, out of the same workflow and the same commit — see
 [Shipping the server](#shipping-the-server).
 
@@ -105,7 +105,7 @@ reach it as imports (`assets.ts`), not as a path it resolves.
 ### Shipping the server
 
 The server is a **standalone executable, one per platform**, with the Bun runtime inside it —
-`bun run build:server:all` (`apps/server/scripts/build-binaries.ts`) writes all five into `dist/`,
+`bun run build:server:all` (`apps/server/scripts/build-binaries.ts`) writes all six into `dist/`,
 cross-compiled from whichever machine runs it, which is why CI builds them on one runner where the
 tray needs a matrix. Nothing has to be installed to run one: that is CLAUDE.md's distribution
 invariant, and it is why the GUI is embedded rather than served from a folder next to the binary.
@@ -133,7 +133,10 @@ Three things about that script are decisions, not detail:
 - **A binary may not contain the path of the machine that built it.** `assertNoBuildPath` fails the
   build on any occurrence, because that is the one class of defect a build-machine test cannot see.
   Measured: two occurrences in the broken binary, zero in the repaired one.
-- **No Windows arm64.** Bun documents no such `--compile` target.
+- **Windows arm64 is built like the rest.** Bun documented no such `--compile` target when this
+  list was written; `bun-windows-arm64` exists now, so the machine that runs the arm64 Node from
+  winget — a Snapdragon laptop, a Windows 11 ARM guest — is no longer an install that begins and
+  cannot finish.
 
 The Linux binaries are dynamically linked against glibc, so a musl distribution (Alpine) is not a
 target either.
@@ -143,7 +146,7 @@ the Windows binary and both Linux ARM binaries are never executed by the build t
 which is exactly how v0.6.0 shipped five artifacts that died at startup on every machine but the
 builder's, with a green workflow to show for it. `release.yml`'s `smoke` job downloads each asset
 onto a runner of its own OS (`ubuntu-latest`, `ubuntu-24.04-arm`, `macos-latest`, `macos-15-intel`,
-`windows-latest`) and runs `.github/scripts/smoke-server.sh`, which asserts that `--version` prints
+`windows-latest`, `windows-11-arm`) and runs `.github/scripts/smoke-server.sh`, which asserts that `--version` prints
 the version being released, that `GET /api/config` answers, and that `/`, `/lib/app.js` and
 `/css/chrome.css` answer too — the last three because the measured failure mode of a first compile
 was an API that answered while every static path 404'd. Both exits from the pipeline wait for it:
@@ -154,7 +157,7 @@ the whole matrix is provable without cutting a release.
 
 #### The npm channel
 
-The same five executables also ship as npm packages, which is what `npm i -g seedeep` installs.
+The same six executables also ship as npm packages, which is what `npm i -g seedeep` installs.
 **Node is needed to install them, never to run one**: the package carries the compiled binary, and
 `bun run build:npm` (`apps/server/scripts/build-npm.ts`) only arranges files — it never compiles, so
 `bun run build:server:all` has to have run first, and in that order, since the compiler wipes
@@ -163,7 +166,7 @@ The same five executables also ship as npm packages, which is what `npm i -g see
 It is the shape Claude Code itself ships with (verified on the registry, 2.1.220): a wrapper package
 whose `bin` points at a file inside itself, plus one `optionalDependency` per platform carrying the
 real executable. npm resolves those against each package's `os`/`cpu`, so a machine downloads one
-binary rather than five, and the wrapper's postinstall (`apps/server/npm/install.cjs`) puts that
+binary rather than six, and the wrapper's postinstall (`apps/server/npm/install.cjs`) puts that
 binary over the placeholder the `bin` field already names. Nothing is fetched by the script itself,
 and no Node process survives the install — `seedeep` on PATH *is* the server.
 
@@ -179,9 +182,9 @@ Four decisions hold it up:
   every Windows install hand the native executable to an interpreter.
 - **An unsupported platform is refused by npm itself.** The wrapper declares the `os` and `cpu` it
   was built for, and npm reads them as a cross product: anything outside fails with `EBADPLATFORM`,
-  naming both what was wanted and what the machine is. The cross product admits one combination
-  seedeep does not build — Windows on arm64, for which Bun has no target — and the postinstall is
-  what refuses that one, by name.
+  naming both what was wanted and what the machine is. Every combination the cross product admits
+  is a package that exists, which a test asserts; the postinstall still refuses a pair it finds no
+  package for, because the two lists are independent and adding to one alone reopens the hole.
 - **The wrapper pins its binaries to its own exact version.** One tag publishes both halves; a range
   would let npm pair a wrapper with an older executable.
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -762,7 +762,8 @@ because a client that links no code cannot import one.
 *The same session as everything above, from the menu bar — the one surface that is a
 recording rather than a crop, because the tray is a native app and not a page.*
 
-Packaged by CI from a tag into a universal DMG and a Windows `-setup.exe`,
+Packaged by CI from a tag into a universal DMG and a Windows `-setup.exe` per
+architecture (x64 and arm64),
 **unsigned**. **Verified on macOS only** — see [Which platforms have actually been
 run](../README.md#which-platforms-have-actually-been-run), because this project
 does not call a thing measured when it has not been. Full rules:

--- a/docs/install.md
+++ b/docs/install.md
@@ -4,8 +4,9 @@
 a page in your browser — one process, no daemon, stopped with Ctrl-C. Two channels
 ship the same executable; a third runs it from a clone.
 
-> **The Windows build has never been run on its own system** — it is built by CI
-> and downloaded by you first. The Linux arm64 build was used on Ubuntu 24 in a VM
+> **Neither Windows build has ever been used on its own system** — x64 and arm64
+> alike are started by CI on a runner of their own architecture, and downloaded by you
+> first. The Linux arm64 build was used on Ubuntu 24 in a VM
 > (2026-08-14); the x64 build has been started but never used in front of a person.
 > [Which platforms have actually been run](../README.md#which-platforms-have-actually-been-run)
 > says exactly what that covers.
@@ -32,7 +33,7 @@ reports success and `seedeep` prints the one command that finishes the job
 
 Take the file for your platform from [the latest release](../../../releases/latest)
 — `seedeep-server_<version>_macos-arm64`, `…_macos-x64`, `…_linux-x64`,
-`…_linux-arm64`, `…_windows-x64.exe` — make it executable, and run it:
+`…_linux-arm64`, `…_windows-x64.exe`, `…_windows-arm64.exe` — make it executable, and run it:
 
 ```sh
 chmod +x seedeep-server_*            # macOS and Linux
@@ -357,7 +358,9 @@ full is in [`architecture.md`](architecture.md#security-model).
 The menu-bar tray is a separate download, built by CI from a tag and attached to
 [the latest release](../../../releases/latest) beside the server: one universal
 `seedeep-tray_<version>_universal.dmg` for macOS — Apple Silicon and Intel in the
-same file, so there is nothing to choose — and a `-setup.exe` for Windows. Until a
+same file, so there is nothing to choose — and one `-setup.exe` per architecture for
+Windows, `_arm64-` on a Snapdragon or any other Windows-on-ARM machine and `_x64-`
+on everything else, since Windows has no universal binary to hide the question. Until a
 release is listed there, `bun run tray:build` produces the same bundle locally,
 under the same name.
 

--- a/docs/tray.md
+++ b/docs/tray.md
@@ -14,8 +14,8 @@ changes the endpoint.
 > **State of the code.** The tray is feature-complete and packaged: it finds a server, pins its
 > certificate, polls the digest, shows the three bands, drives its icon from what it reads, notifies
 > when a session stops on you, has the settings surface that turns that off, and a tag builds its
-> installers ([Packaging and releases](#packaging-and-releases)). Both installers have been built by
-> CI and inspected; no release has been cut, which is a decision and not a missing piece.
+> installers ([Packaging and releases](#packaging-and-releases)). The macOS and the Windows x64
+> installers have been built by CI and inspected; the Windows arm64 leg is new and has never run.
 >
 > What has been checked on a real menu bar, not only by its tests: the icon renders and reads at
 > menu-bar size, the popover opens anchored under it and inside the screen, and it closes. The
@@ -1512,7 +1512,7 @@ leaves them on the workflow run: every step that writes to the repository is gat
 `github.ref_type == 'tag'`, so the pipeline can be proven without cutting a release, which is the
 one step here that cannot be taken back.
 
-**A release has two halves.** The `server` job builds the server's five executables
+**A release has two halves.** The `server` job builds the server's six executables
 (`docs/architecture.md`, *Shipping the server*); this one builds the installers. They no longer wait
 for each other: the draft is created by a job of its own (`gh release create --draft`) rather than
 by `tauri-action`, which used to make the server queue behind a 14-minute Windows build for nothing
@@ -1539,11 +1539,11 @@ uninstall key all survive the rename.
 
 **Publishing is a separate job, and that is what makes it safe to automate.**
 `needs: [tray, server, smoke]` will not start it unless EVERY matrix build, the server's own job and
-the smoke run of all five executables succeeded (`docs/architecture.md`, *Shipping the server*), so a Windows failure
+the smoke run of all six executables succeeded (`docs/architecture.md`, *Shipping the server*), so a Windows failure
 — or a server that would not compile — leaves a draft rather than putting half a download page in
 front of people; and it runs once, where the build job runs per platform. Publishing from a build
 job instead would put a release on the download page as soon as the FIRST runner finished — one
-installer out of two, live, for the minutes the other takes.
+installer out of three, live, for the minutes the others take.
 
 Leaving it a draft was the earlier rule, and it does not survive going public: a draft is invisible
 to anyone without push access and is never `releases/latest` (GitHub's REST docs — *"Only users with
@@ -1561,19 +1561,32 @@ about the build; what the reader needs is the next click.
 | Platform | Artifact | Why this shape |
 | -- | -- | -- |
 | macOS | ONE universal `.dmg` (`seedeep-tray_<version>_universal.dmg`, 6.6 MB for a 15 MB app) | `--target universal-apple-darwin`, so the download page never asks which processor the reader has — a question people get wrong, and the wrong answer is an app that will not start |
-| Windows | NSIS `-setup.exe` (4.2 MB) | Its default `currentUser` install mode needs no Administrator rights. A UAC prompt for an unknown publisher is where an unsigned installer loses people, and `.msi` documents no per-user mode |
+| Windows | TWO NSIS installers, `…_x64-setup.exe` (4.2 MB) and `…_arm64-setup.exe` | Its default `currentUser` install mode needs no Administrator rights. A UAC prompt for an unknown publisher is where an unsigned installer loses people, and `.msi` documents no per-user mode. Two files rather than one because Windows has no universal binary: the reader picks the processor, which is the question the macOS DMG exists to avoid |
 
-Both were built by a real run and inspected rather than trusted: the DMG mounts to `seedeep.app`
+The DMG and the x64 `-setup.exe` were built by a real run and inspected rather than trusted: the DMG
+mounts to `seedeep.app`
 beside the `Applications` symlink, `lipo` reports `x86_64 arm64`, and `CFBundleShortVersionString` is
 the `package.json` number; the Windows artifact is a `PE32 executable (GUI) … Nullsoft Installer
 self-extracting archive`. A cold runner with no Rust cache takes about 9 minutes on macOS and 14 on
-Windows.
+Windows. **The arm64 leg has never run**, so nothing here is measured about it — not the build time,
+not the artifact, not whether the runner's toolchain carries what Tauri needs. A
+`workflow_dispatch` run is what would settle that before a tag depends on it.
 
 Windows is why this is CI and not a script on a laptop: Tauri's own recipe uses one runner per
 platform, and it documents building the Windows installer from a Mac as possible for NSIS only
 *"with caveats"* and *"not tested as much"* — and impossible for `.msi`, since WiX runs on Windows.
 The macOS half could be built locally; it is there so both halves of a version come out of the same
 commit and the same recipe — the [one version](#one-version-for-every-deliverable) rule, applied.
+
+**The arm64 installer is built natively on `windows-11-arm`, not cross-compiled**, though it could
+have been: the `windows-latest` image carries `VC.Tools.ARM64`, so the x64 runner has everything
+`--target aarch64-pc-windows-msvc` would need. What it does not have is a recipe Tauri documents —
+the installer guide describes adding the ARM64 build tools to the machine that BUILDS, and says
+nothing about a host-to-arm64 cross-build. The native leg differs from the x64 one by its runner
+alone, with no flag to get subtly wrong, and the runner is GA and free on public repositories
+(2025-08-07); its image already carries VS 2022, Rust and NSIS. **The installer itself stays x86**
+either way — Tauri documents that it runs under emulation on the ARM machine, and only the app
+inside it is native arm64.
 
 **The workflow sets `TAURI_BUNDLER_DMG_IGNORE_CI: 'false'`, and that is not a formality.** The
 bundler passes `--skip-jenkins` to `bundle_dmg.sh` — skipping the Finder-prettifying AppleScript —
@@ -1606,8 +1619,9 @@ Nothing. The bundle carries only the linker's ad-hoc signature, and both systems
   was `open` over an SSH session, which is not a gesture any user performs. Two conclusions, and the
   second is the reusable one: a shell over SSH cannot answer a question about a GUI decision, and
   *"I could not reproduce the block"* is not *"there is no block"*.
-- **Nothing about Windows is measured**: there is no Windows machine here and the workflow has never
-  run. The SmartScreen wording in the README is Microsoft's documented behaviour, not an observation.
+- **Nothing about Windows is measured**: no Windows desktop is used here, and neither installer has
+  been opened on one. The SmartScreen wording in the README is Microsoft's documented behaviour, not
+  an observation.
 
 Signing and notarization stay out of scope until there is a release worth signing (EPIC 4).
 


### PR DESCRIPTION
`npm i -g seedeep` on a machine with the native arm64 Node — the build winget installs on a Snapdragon laptop — died with `no build for win32 arm64`, on the command the README puts first. The wrapper's `os` and `cpu` are two independent lists that npm reads as a cross product, so `win32` × `arm64` was a pair npm accepted and no package carried.

## What changed

| Area | Change |
| -- | -- |
| Server | A sixth entry in `TARGETS`. Bun documents `bun-windows-arm64` now, so it is cross-compiled beside the other five on the same runner — verified here: the output is a real `PE32+ … Aarch64` |
| npm | `seedeep-windows-arm64`, the seventh package. The wrapper's `os` × `cpu` cross product is now covered in full |
| Smoke | A `windows-11-arm` leg, because nothing else in the workflow would ever EXECUTE that file — the v0.6.0 failure mode |
| Tray | An arm64 NSIS installer, built natively on the same runner rather than cross-compiled from the x64 one: Tauri documents adding the ARM64 build tools to the machine that builds, never a host-to-arm64 cross-build, so the native leg differs from the x64 one by its runner alone. The installer itself stays x86 under emulation by Tauri's design; the app inside is native |
| Publish | The npm step is idempotent: npm refuses to publish over a version, so a run that died partway used to leave the re-run failing on the first package instead of finishing the rest |

## The tests that should have caught it

The one covering this ground asserted the **hole** — that `seedeep-windows-arm64` was ABSENT, described as the combination Bun could not build — so it passed happily while the channel was broken. It now walks the whole `os` × `cpu` cross product and demands a package behind every pair. A second guard ties the tray matrix to the same list, so adding a Windows target without its installer fails. Both were confirmed red before the fix and green after.

## Not covered

No arm64 Windows machine has run any of this. The smoke leg will start the server binary on every release; the tray's arm64 leg has never run at all, and `docs/tray.md` says so.

`seedeep-windows-arm64` also needs its trusted publisher configured on npmjs.com — the first publish of a new package is manual, and the `npm` job is not a dependency of `publish`, so a tag that finds it missing still produces a green release page.