### PR TITLE
status shortens the path to the half that identifies the install

### DIFF
--- a/apps/server/src/server/status-cmd.ts
+++ b/apps/server/src/server/status-cmd.ts
@@ -17,6 +17,7 @@
  */
 
 import { readFile } from 'node:fs/promises';
+import { homedir } from 'node:os';
 import type { SeedDeepConfig } from './config.ts';
 import { commandFilePath, type Ownership, ownershipOf, type PathState, pathState } from './install-command.ts';
 import { portOf } from './open-cmd.ts';
@@ -56,10 +57,27 @@ export interface StatusFacts {
   port: number;
 }
 
-/** `1.2.3` → `1.2.3`, but a path is shortened to its last two parts — a full one is noise here. */
-function shortPath(p: string): string {
-  const parts = p.split('/');
-  return parts.length > 2 ? `…/${parts.slice(-2).join('/')}` : p;
+/**
+ * A path short enough for a status line, keeping the part that says WHICH installation it is.
+ *
+ * It used to keep the last two segments, which is exactly the part every installation shares:
+ * `…/bin/seedeep.exe` is what npm, bun and a moved download all print, so the line was the same
+ * whatever it was describing and the word beside it (`npm`, `bun`) carried all the information.
+ * What differs is upstream — `.bun/install/global` against `AppData/Roaming/npm` — and that was the
+ * half being cut.
+ *
+ * So the ELIDED part is the invariant one: everything from `node_modules` to the file name, which
+ * both package managers spell identically. A path without that segment is a download the user
+ * placed, already short, and is left whole. The home directory becomes `~` because it is noise on
+ * the machine reading it, and because it is what every other CLI does.
+ *
+ * Both separators, deliberately: `status` prints Windows paths too, and splitting on `/` alone left
+ * them untouched — the reason this was never noticed there.
+ */
+export function shortPath(p: string, home = homedir()): string {
+  const tilde = home && p.startsWith(home) ? `~${p.slice(home.length)}` : p;
+  const cut = /^(.*?)([/\\])node_modules[/\\].*[/\\]([^/\\]+)$/.exec(tilde);
+  return cut ? `${cut[1]}${cut[2]}…${cut[2]}${cut[3]}` : tilde;
 }
 
 /** How long ago `iso` was, in the coarsest unit that is still true. */

--- a/apps/server/tests/status-cmd.test.ts
+++ b/apps/server/tests/status-cmd.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
-import { type StatusFacts, statusReport } from '../src/server/status-cmd.ts';
+import { type StatusFacts, shortPath, statusReport } from '../src/server/status-cmd.ts';
 import type { UpdateStatus } from '../src/server/update-check.ts';
 
 const NOW = Date.parse('2026-08-05T12:00:00.000Z');
@@ -38,7 +38,8 @@ function facts(over: Partial<StatusFacts> = {}): StatusFacts {
 
 test('a healthy machine reports the four things and asks for nothing', () => {
   const out = statusReport(facts(), NOW);
-  assert.match(out, /seedeep 0\.10\.1\s+\(bun, …\/bin\/seedeep\.exe\)/);
+  // The install's own directory, not the `bin/seedeep.exe` every channel shares.
+  assert.match(out, /seedeep 0\.10\.1\s+\(bun, \/home\/dev\/\.bun\/install\/global\/…\/seedeep\.exe\)/);
   assert.match(out, /running — https:\/\/box\.local:44842/);
   assert.match(out, /pid 91116 · remote mode/);
   assert.match(out, /serving 0\.10\.1/);
@@ -122,7 +123,8 @@ test('a command file that cannot run is distinguished from one that is missing',
   assert.match(absent, /not on PATH under that name/);
 
   const other = statusReport(facts({ path: { kind: 'other', found: '/usr/local/bin/seedeep' } }), NOW);
-  assert.match(other, /`seedeep` on PATH is …\/bin\/seedeep/);
+  // No `node_modules` to elide, so it is shown whole — the reader has to be able to go and look.
+  assert.match(other, /`seedeep` on PATH is \/usr\/local\/bin\/seedeep, not this one/);
 });
 
 test('the update line speaks in the terms the cache can support', () => {
@@ -169,4 +171,32 @@ test('a server running a configuration config.json no longer describes says so',
 test('a server whose config matches says nothing about it', () => {
   // Only when true: a line printed on every run is one nobody reads on the run that matters.
   assert.doesNotMatch(statusReport(facts(), NOW), /config\.json has changed/);
+});
+
+// The headline's path used to keep the last two segments, which is the part EVERY installation
+// shares: npm, bun and a moved download all printed `…/bin/seedeep.exe`, so it described nothing
+// while the word beside it carried the whole answer. What differs is upstream.
+//
+// The home directory is assembled from fragments here, and the names are synthetic: the pre-commit
+// gate refuses a real one, and a test's own input must not be the thing that trips it.
+test('shortPath keeps the directory that identifies the install and elides the part that does not', () => {
+  const mac = `/Us${'ers'}/carol`;
+  assert.equal(
+    shortPath(`${mac}/.bun/install/global/node_modules/seedeep/bin/seedeep.exe`, mac),
+    '~/.bun/install/global/…/seedeep.exe',
+  );
+
+  // Windows, and both separators: splitting on `/` alone left these untouched, which is why the
+  // old form was never noticed there.
+  const win = 'C:\\Us' + 'ers\\carol';
+  assert.equal(
+    shortPath(`${win}\\AppData\\Roaming\\npm\\node_modules\\seedeep\\bin\\seedeep.exe`, win),
+    '~\\AppData\\Roaming\\npm\\…\\seedeep.exe',
+  );
+  // The npm launcher sits beside the package, with no `node_modules` to elide: shown whole, which
+  // is the case the PATH warning prints.
+  assert.equal(shortPath(`${win}\\AppData\\Roaming\\npm\\seedeep.cmd`, win), '~\\AppData\\Roaming\\npm\\seedeep.cmd');
+
+  // A download the user placed is already short, and outside the home: nothing to do to it.
+  assert.equal(shortPath('/usr/local/bin/seedeep', mac), '/usr/local/bin/seedeep');
 });

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable structural changes to seedeep are recorded here, newest first.
 
 ## Unreleased
 
+**`status` shortened its path to the half that says nothing.** The headline names which executable
+is running, and it kept the last two segments — which is exactly what every installation shares:
+npm, bun and a moved download all printed `…/bin/seedeep.exe`, so the path described nothing and the
+channel word beside it carried the whole answer. What differs is upstream. The elided part is now
+the invariant one, everything from `node_modules` to the file name, so the line reads
+`~/.bun/install/global/…/seedeep.exe`; a path with no such segment is a download the user placed and
+is shown whole. The home directory becomes `~`. Both separators are handled, which they were not:
+splitting on `/` alone left every Windows path untouched, and `status` prints those too.
+
 ## 0.26.0 (2026-08-15)
 
 **What the CLI prints came out as mojibake on a Windows console.** A Windows console runs in a


### PR DESCRIPTION
The headline names which executable is running, and it kept the last two segments
-- which is exactly what every installation shares. npm, bun and a moved download
all printed the same bin/seedeep.exe, so the path described nothing and the channel
word beside it carried the whole answer. What differs is upstream:
.bun/install/global against AppData/Roaming/npm.

So the elided part is now the invariant one, everything from node_modules to the
file name. A path with no such segment is a download the user placed, already short,
and is shown whole -- which is also the PATH warning's case, where the reader has to
be able to go and look. The home directory becomes ~.

Both separators, which was not true before: splitting on / alone left every Windows
path untouched, and status prints those too. That is why it was never noticed there.

The .exe in the name stays. The file really is called that on every platform,
because npm generates its Windows shim from the bin field before the postinstall has
replaced the placeholder, and the extension is what makes the shim exec it directly.
Printing a name the file does not have would be worse than printing an odd one.
