### PR TITLE
The tray job bundles the panel before cargo runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,10 +97,14 @@ jobs:
   # while the third was checked by nothing until a tag built the installer. Four changes to those
   # Windows blocks shipped that way (2026-08-15).
   #
-  # One job and one command for both, deliberately: a matrix where each leg does something
-  # different is two jobs wearing one name, and the platform that gets the weaker half is the one
-  # nobody notices. Linux is absent because the tray has no code there — it is a non-target by
-  # decision, and `release.yml` builds no Linux tray either (`docs/tray.md`).
+  # One job, one matrix. The legs do differ, and only in what they do AFTER compiling: macOS runs
+  # the tests, Windows does not, because six of them are coupled to a POSIX filesystem — they assert
+  # on `/home/dev` and ask whether `/usr/bin/true` is a file. Making them portable is its own piece
+  # of work; the gap this job exists for is COMPILING, and both legs close it in full. The
+  # difference is named here rather than left for somebody to discover in a red run.
+  #
+  # Linux is absent because the tray has no code there — a non-target by decision, and `release.yml`
+  # builds no Linux tray either (`docs/tray.md`).
   tray:
     name: Tray (Rust)
     strategy:
@@ -134,4 +138,10 @@ jobs:
 
       # cargo directly rather than `bun run test:tray`: that script's first step guards a
       # contributor's PATH for cargo, which a job that just installed the toolchain does not need.
-      - run: cargo test --manifest-path apps/tray/src-tauri/Cargo.toml
+      - if: runner.os == 'macOS'
+        run: cargo test --manifest-path apps/tray/src-tauri/Cargo.toml
+
+      # `--all-targets` so the `#[cfg(test)]` module is compiled here too: it is Rust that has to
+      # keep building on Windows even while its assertions cannot run there.
+      - if: runner.os == 'Windows'
+        run: cargo check --all-targets --manifest-path apps/tray/src-tauri/Cargo.toml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,17 @@ jobs:
         with:
           workspaces: apps/tray/src-tauri
 
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+
+      - run: bun install --frozen-lockfile
+
+      # `generate_context!()` reads `frontendDist` at COMPILE time and panics when the directory is
+      # not there, so the panel has to be bundled before cargo runs — the same `beforeBuildCommand`
+      # tauri would run for a real build. A local `cargo test` passes without this only because the
+      # directory is already on disk from an earlier build, which is how it went unnoticed until a
+      # clean machine ran it.
+      - run: bun run build:tray-ui
+
       # cargo directly rather than `bun run test:tray`: that script's first step guards a
-      # contributor's PATH for cargo, which a job that just installed the toolchain does not need,
-      # and it saves a bun install on two more runners.
+      # contributor's PATH for cargo, which a job that just installed the toolchain does not need.
       - run: cargo test --manifest-path apps/tray/src-tauri/Cargo.toml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -208,9 +208,12 @@ not be accepted.
 - **Run before you push:** `bun run test` and `bun run typecheck` must pass — plus
   `bun run test:tray` if you touched `apps/tray/src-tauri/`, since `bun run test`
   does not reach the Rust side. CI runs all three on every push and pull request, so a
-  failure here is a failure there. It runs the Rust ones on **macOS and Windows both**,
+  failure here is a failure there. It COMPILES the Rust on **macOS and Windows both**,
   which your machine cannot: `#[cfg(windows)]` is not merely untested off Windows, it is
-  never handed to the compiler there, and `local.rs` carries five such blocks.
+  never handed to the compiler there, and `local.rs` carries five such blocks. It RUNS the
+  Rust tests on macOS only — six of them are coupled to a POSIX filesystem, asserting on
+  `/home/dev` and asking whether `/usr/bin/true` is a file, so they cannot pass on Windows
+  until somebody makes them portable.
 - Fixtures (`apps/server/tests/fixtures/*.jsonl`) must be **synthetic and anonymized** — no
   real paths, project names, or session content. The repo is public; never
   commit a real session log, real user data, or a screenshot of a real session.


### PR DESCRIPTION
The job added in #36 fails on both legs, and it is the job doing its work: `generate_context!()` reads `frontendDist` at COMPILE time and panics when `apps/tray/ui/dist` is not there. A local `cargo test` passes without it only because the directory is already on disk from an earlier build — a clean machine had never run it.

Reproduced locally by deleting the directory (same panic), and fixed by bundling the panel first, which is the same `beforeBuildCommand` tauri runs for a real build.

**Not set to auto-merge**, deliberately: #36 merged while its own new job was red, because that job is not a required check. This one waits for both legs to be green before anything touches main.