### PR TITLE
Four Windows defects, one commit each

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -213,11 +213,14 @@ not be accepted.
 
 ## Running it on Windows
 
-The single most useful contribution nobody here can make: **no Windows machine is used in this
-project**, so the tray's installers are built on every tag and have never been opened, and the
-server's `.exe` has been started by CI and never used. If you have Windows, one session settles six claims the code makes
-and the docs currently only reason about. Report what you see in an issue — a "it all worked"
-is as valuable as a defect, because today neither is known.
+The single most useful contribution nobody here can make. One Windows session has happened — a
+Windows 11 **arm64** guest, 2026-08-14 — and it found four defects in an evening: the server was
+installed from npm, started and served, and the tray was installed and its popover opened for the
+first time. Everything below is what that session did **not** settle, which is most of it: it never
+got past the popover, and the **x64** build of either app has still been started by CI and never used
+by a person. If you have Windows, one session settles six claims the code makes and the docs
+currently only reason about. Report what you see in an issue — a "it all worked" is as valuable as
+a defect, because today neither is known.
 
 1. **The installer runs at all**, and what SmartScreen actually says for an unsigned unknown
    publisher — the README quotes Microsoft's documentation, not a screenshot. Its `currentUser`

--- a/README.md
+++ b/README.md
@@ -171,10 +171,11 @@ the GUI, stops the server, or reports what the current session cost.
 ## Which platforms have actually been run
 
 Everything above was checked by hand on **macOS**, on the machine `seedeep` is
-developed on. **Linux has been used once**, in a VM, on arm64 — the table says what
-that covered. **Windows has not been used at all.** Building for three systems is not
-the same as having used three, and this section is that difference written down
-rather than left for you to find.
+developed on. **Linux has been used once**, in a VM, on arm64. **Windows has been
+used once too**, in a VM, on arm64 — and only so far: the table says exactly how far
+each got, and what each found. Building for three systems is not the same as having
+used three, and this section is that difference written down rather than left for you
+to find.
 
 Since 0.24.0 there is a middle ground worth naming: **started is not used**. Every
 release now runs each server binary on a runner of its own operating system before
@@ -185,15 +186,16 @@ a person on that machine.
 
 | | macOS | Windows | Linux |
 | -- | -- | -- | -- |
-| **Server** — download or npm | Used daily; every claim above was checked here | **x64 and arm64: started on every release, never used.** CI runs each `.exe` on a Windows runner of its own architecture and checks it serves the GUI; nobody has worked in either | **arm64: used on Ubuntu 24 in a VM** (2026-08-14) — GUI opened against a real Claude Code session, lifecycle and `install-command` confirmed. **x64: started on every release, never used** — version-checked in CI and on Docker, never run in front of a person. Both builds require glibc; Alpine/musl is not supported. |
-| **Tray** | Used daily on a real menu bar | **Never run.** Both installers, x64 and arm64, are built on every tag and nothing has opened either: a menu-bar app needs a desktop, and CI runners have none | **Not a target**, deliberately: Tauri emits no tray click event on Linux, so the panel could not open — see [`docs/tray.md`](docs/tray.md) |
+| **Server** — download or npm | Used daily; every claim above was checked here | **arm64: used on Windows 11 in a VM** (2026-08-14) — installed from npm on a native arm64 Node, server started and served its API against a real Claude Code session, `status`, `stop` and `install-command` confirmed, and ten consecutive cold starts measured without a failure. Four defects it found — a `restart` that left no replacement running, a popover off the bottom of the screen, a console window the tray had no reason to open, and unreadable punctuation — are fixed and **await a build somebody can run**. `/seedeep` there needs one line of configuration ([`install.md`](docs/install.md#seedeep-inside-claude-code)). **x64: started on every release, never used** — and on a Windows-on-arm machine, where an x64 Node makes npm resolve it, it crashes within seconds of starting; install an arm64 Node so npm resolves the native build | **arm64: used on Ubuntu 24 in a VM** (2026-08-14) — GUI opened against a real Claude Code session, lifecycle and `install-command` confirmed. **x64: started on every release, never used** — version-checked in CI and on Docker, never run in front of a person. Both builds require glibc; Alpine/musl is not supported. |
+| **Tray** | Used daily on a real menu bar | **arm64: opened once** (2026-08-14), and it got no further than the popover — which appeared off the bottom of the screen, beside a console window the app had no reason to open. Both are fixed and await a build somebody can run; the icon's legibility, the notifications and the connection screen are still unanswered. **x64: never run** — its installer is built on every tag and nothing has opened it | **Not a target**, deliberately: Tauri emits no tray click event on Linux, so the panel could not open — see [`docs/tray.md`](docs/tray.md) |
 
-Concretely: on Windows **you are the first to use it**, and on Linux x64 as well. A defect there
-is expected rather than surprising, and [an issue](../../issues) saying what you saw
-is the most useful thing you can send. If you use Windows,
-[`CONTRIBUTING.md`](CONTRIBUTING.md#running-it-on-windows) lists the six things one
-session on that machine would settle — the largest single gap in what this project
-knows about itself.
+Concretely: on **Windows x64**, on **Linux x64**, and on the **tray anywhere but macOS**,
+you are the first to use it. A defect there is expected rather than surprising, and
+[an issue](../../issues) saying what you saw is the most useful thing you can send.
+The one Windows session behind the table above found four defects in an evening, which
+is the honest estimate of what the untouched squares still hold; if you use Windows,
+[`CONTRIBUTING.md`](CONTRIBUTING.md#running-it-on-windows) lists what a session on that
+machine would settle next.
 
 ## Design principles
 

--- a/apps/server/src/server/console-encoding.ts
+++ b/apps/server/src/server/console-encoding.ts
@@ -26,6 +26,10 @@
  * `SetConsoleOutputCP` through FFI in a cross-compiled binary, and nothing here could verify it.
  */
 
+// LIMIT: seedeep's OWN typography only. The data it prints verbatim — commit subjects, card titles,
+// project paths, file names — can carry anything, and an accented directory or a curly apostrophe
+// still garbles on a legacy code page. Covering that needs the console's code page set to UTF-8
+// (`SetConsoleOutputCP` through FFI), which is declined above, not a longer table.
 /** What a legacy Windows console cannot show, and what it is spelled as instead. */
 const ASCII: ReadonlyArray<readonly [string, string]> = [
   ['—', '-'],

--- a/apps/server/src/server/console-encoding.ts
+++ b/apps/server/src/server/console-encoding.ts
@@ -1,0 +1,67 @@
+/**
+ * Make what seedeep prints readable on a Windows console.
+ *
+ * A Windows console runs in a legacy code page unless something changes it — CP850 or CP437 under
+ * `cmd`, CP1252 elsewhere — and seedeep writes UTF-8. So the characters it separates its lines with
+ * arrive as `ΓÇö` and `â€"`. Measured on Windows 11, 2026-08-14: every line of every capture.
+ * Invisible on macOS and Linux, which is how it shipped.
+ *
+ * **The table is measured, not imagined.** It came from running the CLI and reading what actually
+ * left the process — `--help`, `--version`, `status`, `update` — plus the three sites a console run
+ * cannot reach here (`restart` and `self-update` print `→`, `report` prints `≥`). Five characters.
+ * The `▲ ✓ 🔒 × ↔` in `core/` never come near a console: they are rendered in the browser and in the
+ * share card, where UTF-8 is not in question. A first attempt at this claimed one character on a
+ * count of source lines rather than of printed output, and was wrong.
+ *
+ * **It wraps `console`, not the streams.** In Bun `console.log` does NOT route through
+ * `process.stdout.write` — verified on 1.3.13 — so wrapping the streams translated nothing at all
+ * while its test, which only ever wrote to a fake stream, passed. seedeep prints through
+ * `console.log`, `console.error` and `console.warn` and through nothing else.
+ *
+ * One boundary rather than the ~70 sites that build these strings: a rule enforced in one place
+ * cannot be forgotten by the next line somebody writes, and spelling the separators ASCII in the
+ * sources would take the typography off macOS and Linux too, where it renders correctly.
+ *
+ * Setting the console's code page to UTF-8 would be the other repair, and it is not taken: it needs
+ * `SetConsoleOutputCP` through FFI in a cross-compiled binary, and nothing here could verify it.
+ */
+
+/** What a legacy Windows console cannot show, and what it is spelled as instead. */
+const ASCII: ReadonlyArray<readonly [string, string]> = [
+  ['—', '-'],
+  ['…', '...'],
+  ['·', '-'],
+  ['→', '->'],
+  ['≥', '>='],
+];
+
+/** Spell `text` for a console that cannot show those five. Pure, so the table itself is testable. */
+export function asciiFallback(text: string): string {
+  let out = text;
+  for (const [from, to] of ASCII) out = out.replaceAll(from, to);
+  return out;
+}
+
+/** The console methods seedeep prints through, and the only ones this touches. */
+export interface ConsoleLike {
+  log(...args: unknown[]): void;
+  error(...args: unknown[]): void;
+  warn(...args: unknown[]): void;
+}
+
+/**
+ * Apply {@link asciiFallback} to everything `target` prints, on Windows only. Returns true when it
+ * wrapped.
+ *
+ * Off Windows it does nothing at all — not even wrap — because a console that renders these
+ * correctly should receive them. Strings only: an argument that is not a string was not encoded
+ * here, and rewriting bytes it did not encode is how an encoder becomes a corruption.
+ */
+export function useAsciiConsole(target: ConsoleLike = console, platform: string = process.platform): boolean {
+  if (platform !== 'win32') return false;
+  for (const name of ['log', 'error', 'warn'] as const) {
+    const original = target[name].bind(target);
+    target[name] = (...args: unknown[]) => original(...args.map((a) => (typeof a === 'string' ? asciiFallback(a) : a)));
+  }
+  return true;
+}

--- a/apps/server/src/server/install-command.ts
+++ b/apps/server/src/server/install-command.ts
@@ -193,9 +193,15 @@ export function pathState(
     execPath?: string;
     fromSource?: boolean;
     realpath?: (p: string) => string;
+    platform?: string;
   } = {},
 ): PathState {
-  const { which = (cmd: string) => Bun.which(cmd), execPath = process.execPath, fromSource = FROM_SOURCE } = deps;
+  const {
+    which = (cmd: string) => Bun.which(cmd),
+    execPath = process.execPath,
+    fromSource = FROM_SOURCE,
+    platform = process.platform,
+  } = deps;
   const realpath =
     deps.realpath ??
     ((p: string) => {
@@ -208,7 +214,45 @@ export function pathState(
   if (fromSource) return { kind: 'from-source' };
   const found = which('seedeep');
   if (!found) return { kind: 'absent' };
-  return realpath(found) === realpath(execPath) ? { kind: 'ok' } : { kind: 'other', found };
+  if (realpath(found) === realpath(execPath)) return { kind: 'ok' };
+  return isNpmWindowsLauncher(found, execPath, platform) ? { kind: 'ok' } : { kind: 'other', found };
+}
+
+/**
+ * True when what is on the PATH is the npm-on-Windows LAUNCHER for `execPath`, not another seedeep.
+ *
+ * Windows has no symlink for `realpath` to follow: npm writes a `.cmd` (and a `.ps1`, and an
+ * extensionless script for Git Bash) into its global bin directory and lets it exec the binary that
+ * lives under that directory's `node_modules`. The comparison above therefore never matched, and
+ * every npm install on Windows was told its own launcher was a different executable — measured
+ * 2026-08-14 on Windows 11: `…\npm\seedeep.cmd` on the PATH against
+ * `…\npm\node_modules\seedeep\bin\seedeep.exe` running, which is one install and not two.
+ *
+ * The `node_modules` segment is required rather than any ancestor, and that is the whole
+ * difference: a bare "the launcher's directory contains this executable" would make a stray
+ * `seedeep.cmd` at a drive root vouch for every binary on the drive — including the downloaded one
+ * in `Downloads` that the warning exists to report. Case-insensitive because the filesystem is.
+ *
+ * The splitting is done by hand rather than with `node:path`, which follows the HOST: its `dirname`
+ * answers `.` for every one of these paths when this runs anywhere but Windows, and a function whose
+ * whole subject is a Windows path cannot depend on where it executes.
+ *
+ * LIMIT: npm only. Bun's global layout on Windows has not been measured — on POSIX it is a symlink
+ * (`~/.bun/bin/seedeep` → `~/.bun/install/global/node_modules/…`), which `realpath` already
+ * resolves, and what it writes on Windows is a guess this refuses to make. A bun install there keeps
+ * the false warning until somebody looks.
+ */
+export function isNpmWindowsLauncher(found: string, execPath: string, platform: string): boolean {
+  if (platform !== 'win32') return false;
+  const win = (p: string) => p.toLowerCase().replace(/\//g, '\\');
+  const shim = win(found);
+  const cut = shim.lastIndexOf('\\');
+  if (cut === -1) return false;
+  const name = shim.slice(cut + 1);
+  const dot = name.lastIndexOf('.');
+  const ext = dot === -1 ? '' : name.slice(dot);
+  if (ext !== '.cmd' && ext !== '.bat' && ext !== '.ps1' && ext !== '') return false;
+  return win(execPath).startsWith(`${shim.slice(0, cut)}\\node_modules\\`);
 }
 
 /**

--- a/apps/server/src/server/install-command.ts
+++ b/apps/server/src/server/install-command.ts
@@ -15,7 +15,7 @@
 import { realpathSync } from 'node:fs';
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
-import { dirname, join } from 'node:path';
+import { dirname, join, win32 } from 'node:path';
 import { claudeDir } from './roots.ts';
 import { type Channel, detectChannel } from './update-cmd.ts';
 import { FROM_SOURCE, VERSION } from './version.ts';
@@ -214,8 +214,12 @@ export function pathState(
   if (fromSource) return { kind: 'from-source' };
   const found = which('seedeep');
   if (!found) return { kind: 'absent' };
-  if (realpath(found) === realpath(execPath)) return { kind: 'ok' };
-  return isNpmWindowsLauncher(found, execPath, platform) ? { kind: 'ok' } : { kind: 'other', found };
+  const [realFound, realExec] = [realpath(found), realpath(execPath)];
+  if (realFound === realExec) return { kind: 'ok' };
+  // Resolved on both sides here too: `Bun.which` can answer through a directory junction or an 8.3
+  // short name while `process.execPath` is the long form, and a prefix test on the two spellings
+  // would then miss. The message still names what the user would type — `found`, not its target.
+  return isNpmWindowsLauncher(realFound, realExec, platform) ? { kind: 'ok' } : { kind: 'other', found };
 }
 
 /**
@@ -228,14 +232,15 @@ export function pathState(
  * 2026-08-14 on Windows 11: `…\npm\seedeep.cmd` on the PATH against
  * `…\npm\node_modules\seedeep\bin\seedeep.exe` running, which is one install and not two.
  *
- * The `node_modules` segment is required rather than any ancestor, and that is the whole
- * difference: a bare "the launcher's directory contains this executable" would make a stray
- * `seedeep.cmd` at a drive root vouch for every binary on the drive — including the downloaded one
- * in `Downloads` that the warning exists to report. Case-insensitive because the filesystem is.
+ * The package's OWN directory is required, not merely a `node_modules` under the launcher: a
+ * looser prefix would let `…\npm\node_modules\some-other-package\bin\seedeep.exe` vouch for the
+ * PATH entry, and at a drive root it degenerates to `c:\node_modules\` — the very case a bare
+ * ancestor test was supposed to rule out. Case-insensitive because the filesystem is.
  *
- * The splitting is done by hand rather than with `node:path`, which follows the HOST: its `dirname`
- * answers `.` for every one of these paths when this runs anywhere but Windows, and a function whose
- * whole subject is a Windows path cannot depend on where it executes.
+ * `path.win32` and not the default export: the default follows the HOST, and this reasons about a
+ * Windows path wherever it runs. The `win32` variant is host-independent — verified on darwin,
+ * `win32.dirname('C:\\…\\npm\\seedeep.cmd')` answers `C:\…\npm` — which an earlier version of this
+ * comment denied while hand-rolling eight lines to work around a problem that does not exist.
  *
  * LIMIT: npm only. Bun's global layout on Windows has not been measured — on POSIX it is a symlink
  * (`~/.bun/bin/seedeep` → `~/.bun/install/global/node_modules/…`), which `realpath` already
@@ -244,15 +249,11 @@ export function pathState(
  */
 export function isNpmWindowsLauncher(found: string, execPath: string, platform: string): boolean {
   if (platform !== 'win32') return false;
-  const win = (p: string) => p.toLowerCase().replace(/\//g, '\\');
-  const shim = win(found);
-  const cut = shim.lastIndexOf('\\');
-  if (cut === -1) return false;
-  const name = shim.slice(cut + 1);
-  const dot = name.lastIndexOf('.');
-  const ext = dot === -1 ? '' : name.slice(dot);
+  const ext = win32.extname(found).toLowerCase();
+  // `''` covers the extensionless script npm also writes, for Git Bash.
   if (ext !== '.cmd' && ext !== '.bat' && ext !== '.ps1' && ext !== '') return false;
-  return win(execPath).startsWith(`${shim.slice(0, cut)}\\node_modules\\`);
+  const pkg = win32.join(win32.dirname(found), 'node_modules', 'seedeep', win32.sep);
+  return execPath.toLowerCase().replace(/\//g, '\\').startsWith(pkg.toLowerCase().replace(/\//g, '\\'));
 }
 
 /**

--- a/apps/server/src/server/main.ts
+++ b/apps/server/src/server/main.ts
@@ -4,6 +4,7 @@ import { type CliOptions, parseArgs } from './args.ts';
 import { openBrowser } from './browser.ts';
 import { planClaudeCommand } from './claude-command.ts';
 import { defaultConfig, readConfigStrict, resolveConfig, type SeedDeepConfig } from './config.ts';
+import { useAsciiConsole } from './console-encoding.ts';
 import { discoverSessions } from './discovery.ts';
 import { usage, versionLine } from './help.ts';
 import { refreshOwnedCommandFile, runInstallCommand, staleCommandNotice } from './install-command.ts';
@@ -229,6 +230,9 @@ async function withConfig(
 }
 
 function main(): void {
+  // First, before anything can print: every subcommand and the server itself go through `console`,
+  // and on Windows the console cannot render the characters they carry.
+  useAsciiConsole();
   runSubcommand(process.argv.slice(2))
     .then((code) => {
       if (code !== null) process.exit(code);

--- a/apps/server/src/server/server.ts
+++ b/apps/server/src/server/server.ts
@@ -69,9 +69,10 @@ export interface ServerDeps {
    */
   exit?: (code: number) => void;
   /**
-   * Injectable self-restart function for `POST /api/restart`. Defaults to spawning a
-   * detached copy of the current process via `Bun.spawn` + `unref()`. Override in tests
-   * to avoid actually spawning a child process.
+   * Injectable self-restart function for `POST /api/restart`. Defaults to `Bun.spawn` on
+   * {@link selfSpawnPlan} plus `unref()`. Override in tests to avoid actually spawning a child —
+   * but note that an override cannot see HOW the real one spawns, which is why the plan is
+   * asserted separately.
    */
   spawnSelf?: () => void;
   /**
@@ -349,6 +350,52 @@ function mergeNotificationsPost(stored: NotifyConfig, given: Record<string, unkn
   };
 }
 
+/** How the successor of a restart is launched: the same executable, the same flags. */
+export interface SelfSpawnPlan {
+  /** argv for `Bun.spawn` — this executable, then the flags this process was given. */
+  cmd: string[];
+  /** `detached` is present on Windows and absent everywhere else; see {@link selfSpawnPlan}. */
+  options: { stdio: ['inherit', 'inherit', 'inherit']; detached?: true };
+}
+
+/**
+ * Build the command line and options for the server a restart hands over to.
+ *
+ * Separated from the spawn itself because the two things that decide whether the handover works are
+ * both in here, and neither is visible to a test that injects `ServerDeps.spawnSelf`.
+ *
+ * **`detached` on Windows, and only there.** A Windows child stays in its parent's job object and is
+ * terminated the moment the parent exits, which is why `restart` left the old server stopped with no
+ * replacement running and not one line in the log — measured on Windows 11 arm64, 2026-08-14, on the
+ * same machine where `seedeep start`, the path that passes the flag, survived ten starts of ten.
+ * On POSIX the flag is `setsid()`: it would put the successor in a session of its own, so a Ctrl-C
+ * in the terminal that started `seedeep serve` would no longer reach it and closing that terminal
+ * would leave an orphan holding the port. Nothing there needs it — `unref()` plus adoption by init
+ * already outlives this process — so fixing Windows must not change macOS and Linux at all.
+ *
+ * `selfInvocation` rather than `argv.slice(1)`: in the compiled binary that slice starts with the
+ * bunfs entry path, which is not an argument the program can be given back. Measured on the real
+ * binary — the restarted server refused it and never came up.
+ */
+export function selfSpawnPlan(
+  deps: { argv?: readonly string[]; execPath?: string; main?: string; fromSource?: boolean; platform?: string } = {},
+): SelfSpawnPlan {
+  const {
+    argv = process.argv,
+    execPath = process.execPath,
+    main = Bun.main,
+    fromSource = FROM_SOURCE,
+    platform = process.platform,
+  } = deps;
+  return {
+    cmd: [...selfInvocation(execPath, main, fromSource), ...argv.slice(2)],
+    options: {
+      stdio: ['inherit', 'inherit', 'inherit'],
+      ...(platform === 'win32' ? { detached: true as const } : {}),
+    },
+  };
+}
+
 /** Run the macOS `security add-generic-password` command and return the result. */
 /**
  * Start the local HTTP(S) server. On a non-loopback `host`:
@@ -370,13 +417,8 @@ export async function startServer(deps: ServerDeps): Promise<RunningServer> {
   const spawnSelfFn =
     deps.spawnSelf ??
     (() => {
-      // `selfInvocation` rather than `argv.slice(1)`: in the compiled binary that slice starts
-      // with the bunfs entry path, which is not an argument the program can be given back.
-      // Measured on the real binary — the restarted server refused it and never came up.
-      const child = Bun.spawn([...selfInvocation(process.execPath, Bun.main, FROM_SOURCE), ...process.argv.slice(2)], {
-        stdio: ['inherit', 'inherit', 'inherit'],
-      });
-      child.unref();
+      const plan = selfSpawnPlan();
+      Bun.spawn(plan.cmd, plan.options).unref();
     });
 
   // Mutable config copy — updated by POST /api/config without touching the rest of the server.

--- a/apps/server/src/server/server.ts
+++ b/apps/server/src/server/server.ts
@@ -814,9 +814,10 @@ export async function startServer(deps: ServerDeps): Promise<RunningServer> {
       }
 
       if (pathname === '/api/restart' && req.method === 'POST') {
-        // Spawn a detached copy of this process, then exit. The child inherits all argv
-        // so flags like --no-open survive the restart. unref() detaches it from our
-        // lifetime — it keeps running after process.exit(0).
+        // Spawn a copy of this process, then exit. The child inherits all argv, so flags like
+        // --no-open survive the restart. What lets it outlive this process differs by platform and
+        // is decided in {@link selfSpawnPlan}: `unref()` only stops the handle holding this event
+        // loop open, and on Windows that is not enough on its own.
         setTimeout(() => {
           spawnSelfFn();
           exitFn(0);

--- a/apps/server/tests/console-encoding.test.ts
+++ b/apps/server/tests/console-encoding.test.ts
@@ -1,0 +1,71 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { asciiFallback, type ConsoleLike, useAsciiConsole } from '../src/server/console-encoding.ts';
+import { usage } from '../src/server/help.ts';
+
+/** A stand-in for the global console: records what each method actually received. */
+function fakeConsole(): ConsoleLike & { said: unknown[] } {
+  const said: unknown[] = [];
+  return {
+    said,
+    log: (...a: unknown[]) => said.push(...a),
+    error: (...a: unknown[]) => said.push(...a),
+    warn: (...a: unknown[]) => said.push(...a),
+  };
+}
+
+/** Every character a legacy Windows console cannot show, or an empty string. */
+const nonAscii = (s: string) => [...s].filter((c) => c.charCodeAt(0) > 127).join('');
+
+test('asciiFallback: the five measured characters, every occurrence', () => {
+  assert.equal(asciiFallback('a — b'), 'a - b');
+  assert.equal(asciiFallback('/very/long/…/path'), '/very/long/.../path');
+  assert.equal(asciiFallback('pid 8064 · loopback'), 'pid 8064 - loopback');
+  assert.equal(asciiFallback('pid 7 → 9'), 'pid 7 -> 9');
+  assert.equal(asciiFallback('≥ 3 turns'), '>= 3 turns');
+  assert.equal(asciiFallback('a — b — c'), 'a - b - c', 'every occurrence, not the first');
+  assert.equal(asciiFallback('plain ascii'), 'plain ascii');
+});
+
+// The first attempt wrapped `process.stdout.write`, which in Bun `console.log` does not go through:
+// it translated nothing while its test, which only wrote to a fake stream, passed. seedeep prints
+// through these three methods and through nothing else.
+test('useAsciiConsole: log, error and warn are all translated on Windows', () => {
+  const fake = fakeConsole();
+  assert.equal(useAsciiConsole(fake, 'win32'), true);
+  fake.log('seedeep watching — url');
+  fake.error('seedeep: pid 7 → 9');
+  fake.warn('a … b');
+  assert.deepEqual(fake.said, ['seedeep watching - url', 'seedeep: pid 7 -> 9', 'a ... b']);
+});
+
+// A console that renders these correctly gets them. Nothing is wrapped at all, so this cannot cost
+// anything on the platform seedeep is used on every day.
+test('useAsciiConsole: off Windows it does not even wrap', () => {
+  for (const platform of ['darwin', 'linux']) {
+    const fake = fakeConsole();
+    assert.equal(useAsciiConsole(fake, platform), false, platform);
+    fake.log('seedeep watching — url');
+    assert.deepEqual(fake.said, ['seedeep watching — url'], platform);
+  }
+});
+
+// An encoder that rewrites what it did not encode is a corruption. Only strings are translated.
+test('useAsciiConsole: a non-string argument passes through untouched', () => {
+  const fake = fakeConsole();
+  useAsciiConsole(fake, 'win32');
+  const obj = { dash: '—' };
+  fake.log(obj, 42);
+  assert.deepEqual(fake.said, [obj, 42]);
+});
+
+// The end-to-end check the first attempt lacked: a REAL string seedeep prints, through the REAL
+// wrapper, asserted to carry nothing a legacy console cannot show. `usage()` is the longest single
+// block the CLI emits and the one with the most separators in it.
+test('the help screen comes out pure ASCII on Windows', () => {
+  assert.notEqual(nonAscii(usage()), '', 'the source text must contain some, or this proves nothing');
+  const fake = fakeConsole();
+  useAsciiConsole(fake, 'win32');
+  fake.log(usage());
+  assert.equal(nonAscii(String(fake.said[0])), '');
+});

--- a/apps/server/tests/install-command.test.ts
+++ b/apps/server/tests/install-command.test.ts
@@ -141,8 +141,18 @@ test('the npm launcher on Windows is this executable, not another seedeep', () =
     found: shim,
   });
 
-  // `node_modules` is required, not merely an ancestor: a launcher at a drive root must not vouch
-  // for every executable on the drive.
+  // The package's OWN directory is required. A looser `node_modules\` prefix would accept another
+  // package's binary, and at a drive root it degenerates to `c:\node_modules\`.
+  assert.deepEqual(at(shim, 'C:\\Users\\dev\\AppData\\Roaming\\npm\\node_modules\\other\\bin\\seedeep.exe', 'win32'), {
+    kind: 'other',
+    found: shim,
+  });
+  assert.deepEqual(at('C:\\seedeep.cmd', 'C:\\node_modules\\anything\\seedeep.exe', 'win32'), {
+    kind: 'other',
+    found: 'C:\\seedeep.cmd',
+  });
+
+  // A launcher at a drive root must not vouch for an executable elsewhere on the drive either.
   assert.deepEqual(at('C:\\seedeep.cmd', 'C:\\Users\\dev\\Downloads\\seedeep-server.exe', 'win32'), {
     kind: 'other',
     found: 'C:\\seedeep.cmd',

--- a/apps/server/tests/install-command.test.ts
+++ b/apps/server/tests/install-command.test.ts
@@ -121,6 +121,37 @@ test('the PATH is checked against the executable actually running', () => {
   });
 });
 
+// Windows has no symlink for `realpath` to follow: npm writes a `.cmd` beside the package and lets
+// it exec the binary, so the comparison above always failed and EVERY npm install on Windows was
+// told its own launcher was a different executable. Measured on Windows 11, 2026-08-14, with these
+// two exact paths.
+test('the npm launcher on Windows is this executable, not another seedeep', () => {
+  const same = (p: string) => p;
+  const shim = 'C:\\Users\\dev\\AppData\\Roaming\\npm\\seedeep.cmd';
+  const exe = 'C:\\Users\\dev\\AppData\\Roaming\\npm\\node_modules\\seedeep\\bin\\seedeep.exe';
+  const at = (found: string, execPath: string, platform: string) =>
+    pathState({ which: () => found, execPath, fromSource: false, realpath: same, platform });
+
+  assert.deepEqual(at(shim, exe, 'win32'), { kind: 'ok' });
+
+  // The case the warning exists for survives: a downloaded binary run from elsewhere, with an npm
+  // install on the PATH, really is two seedeeps.
+  assert.deepEqual(at(shim, 'C:\\Users\\dev\\Downloads\\seedeep-server.exe', 'win32'), {
+    kind: 'other',
+    found: shim,
+  });
+
+  // `node_modules` is required, not merely an ancestor: a launcher at a drive root must not vouch
+  // for every executable on the drive.
+  assert.deepEqual(at('C:\\seedeep.cmd', 'C:\\Users\\dev\\Downloads\\seedeep-server.exe', 'win32'), {
+    kind: 'other',
+    found: 'C:\\seedeep.cmd',
+  });
+
+  // Nothing about this is portable: the same shape on macOS is not a launcher and must still warn.
+  assert.deepEqual(at(shim, exe, 'darwin'), { kind: 'other', found: shim });
+});
+
 // A package manager puts a LINK on the PATH, never the file: measured, `~/.bun/bin/seedeep` points
 // into `~/.bun/install/global/node_modules/…`. Comparing the two spellings warned every npm and bun
 // install that its own binary was "a different executable" — the normal case, and a false alarm.

--- a/apps/server/tests/server.test.ts
+++ b/apps/server/tests/server.test.ts
@@ -7,7 +7,7 @@ import { test } from 'node:test';
 import { mergeRoster } from '../src/core/roster.ts';
 import type { SessionRecord } from '../src/core/types.ts';
 import { defaultConfig, type SeedDeepConfig } from '../src/server/config.ts';
-import { isLoopback, parseMarks, startServer } from '../src/server/server.ts';
+import { isLoopback, parseMarks, selfSpawnPlan, startServer } from '../src/server/server.ts';
 import type { Channel } from '../src/server/update-cmd.ts';
 import { VERSION } from '../src/server/version.ts';
 
@@ -1027,6 +1027,44 @@ test('POST /api/restart: responds { ok: true }, spawns self, then calls exit(0)'
   } finally {
     srv.stop();
   }
+});
+
+// The test above injects `spawnSelf`, so it can never see HOW the real one spawns — which is where
+// the defect was. Windows 11 arm64, 2026-08-14: `restart` left the old server stopped and no
+// replacement running, because a non-detached child dies with its parent's job object.
+test('the restart successor is detached on Windows, and on Windows only', () => {
+  const argv = ['/opt/seedeep', 'B:/~BUN/root/main.ts', 'serve', '--no-open', '--port', '9000'];
+  const at = (platform: string) =>
+    selfSpawnPlan({ argv, execPath: '/opt/seedeep', main: 'B:/~BUN/root/main.ts', fromSource: false, platform });
+
+  assert.equal(at('win32').options.detached, true, 'without this the successor dies with its parent');
+  // `setsid()` on POSIX: it would take the successor out of the terminal's session, so Ctrl-C would
+  // no longer reach it. Nothing there needs the flag, so fixing Windows must not change these.
+  assert.equal(at('darwin').options.detached, undefined);
+  assert.equal(at('linux').options.detached, undefined);
+  assert.ok(!('detached' in at('darwin').options), 'absent, not merely false');
+});
+
+test('the restart successor re-execs this binary with the flags it was given', () => {
+  // argv in the compiled binary: the executable, then the bunfs entry path, then what was typed.
+  const compiled = selfSpawnPlan({
+    argv: ['/opt/seedeep', 'B:/~BUN/root/main.ts', 'serve', '--no-open', '--port', '9000'],
+    execPath: '/opt/seedeep',
+    main: 'B:/~BUN/root/main.ts',
+    fromSource: false,
+    platform: 'linux',
+  });
+  assert.deepEqual(compiled.cmd, ['/opt/seedeep', 'serve', '--no-open', '--port', '9000'], 'never the bunfs path');
+
+  // From source the entry path IS an argument the program can be given back, and must be kept.
+  const fromSource = selfSpawnPlan({
+    argv: ['bun', 'main.ts', 'serve', '--port', '9000'],
+    execPath: 'bun',
+    main: 'main.ts',
+    fromSource: true,
+    platform: 'linux',
+  });
+  assert.deepEqual(fromSource.cmd, ['bun', 'main.ts', 'serve', '--port', '9000']);
 });
 
 test('POST /api/restart: requires auth on non-loopback host', async () => {

--- a/apps/tray/src-tauri/src/main.rs
+++ b/apps/tray/src-tauri/src/main.rs
@@ -157,18 +157,45 @@ struct PanelGeom {
 /// window on the wrong side of its icon. All arithmetic, and none of it observable from an SSH
 /// shell — which is the whole reason this is a function and not five lines inside a command.
 fn panel_geometry(content: f64, icon_top: f64, icon_height: f64, area: Option<(f64, f64)>) -> PanelGeom {
-    let Some((area_top, area_bottom)) = area else {
-        // Nothing to respect, so honour the content in full and grow down, as this did before it
-        // knew about edges.
-        return PanelGeom { top: icon_top + icon_height, height: content.max(PANEL_MIN_H), grows_up: false };
+    let up = grows_up(icon_top, icon_height, area);
+    let room = match area {
+        Some((area_top, area_bottom)) => {
+            (if up { icon_top - area_top } else { area_bottom - icon_top - icon_height }) - PANEL_MARGIN
+        }
+        // Nothing to respect, so honour the content in full.
+        None => f64::INFINITY,
     };
-    let grows_up = icon_top + icon_height / 2.0 > (area_top + area_bottom) / 2.0;
-    let room = (if grows_up { icon_top - area_top } else { area_bottom - icon_top - icon_height }) - PANEL_MARGIN;
-    // `min` then `max`, never `clamp`: with less room than the floor the range inverts, and
-    // `clamp` panics on an inverted range (the same trap the x position already documents).
-    let height = content.min(room).max(PANEL_MIN_H);
-    let top = if grows_up { icon_top - height } else { icon_top + icon_height };
-    PanelGeom { top, height, grows_up }
+    let height = fitted_height(content, room);
+    PanelGeom { top: panel_top(height, icon_top, icon_height, up), height, grows_up: up }
+}
+
+/// The height a popover takes for `content` with `room` in the direction it grows.
+///
+/// One function because two callers need the rule and it has a trap in it: `min` then `max`, never
+/// `clamp` — with less room than the floor the range inverts, and `clamp` panics on an inverted
+/// range. A tray that panics is a tray that disappears.
+fn fitted_height(content: f64, room: f64) -> f64 {
+    content.min(room).max(PANEL_MIN_H)
+}
+
+/// Which way the popover opens. `None` — no monitor answered — grows down, as this did before it
+/// knew about edges.
+fn grows_up(icon_top: f64, icon_height: f64, area: Option<(f64, f64)>) -> bool {
+    match area {
+        Some((area_top, area_bottom)) => icon_top + icon_height / 2.0 > (area_top + area_bottom) / 2.0,
+        None => false,
+    }
+}
+
+/// The top edge of a popover `height` tall, opening `up` or down from the icon.
+///
+/// Separate from {@link panel_geometry} because the click that opens the panel does NOT know the
+/// content height and must not guess at one: it places the window at the size it already has. Asking
+/// for a clamped height there and applying it made the panel ratchet DOWN and never back up — the
+/// clamped result became the next open's stand-in, and `fit()` caches the height it asked for
+/// (`ui/panel.ts`), so unchanged content never calls `resize` to correct it.
+fn panel_top(height: f64, icon_top: f64, icon_height: f64, up: bool) -> f64 {
+    if up { icon_top - height } else { icon_top + icon_height }
 }
 
 /// The vertical bounds of a monitor's work area, in logical points, or `None` when none answered.
@@ -262,18 +289,12 @@ fn toggle_panel(app: &AppHandle, rect: Rect) {
         };
         let icon_anchor =
             IconAnchor { x: anchor.x / scale, top: anchor.y / scale, height: icon.height / scale };
-        // The window's CURRENT height stands in for the content until the webview measures itself
-        // and calls `resize`; both the position AND the size are applied, since a panel placed as
-        // if it had been clamped while keeping its old height would hang over the icon it opened
-        // from.
-        let geom = panel_geometry(
-            size.height as f64 / scale,
-            icon_anchor.top,
-            icon_anchor.height,
-            work_area_v(mon.as_ref(), scale),
-        );
-        let _ = win.set_position(PhysicalPosition::new(x, geom.top * scale));
-        let _ = win.set_size(tauri::LogicalSize::new(size.width as f64 / scale, geom.height));
+        // Placed at the size it ALREADY has, and never resized here: the click does not know the
+        // content height, and a clamped guess would become the next open's stand-in and ratchet the
+        // panel down for good. `resize` is what fits it, the moment the webview has measured itself.
+        let up = grows_up(icon_anchor.top, icon_anchor.height, work_area_v(mon.as_ref(), scale));
+        let top = panel_top(size.height as f64 / scale, icon_anchor.top, icon_anchor.height, up);
+        let _ = win.set_position(PhysicalPosition::new(x, top * scale));
         if let Some(state) = app.try_state::<Mutex<Option<IconAnchor>>>() {
             if let Ok(mut slot) = state.lock() {
                 *slot = Some(icon_anchor);
@@ -496,11 +517,14 @@ fn resize(height: f64, app: AppHandle) -> Result<f64, String> {
         }
         // Nothing has been opened from the icon yet, so there is no anchor to keep: hold the top
         // where it is and grow down, which is what this command did before it knew about edges.
+        // Expressed through the same function rather than repeating its clamp — an icon of zero
+        // height at the window's own top is exactly "grow down from here", and the arithmetic that
+        // must never become `clamp` then lives in one place.
         None => {
             let top = pos.to_logical::<f64>(scale).y;
             let mon = win.monitor_from_point(f64::from(pos.x), f64::from(pos.y)).ok().flatten();
             let bottom = work_area_v(mon.as_ref(), scale).map_or(f64::INFINITY, |(_, b)| b);
-            PanelGeom { top, height: height.min(bottom - top - PANEL_MARGIN).max(PANEL_MIN_H), grows_up: false }
+            PanelGeom { top, height: fitted_height(height, bottom - top - PANEL_MARGIN), grows_up: false }
         }
     };
     // Position first: growing upward, moving after resizing would put the bottom edge through the
@@ -702,6 +726,11 @@ fn main() {
                 // open question. `println!` stays for the macOS run, where a terminal is how this
                 // is used.
                 println!("NOTIFY_PROBE: {outcome:?}");
+                // The directory is created here because nothing else has yet: Tauri does not make
+                // `app_config_dir`, and the two places that do are save paths that have not run on
+                // a fresh install. Without it the write fails with NotFound on exactly the first
+                // run the file exists for.
+                let _ = std::fs::create_dir_all(&config_dir);
                 let _ = std::fs::write(config_dir.join(NOTIFY_PROBE_OUT), format!("{outcome:?}\n"));
             }
             Ok(())
@@ -722,7 +751,7 @@ fn main() {
 
 #[cfg(test)]
 mod tests {
-    use super::{config_root, panel_geometry, PANEL_MARGIN, PANEL_MIN_H};
+    use super::{config_root, panel_geometry, panel_top, PANEL_MARGIN, PANEL_MIN_H};
     use std::path::PathBuf;
 
     // The default, and the only one a user ever takes: the app's own directory, untouched.
@@ -830,6 +859,17 @@ mod tests {
         assert!(geom.grows_up);
         assert_eq!(geom.height, PANEL_MIN_H);
         assert!(geom.top < 0.0, "it overhangs the top rather than vanishing: {}", geom.top);
+    }
+
+    // The ratchet, as arithmetic. Asking the clamped rule for a height at open time made the
+    // clamped result the NEXT open's stand-in, so the panel could only ever shrink — and `fit()`
+    // caches the height it asked for, so unchanged content never calls `resize` to undo it. The
+    // click uses `panel_top` with the height the window HAS, so nothing feeds back into itself.
+    #[test]
+    fn the_open_time_placement_does_not_clamp() {
+        let (t, h, area) = TASKBAR_BOTTOM;
+        assert!(panel_geometry(2000.0, t, h, area).height < 2000.0, "the fitting rule does clamp");
+        assert_eq!(panel_top(2000.0, t, h, true), t - 2000.0, "the placement rule does not");
     }
 
     // No monitor answered. Expressed as its own branch and not as an infinite work area: infinities

--- a/apps/tray/src-tauri/src/main.rs
+++ b/apps/tray/src-tauri/src/main.rs
@@ -1,3 +1,12 @@
+// A tray app has no console, and Windows gives it one unless it is told otherwise: without this the
+// release binary is linked as a console subsystem application, so launching `seedeep-tray` opens a
+// terminal window that sits there for the life of the app. Observed on Windows 11 arm64,
+// 2026-08-14. It is the line Tauri's own template carries and this crate never had.
+//
+// `not(debug_assertions)` so a debug build keeps its console, which is where a panic goes; the
+// attribute means nothing on macOS and Linux, where rustc ignores it.
+#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
+
 mod client;
 mod connection;
 mod icon;
@@ -51,6 +60,13 @@ const SHOW_PANEL: &str = "SEEDEEP_TRAY_SHOW_PANEL";
 /// terminal's environment nor `launchctl setenv` (measured 2026-08-04 — the variable was simply
 /// absent). A file is the only channel into a process nobody can hand arguments to.
 const LOCATE_PROBE: &str = "locate-probe";
+
+/// Where {@link NOTIFY_PROBE} leaves its answer, in the tray's config directory.
+///
+/// A file because the release build has no console on Windows — see the subsystem attribute at the
+/// top of this file — and Windows is exactly where the question *"is a banner delivered at all?"* is
+/// still open. Written on every probe run, on every platform, so the two agree.
+const NOTIFY_PROBE_OUT: &str = "notify-probe";
 
 /// The ONE variable that decides which seedeep this process belongs to.
 ///
@@ -590,7 +606,13 @@ fn main() {
                     .title("seedeep")
                     .body("Notification probe — this build is unsigned.")
                     .show();
+                // To a file BESIDE stdout, not instead of it: a release build has no console on
+                // Windows (the subsystem attribute at the top of this file), so a probe that only
+                // printed would be unreadable on the one platform whose notifications are the
+                // open question. `println!` stays for the macOS run, where a terminal is how this
+                // is used.
                 println!("NOTIFY_PROBE: {outcome:?}");
+                let _ = std::fs::write(config_dir.join(NOTIFY_PROBE_OUT), format!("{outcome:?}\n"));
             }
             Ok(())
         })

--- a/apps/tray/src-tauri/src/main.rs
+++ b/apps/tray/src-tauri/src/main.rs
@@ -16,7 +16,7 @@ mod poll;
 mod store;
 mod update;
 
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use client::{Conn, Status};
@@ -114,21 +114,70 @@ const PANEL_MIN_H: f64 = 90.0;
 /// way.
 const NOTIFY_SETTLE: Duration = Duration::from_millis(400);
 
-/// The height the popover should take to show `content`, given where its top edge is and how much
-/// screen there is below it.
+/// Where the OS last drew the tray icon, in logical points.
 ///
-/// Pure, and tested: the two failure modes are a window taller than the screen (the bottom of the
-/// list unreachable, since a popover cannot be dragged) and a window collapsed to nothing. Both are
-/// arithmetic, and neither is observable from an SSH shell — which is the whole reason this is a
-/// function and not three lines inside a command.
+/// Held because two things need the icon after the click that reported it: the edge {@link resize}
+/// keeps fixed — the BOTTOM one when the popover opens upward, which the window's own position
+/// cannot say — and the point the monitor is looked up from, which has to be the icon's because the
+/// window's may be off the screen.
+#[derive(Clone, Copy)]
+struct IconAnchor {
+    x: f64,
+    top: f64,
+    height: f64,
+}
+
+/// The popover's vertical geometry: where its top edge goes, how tall it is, and which way it grew.
+struct PanelGeom {
+    top: f64,
+    height: f64,
+    grows_up: bool,
+}
+
+/// Place and size the popover for an icon at `icon_top`/`icon_height` inside a work area spanning
+/// `area`, all in logical points. `None` is "no monitor answered", not "no room".
 ///
-/// `top` and `available_bottom` are in the same units as `content` (points). A screen with no room
-/// at all still yields {@link PANEL_MIN_H}: better a panel that overhangs than one that vanishes.
-fn panel_height(content: f64, top: f64, available_bottom: f64) -> f64 {
-    let room = available_bottom - top - PANEL_MARGIN;
+/// **Which way it opens is read off the icon, never off the platform.** The panel used to be
+/// anchored below the icon unconditionally, which is right for a menu bar — macOS always draws one
+/// as the top strip, so the icon's centre is always in the upper half and this returns exactly the
+/// behaviour that shipped. A Windows taskbar sits on any edge, and on three of the four the icons
+/// are in the LOWER half: anchoring below them put the panel's top edge at the bottom of the screen,
+/// which left it off-screen and, since the room below was then a few pixels, collapsed it to
+/// {@link PANEL_MIN_H} with the content scrolling inside. One cause, both symptoms, observed on
+/// Windows 11 arm64 on 2026-08-14.
+///
+/// The absent work area is its own branch rather than an infinite pair, and that is not tidiness: an
+/// infinite pair makes the midpoint `NaN`, every comparison with `NaN` is false, and the direction
+/// would silently fall back to downward — re-creating the bug on the one machine where the lookup
+/// fails, which is the machine whose window is off-screen.
+///
+/// Pure, and tested: the failure modes are a window taller than the screen (the bottom of the list
+/// unreachable, since a popover cannot be dragged), a window collapsed to nothing, an inverted range
+/// in either direction (`clamp` panics there; a tray that panics is a tray that disappears), and a
+/// window on the wrong side of its icon. All arithmetic, and none of it observable from an SSH
+/// shell — which is the whole reason this is a function and not five lines inside a command.
+fn panel_geometry(content: f64, icon_top: f64, icon_height: f64, area: Option<(f64, f64)>) -> PanelGeom {
+    let Some((area_top, area_bottom)) = area else {
+        // Nothing to respect, so honour the content in full and grow down, as this did before it
+        // knew about edges.
+        return PanelGeom { top: icon_top + icon_height, height: content.max(PANEL_MIN_H), grows_up: false };
+    };
+    let grows_up = icon_top + icon_height / 2.0 > (area_top + area_bottom) / 2.0;
+    let room = (if grows_up { icon_top - area_top } else { area_bottom - icon_top - icon_height }) - PANEL_MARGIN;
     // `min` then `max`, never `clamp`: with less room than the floor the range inverts, and
     // `clamp` panics on an inverted range (the same trap the x position already documents).
-    content.min(room).max(PANEL_MIN_H)
+    let height = content.min(room).max(PANEL_MIN_H);
+    let top = if grows_up { icon_top - height } else { icon_top + icon_height };
+    PanelGeom { top, height, grows_up }
+}
+
+/// The vertical bounds of a monitor's work area, in logical points, or `None` when none answered.
+fn work_area_v(mon: Option<&tauri::Monitor>, scale: f64) -> Option<(f64, f64)> {
+    let area = mon?.work_area();
+    Some((
+        f64::from(area.position.y) / scale,
+        f64::from(area.position.y + area.size.height as i32) / scale,
+    ))
 }
 
 /// Where the tray keeps `connection.json`: under {@link SEEDEEP_HOME} when that is set to something,
@@ -190,13 +239,16 @@ fn toggle_panel(app: &AppHandle, rect: Rect) {
         let anchor = rect.position.to_physical::<f64>(scale);
         let icon = rect.size.to_physical::<f64>(scale);
         let centred = anchor.x + icon.width / 2.0 - size.width as f64 / 2.0;
+        // The work area of the monitor UNDER THE ICON — `current_monitor` would answer for a
+        // window that is still hidden and has no position worth trusting. Asked once: both axes
+        // need it.
+        let mon = win.monitor_from_point(anchor.x, anchor.y).ok().flatten();
         // Merely centring hangs the panel off the screen: the menu bar's right-hand end is
         // where the icon usually sits, and a 392 pt panel centred there loses everything past
-        // the edge. Clamp to the work area of the monitor UNDER THE ICON — `current_monitor`
-        // would answer for a window that is still hidden and has no position worth trusting.
-        let x = match win.monitor_from_point(anchor.x, anchor.y) {
-            Ok(Some(mon)) => {
-                let area = mon.work_area();
+        // the edge.
+        let x = match &mon {
+            Some(m) => {
+                let area = m.work_area();
                 let margin = PANEL_MARGIN * scale;
                 let left = f64::from(area.position.x) + margin;
                 let right = f64::from(area.position.x + area.size.width as i32)
@@ -206,9 +258,27 @@ fn toggle_panel(app: &AppHandle, rect: Rect) {
                 // `right < left`, and `clamp` panics on an inverted range.
                 centred.min(right).max(left)
             }
-            _ => centred,
+            None => centred,
         };
-        let _ = win.set_position(PhysicalPosition::new(x, anchor.y + icon.height));
+        let icon_anchor =
+            IconAnchor { x: anchor.x / scale, top: anchor.y / scale, height: icon.height / scale };
+        // The window's CURRENT height stands in for the content until the webview measures itself
+        // and calls `resize`; both the position AND the size are applied, since a panel placed as
+        // if it had been clamped while keeping its old height would hang over the icon it opened
+        // from.
+        let geom = panel_geometry(
+            size.height as f64 / scale,
+            icon_anchor.top,
+            icon_anchor.height,
+            work_area_v(mon.as_ref(), scale),
+        );
+        let _ = win.set_position(PhysicalPosition::new(x, geom.top * scale));
+        let _ = win.set_size(tauri::LogicalSize::new(size.width as f64 / scale, geom.height));
+        if let Some(state) = app.try_state::<Mutex<Option<IconAnchor>>>() {
+            if let Ok(mut slot) = state.lock() {
+                *slot = Some(icon_anchor);
+            }
+        }
     }
     // Before the window, and harmless in every other case: the test notification hides the whole APP
     // to stop being frontmost (`test_notification`), and every window of a hidden app stays down
@@ -403,28 +473,45 @@ fn hand_to_browser(app: &AppHandle, url: String) -> Result<(), String> {
 /// Answers with the height actually applied, which is not always the one asked for: the panel needs
 /// to know when it was clamped, because that is exactly when its list has to scroll.
 ///
-/// Growing DOWNWARD only — the top edge is anchored under the tray icon and is never moved here. A
-/// popover that re-centred itself as its content changed would walk across the menu bar.
+/// **The anchored edge is the icon's, not the window's.** Growing downward the top never moves, as
+/// before; growing upward the BOTTOM edge is what stays put, so a taller panel moves as well as
+/// grows. The monitor is looked up from the ICON's point for the same reason: the window's may be
+/// off the screen — that is the state this whole change exists to repair — and a lookup that finds
+/// no monitor there would drop the direction back to downward and put it there again.
 #[tauri::command]
 fn resize(height: f64, app: AppHandle) -> Result<f64, String> {
     let win = app.get_webview_window(PANEL).ok_or("no panel window")?;
     let scale = win.scale_factor().map_err(|e| e.to_string())?;
     let size = win.inner_size().map_err(|e| e.to_string())?.to_logical::<f64>(scale);
-    let top = win.outer_position().map_err(|e| e.to_string())?.to_logical::<f64>(scale).y;
-    // The monitor under the popover's own top edge, not `primary_monitor`: a menu bar exists on
-    // every screen and the icon may well be on the second one.
-    let bottom = match win.monitor_from_point(top * scale, top * scale) {
-        Ok(Some(mon)) => {
-            let area = mon.work_area();
-            f64::from(area.position.y + area.size.height as i32) / scale
+    let pos = win.outer_position().map_err(|e| e.to_string())?;
+    let icon = app
+        .try_state::<Mutex<Option<IconAnchor>>>()
+        .and_then(|state| state.lock().ok().and_then(|slot| *slot));
+    let geom = match icon {
+        Some(icon) => {
+            // Not `primary_monitor`: a work area exists on every screen and the icon may well be
+            // on the second one.
+            let mon = win.monitor_from_point(icon.x * scale, icon.top * scale).ok().flatten();
+            panel_geometry(height, icon.top, icon.height, work_area_v(mon.as_ref(), scale))
         }
-        // No monitor to ask: honour the content rather than invent a ceiling for it.
-        _ => f64::INFINITY,
+        // Nothing has been opened from the icon yet, so there is no anchor to keep: hold the top
+        // where it is and grow down, which is what this command did before it knew about edges.
+        None => {
+            let top = pos.to_logical::<f64>(scale).y;
+            let mon = win.monitor_from_point(f64::from(pos.x), f64::from(pos.y)).ok().flatten();
+            let bottom = work_area_v(mon.as_ref(), scale).map_or(f64::INFINITY, |(_, b)| b);
+            PanelGeom { top, height: height.min(bottom - top - PANEL_MARGIN).max(PANEL_MIN_H), grows_up: false }
+        }
     };
-    let fitted = panel_height(height, top, bottom);
-    win.set_size(tauri::LogicalSize::new(size.width, fitted))
+    // Position first: growing upward, moving after resizing would put the bottom edge through the
+    // taskbar for a frame. Growing downward the top is already where it belongs and this is a no-op.
+    if geom.grows_up {
+        win.set_position(PhysicalPosition::new(f64::from(pos.x), geom.top * scale))
+            .map_err(|e| e.to_string())?;
+    }
+    win.set_size(tauri::LogicalSize::new(size.width, geom.height))
         .map_err(|e| e.to_string())?;
-    Ok(fitted)
+    Ok(geom.height)
 }
 
 /// Put the popover away, then post one notification.
@@ -518,6 +605,9 @@ fn main() {
             // guessing at a port.
             let local = Arc::new(LocalServer::new(local::seedeep_home(app.path().home_dir()?, home)));
             app.manage(local.clone());
+            // Empty until the first click on the icon; `resize` holds the window where it is
+            // until then, which is where it would sit anyway with nothing yet shown.
+            app.manage(Mutex::new(None::<IconAnchor>));
             // The connection is the app's, not a window's: it outlives the popover, which is
             // created and hidden repeatedly, and a per-window client would re-handshake on every
             // open. Shared with the poll, which reads through the same one so a tick and a click
@@ -632,7 +722,7 @@ fn main() {
 
 #[cfg(test)]
 mod tests {
-    use super::{config_root, panel_height, PANEL_MARGIN, PANEL_MIN_H};
+    use super::{config_root, panel_geometry, PANEL_MARGIN, PANEL_MIN_H};
     use std::path::PathBuf;
 
     // The default, and the only one a user ever takes: the app's own directory, untouched.
@@ -668,32 +758,90 @@ mod tests {
         assert!(resolved.ends_with(".seedeep-dev/tray"), "{resolved:?}");
     }
 
+    /// A macOS menu bar: a 24 pt icon strip above a work area that starts under it.
+    const MENU_BAR: (f64, f64, Option<(f64, f64)>) = (0.0, 24.0, Some((25.0, 1050.0)));
+    /// A Windows taskbar on the bottom edge: the work area stops above it, the icon sits below.
+    const TASKBAR_BOTTOM: (f64, f64, Option<(f64, f64)>) = (1038.0, 24.0, Some((0.0, 1032.0)));
+
     // The ordinary case, and the whole point of the clamp: a short screen gets a short window rather
     // than 360 pt of void under it.
     #[test]
     fn a_short_panel_is_as_tall_as_its_content() {
-        assert_eq!(panel_height(200.0, 40.0, 1000.0), 200.0);
+        let (t, h, area) = MENU_BAR;
+        let geom = panel_geometry(200.0, t, h, area);
+        assert_eq!(geom.height, 200.0);
+        assert_eq!(geom.top, 24.0, "flush under the icon");
+        assert!(!geom.grows_up);
     }
 
-    // A menu-bar popover cannot be dragged, so anything past the bottom of the screen is not merely
-    // ugly — it is unreachable. The list scrolls instead, which is why the applied height is
-    // returned to the panel.
+    // A popover cannot be dragged, so anything past the bottom of the screen is not merely ugly —
+    // it is unreachable. The list scrolls instead, which is why the applied height is returned to
+    // the panel.
     #[test]
     fn a_tall_panel_stops_at_the_bottom_of_the_screen() {
-        assert_eq!(panel_height(2000.0, 40.0, 1000.0), 1000.0 - 40.0 - PANEL_MARGIN);
+        let (t, h, area) = MENU_BAR;
+        assert_eq!(panel_geometry(2000.0, t, h, area).height, 1050.0 - (t + h) - PANEL_MARGIN);
     }
 
     // A webview that has not laid out yet reports 0. Collapsing the window to nothing would leave
     // no way to click the panel back, so the floor wins over an honest reading of an empty page.
     #[test]
     fn a_panel_never_collapses_to_nothing() {
-        assert_eq!(panel_height(0.0, 40.0, 1000.0), PANEL_MIN_H);
+        let (t, h, area) = MENU_BAR;
+        assert_eq!(panel_geometry(0.0, t, h, area).height, PANEL_MIN_H);
     }
 
-    // An icon low enough that the margin eats the whole screen inverts the range. `clamp` panics
-    // there; a tray that panics is a tray that disappears.
+    // The Windows defect, as arithmetic. Anchoring below a taskbar icon put the top edge at 1062 —
+    // off the bottom of a 1080 screen — and left about -30 pt of room, so the height collapsed to
+    // the floor and the content scrolled inside it. Both symptoms, one cause.
     #[test]
-    fn no_room_at_all_overhangs_rather_than_panicking() {
-        assert_eq!(panel_height(300.0, 990.0, 1000.0), PANEL_MIN_H);
+    fn an_icon_in_the_lower_half_opens_upward() {
+        let (t, h, area) = TASKBAR_BOTTOM;
+        let geom = panel_geometry(400.0, t, h, area);
+        assert!(geom.grows_up, "a taskbar icon is below its work area, so the panel goes up");
+        assert_eq!(geom.height, 400.0, "there is a whole screen above it — nothing to clamp");
+        assert_eq!(geom.top, t - 400.0, "the anchored edge is the BOTTOM, flush above the icon");
+    }
+
+    // The property that makes the change safe to ship: macOS draws its menu bar as the top strip and
+    // nothing else, so the icon is always in the upper half and this is the behaviour that shipped.
+    #[test]
+    fn a_menu_bar_icon_still_opens_downward() {
+        let (t, h, area) = MENU_BAR;
+        let geom = panel_geometry(400.0, t, h, area);
+        assert!(!geom.grows_up);
+        assert_eq!(geom.top, t + h);
+    }
+
+    // An inverted range panics under `clamp`, and a tray that panics is a tray that disappears. It
+    // is reachable in BOTH directions, so both are held: this is the downward one, an icon in the
+    // upper half of a work area too short for the floor.
+    #[test]
+    fn no_room_below_overhangs_rather_than_panicking() {
+        let geom = panel_geometry(300.0, 0.0, 4.0, Some((0.0, 60.0)));
+        assert!(!geom.grows_up);
+        assert_eq!(geom.height, PANEL_MIN_H);
+    }
+
+    // And the upward one, which overhangs the TOP of the screen rather than vanishing.
+    #[test]
+    fn no_room_above_overhangs_rather_than_panicking() {
+        let geom = panel_geometry(300.0, 56.0, 4.0, Some((0.0, 60.0)));
+        assert!(geom.grows_up);
+        assert_eq!(geom.height, PANEL_MIN_H);
+        assert!(geom.top < 0.0, "it overhangs the top rather than vanishing: {}", geom.top);
+    }
+
+    // No monitor answered. Expressed as its own branch and not as an infinite work area: infinities
+    // make the midpoint NaN, every comparison with NaN is false, and the direction would fall back
+    // to downward — putting the panel off-screen again on exactly the machine whose window is
+    // off-screen, which is where the lookup fails.
+    #[test]
+    fn no_monitor_honours_the_content_and_grows_down() {
+        let geom = panel_geometry(400.0, 1038.0, 24.0, None);
+        assert!(!geom.grows_up);
+        assert_eq!(geom.height, 400.0);
+        assert_eq!(geom.top, 1062.0);
+        assert!(geom.top.is_finite() && geom.height.is_finite(), "no NaN reaches the window");
     }
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable structural changes to seedeep are recorded here, newest first.
 
 ## Unreleased
 
+**The tray's popover opened off the bottom of the screen on Windows, and collapsed while it did.**
+The panel was anchored below the icon unconditionally — correct for a menu bar, which macOS always
+draws as the top strip, and wrong for a taskbar, which sits on any edge and puts its icons in the
+lower half on three of the four. The top edge landed below the taskbar, so the panel was off-screen;
+the room below it was then a few pixels, so the height collapsed to the 90 pt floor and the content
+scrolled inside. Two symptoms, one cause. The direction is now read off where the OS drew the icon
+inside the work area, so nothing about the platform is assumed, and a test holds the macOS behaviour
+still — which the rule guarantees by construction, since a menu-bar icon is always in the upper half.
+The absent work area is its own branch rather than an infinite pair: infinities make the midpoint
+`NaN`, every comparison with `NaN` is false, and the direction would have fallen back to downward on
+exactly the machine whose window is off the screen.
+
 **`restart` left the old server stopped and no replacement running, on Windows.** The handover
 spawns the successor and exits, and a Windows child stays in its parent's job object: it was
 terminated the moment the parent went, before writing a single line. `detached` is what breaks it

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,16 @@ The absent work area is its own branch rather than an infinite pair: infinities 
 `NaN`, every comparison with `NaN` is false, and the direction would have fallen back to downward on
 exactly the machine whose window is off the screen.
 
+**Every npm install on Windows was told its own launcher was a different seedeep.** Windows has no
+symlink for the PATH check to resolve: npm writes a `.cmd` into its global bin directory and lets it
+exec the binary under that directory's `node_modules`, so `…\npm\seedeep.cmd` and
+`…\npm\node_modules\seedeep\bin\seedeep.exe` never compared equal and `install-command` and `status`
+both warned that one install was two. That exact shape is now recognised — the `node_modules`
+segment is required rather than any ancestor, so a stray launcher cannot vouch for an unrelated
+binary — while a downloaded executable run from elsewhere still reports honestly, which is the case
+the warning exists for. Bun's layout on Windows is not covered: it has never been measured, and the
+code says so rather than guessing.
+
 **`restart` left the old server stopped and no replacement running, on Windows.** The handover
 spawns the successor and exits, and a Windows child stays in its parent's job object: it was
 terminated the moment the parent went, before writing a single line. `detached` is what breaks it

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable structural changes to seedeep are recorded here, newest first.
 
 ## Unreleased
 
+**What the CLI prints came out as mojibake on a Windows console.** A Windows console runs in a
+legacy code page unless something changes it, and seedeep writes UTF-8, so the em dash it separates
+its lines with arrived as `ΓÇö`. Five characters reach a console — `—`, `…`, `·`, `→`, `≥`, measured
+by reading what the commands actually emit rather than by counting source lines — and on Windows
+they are now spelled `-`, `...`, `-`, `->` and `>=` at the one place seedeep prints from. macOS and
+Linux keep the typography they render correctly, and are not wrapped at all. The `▲ ✓ 🔒 × ↔` in
+`core/` are untouched: they are rendered in the browser and the share card, where UTF-8 is not in
+question.
+
 **The tray's popover opened off the bottom of the screen on Windows, and collapsed while it did.**
 The panel was anchored below the icon unconditionally — correct for a menu bar, which macOS always
 draws as the top strip, and wrong for a taskbar, which sits on any edge and puts its icons in the

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable structural changes to seedeep are recorded here, newest first.
 
 ## Unreleased
 
+**Launching the tray on Windows opened a console window that stayed for the life of the app.** The
+line Tauri's own template carries — `windows_subsystem = "windows"` — had never been added, so the
+release binary was linked as a console subsystem application and Windows gave it a terminal.
+Invisible on macOS and Linux, where rustc ignores the attribute, which is how it got this far.
+Observed on Windows 11 arm64, 2026-08-14. The notification probe writes its outcome to a
+`notify-probe` file as well as printing it, since without a console the print was the only record of
+the one question Windows notifications still have open.
+
 ## 0.25.0 (2026-08-14)
 
 **A publish to npm that dies halfway can now be re-run.** The step published seven packages in a

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable structural changes to seedeep are recorded here, newest first.
 
 ## Unreleased
 
+**`restart` left the old server stopped and no replacement running, on Windows.** The handover
+spawns the successor and exits, and a Windows child stays in its parent's job object: it was
+terminated the moment the parent went, before writing a single line. `detached` is what breaks it
+out, and it is now passed **on Windows only** — on POSIX that flag is `setsid()`, so passing it
+everywhere would take the successor out of the terminal's session and leave a Ctrl-C reaching
+nothing and a closed terminal leaking an orphan on the port. Nothing there needs it; `unref()` plus
+adoption by init already outlives the parent. Measured on Windows 11 arm64, 2026-08-14, on the
+machine where `seedeep start` — which always passed the flag — survived ten starts of ten. Three
+surfaces, not one: `seedeep restart`, the portal's Restart button, and the restart after a
+configuration change. The command line and the flags now come from one exported `selfSpawnPlan`,
+because a test that injects `spawnSelf` can never see how the real one spawns, which is exactly
+where the defect lived.
+
 **Launching the tray on Windows opened a console window that stayed for the life of the app.** The
 line Tauri's own template carries — `windows_subsystem = "windows"` — had never been added, so the
 release binary was linked as a console subsystem application and Windows gave it a terminal.

--- a/docs/install.md
+++ b/docs/install.md
@@ -4,12 +4,12 @@
 a page in your browser — one process, no daemon, stopped with Ctrl-C. Two channels
 ship the same executable; a third runs it from a clone.
 
-> **Neither Windows build has ever been used on its own system** — x64 and arm64
-> alike are started by CI on a runner of their own architecture, and downloaded by you
-> first. The Linux arm64 build was used on Ubuntu 24 in a VM
-> (2026-08-14); the x64 build has been started but never used in front of a person.
+> **The Windows arm64 build has been used once**, in a VM (2026-08-14), which found four
+> defects in an evening; the **x64** build is started by CI on a runner of its own
+> architecture and has never been used in front of a person. The Linux arm64 build was
+> used on Ubuntu 24 in a VM (2026-08-14); its x64 build has been started, never used.
 > [Which platforms have actually been run](../README.md#which-platforms-have-actually-been-run)
-> says exactly what that covers.
+> says exactly what each of those covers.
 
 ## From npm — Node or Bun
 
@@ -150,6 +150,27 @@ The command file it writes calls `seedeep` **by name**, so the binary has to be 
 your PATH under that name. From npm it already is. From a downloaded file it is not
 until you move it there (see above) — otherwise `install-command` succeeds and
 `/seedeep` then fails with *command not found*.
+
+**On native Windows it needs one line of configuration.** The command file carries a
+single shell line, and Claude Code runs it in the shell it has: with Git Bash on the
+machine that is Bash, and without it the PowerShell tool, which splits that line into
+more than one operation and stops on the part it has no rule for. `/seedeep` then
+answers with a permission error naming the command instead of running it. Allow it once,
+in `%USERPROFILE%\.claude\settings.json`:
+
+```json
+{
+  "permissions": {
+    "allow": ["PowerShell(seedeep claude-code *)"]
+  }
+}
+```
+
+Restart Claude Code afterwards — settings are read at startup. If the file already
+exists, merge the `permissions` key into it rather than replacing the file. Installing
+[Git for Windows](https://git-scm.com/downloads/win) fixes it too, by giving Claude Code
+the Bash tool the line is written for. Inside WSL none of this applies: the shell there
+is already Bash.
 
 After that, any Claude Code session has these:
 

--- a/docs/tray.md
+++ b/docs/tray.md
@@ -372,13 +372,32 @@ the key; `Surface.putIfChanged` draws only on a different key. The forgetting is
 "Connecting…" is drawn unkeyed, so without it a connect that failed back to the same status would be
 skipped and the panel would sit on "Connecting…" for good.
 
-Left-click **toggles** a chromeless window anchored **under the icon's actual rectangle**, which
-the OS reports with the click. A menu bar reorders itself as other apps come and go, so a
-remembered position would drift.
+Left-click **toggles** a chromeless window anchored on **the icon's actual rectangle**, which the
+OS reports with the click. A menu bar reorders itself as other apps come and go, so a remembered
+position would drift.
 
 Centred on the icon, but **clamped to the work area of the monitor the icon is on**. The
 right-hand end of the menu bar is exactly where a tray icon sits, so a panel merely centred on
 it hangs off the edge of the screen.
+
+**Which way it opens is read off the icon, never off the platform.** If the icon's centre falls in
+the lower half of that work area the panel grows **upward**, with its BOTTOM edge flush above the
+icon; otherwise it grows downward from just below it, as it always has. A macOS menu bar is always
+the top strip, so the icon is always in the upper half and the direction there cannot change. A
+Windows taskbar sits on any edge, and on three of the four its icons are in the lower half —
+anchoring below them put the panel's top edge at the bottom of the screen, which left it off-screen
+and, since the room below was then a few pixels, collapsed it to the 90 pt floor with the content
+scrolling inside. One cause, both symptoms, observed on Windows 11 arm64 on 2026-08-14.
+
+Two consequences worth naming, because both were defects in the first attempt at this. The anchored
+edge is the icon's, not the window's: growing downward the top never moves, growing upward the panel
+has to move as well as grow, and the click that opens it applies BOTH the position and the size —
+a panel placed as if it had been clamped while keeping its old height hangs over the icon it opened
+from. And the monitor is looked up from the ICON's point, never the window's: the window may be off
+the screen, which is the state this repairs, and a lookup that found no monitor there would drop the
+direction back to downward and put it there again. `panel_geometry` is pure and carries the tests,
+including the one that holds the macOS behaviour still and the two that hold the inverted range in
+each direction — `clamp` panics on one, and a tray that panics is a tray that disappears.
 
 It also closes when it loses focus. A window with no title bar has no close button, so clicking
 anywhere else *is* the dismissal — the way a menu behaves.

--- a/docs/tray.md
+++ b/docs/tray.md
@@ -107,7 +107,7 @@ Two more variables exist for development and are never set for a user:
 
 | Variable | Effect |
 | -- | -- |
-| `SEEDEEP_TRAY_NOTIFY_PROBE` | Sends one notification at startup and prints the outcome. It exists so the finding in [Notifications](#notifications) can be re-measured on a later OS. |
+| `SEEDEEP_TRAY_NOTIFY_PROBE` | Sends one notification at startup, prints the outcome **and writes it to `notify-probe`** beside the connection file. It exists so the finding in [Notifications](#notifications) can be re-measured on a later OS. The file is what makes it readable on Windows, where a release build has no console to print to. |
 | `SEEDEEP_TRAY_SHOW_PANEL` | Shows the popover at startup, so the panel can be LOOKED at without a click on the menu bar — which is the one thing no test can perform. |
 
 `SEEDEEP_TRAY_STATE`, which forced an icon state, is gone: the icon now comes from the digest, and


### PR DESCRIPTION
One Windows session found four defects in an evening. Each is a commit of its own, so the
build that goes to the VM can be judged one fix at a time, and a fifth commit says in the
docs what that session actually covered.

The four are unrelated in cause and share only the platform:

| Commit | What was wrong |
|---|---|
| The tray no longer opens a console window | `windows_subsystem = "windows"` had never been added, so the release binary was linked as a console application |
| `restart` leaves a live replacement | a Windows child stays in its parent's job object and died with it; `detached` is now passed **on Windows only**, since on POSIX that flag is `setsid()` |
| The popover opens on the side that has room | it was anchored below the icon unconditionally — right for a menu bar, wrong for a taskbar, which put it off the bottom of the screen and collapsed it to the floor |
| An npm launcher is not a different seedeep | Windows has no symlink for the PATH check to resolve, so every npm install was warned that it was two |
| What the CLI prints is readable | five characters reach a console and a legacy code page renders none of them |

## What is verified, and what is not

Everything here is verified as far as a macOS machine can: 1679 TypeScript tests, 96 Rust
tests, `typecheck` and `lint` clean. Each fix carries a test that was confirmed to go **red**
with the fix disabled — a test that passes both ways is decoration.

Two of them additionally ran their real path rather than an injected one. `selfSpawnPlan()`
was executed with no injected dependencies and shown to carry no `detached` key on macOS.

**One claim in this branch is weaker than it looks, and a review caught it.** The ten-of-ten
evidence comes from `spawnDetachedServer`, which passes `stdio: ['ignore', fd, fd]` — a file.
The restart successor passes `['inherit','inherit','inherit']`, and on Windows `detached` means
`DETACHED_PROCESS`, so the child has no console of its own while holding handles to the parent's,
which is going away. That combination has never run anywhere. It is the FIRST thing to check on
the VM, and if the successor still dies the answer is probably to give it a file, exactly as the
working path does.
The console encoder was driven with the actual `usage()`, `versionLine()` and `runStatus()`
output through the real `console`: forced to `win32` it emitted 37 lines and zero non-ASCII
characters, and the same run on `darwin` kept `—`(15), `…`(1), `·`(1) — the control that
makes the first result mean anything.

**Nothing here has run on Windows.** The four defects were seen there; the four fixes have
not. What still needs a build somebody can start: the console window is gone, `restart`
leaves a server running, the popover appears on the right side **with the taskbar on all
four edges**, the false PATH warning is silent, and the output is legible.

## Two decisions taken deliberately

`localhost` stays what a loopback server advertises. Naming `127.0.0.1` instead would save
203–221 ms per request on Windows, measured, but the two are different browser origins and
the change would discard every existing user's saved tabs and token once.

The ASCII table covers five characters and not the twelve in the sources. The rest are
rendered in the browser and in the share card, where UTF-8 is not in question — measured by
reading what the commands emit rather than by counting source lines.

