### PR TITLE
The tray's Rust tests pass on Windows too

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,11 +97,9 @@ jobs:
   # while the third was checked by nothing until a tag built the installer. Four changes to those
   # Windows blocks shipped that way (2026-08-15).
   #
-  # One job, one matrix. The legs do differ, and only in what they do AFTER compiling: macOS runs
-  # the tests, Windows does not, because six of them are coupled to a POSIX filesystem — they assert
-  # on `/home/dev` and ask whether `/usr/bin/true` is a file. Making them portable is its own piece
-  # of work; the gap this job exists for is COMPILING, and both legs close it in full. The
-  # difference is named here rather than left for somebody to discover in a red run.
+  # One job, one matrix, one command. Both legs compile and both run the tests: six of them used to
+  # be coupled to a POSIX filesystem — asserting on `/home/dev`, asking whether `/usr/bin/true` is a
+  # file — and this job is what found that, on its first run.
   #
   # Linux is absent because the tray has no code there — a non-target by decision, and `release.yml`
   # builds no Linux tray either (`docs/tray.md`).
@@ -138,10 +136,4 @@ jobs:
 
       # cargo directly rather than `bun run test:tray`: that script's first step guards a
       # contributor's PATH for cargo, which a job that just installed the toolchain does not need.
-      - if: runner.os == 'macOS'
-        run: cargo test --manifest-path apps/tray/src-tauri/Cargo.toml
-
-      # `--all-targets` so the `#[cfg(test)]` module is compiled here too: it is Rust that has to
-      # keep building on Windows even while its assertions cannot run there.
-      - if: runner.os == 'Windows'
-        run: cargo check --all-targets --manifest-path apps/tray/src-tauri/Cargo.toml
+      - run: cargo test --manifest-path apps/tray/src-tauri/Cargo.toml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -208,12 +208,13 @@ not be accepted.
 - **Run before you push:** `bun run test` and `bun run typecheck` must pass — plus
   `bun run test:tray` if you touched `apps/tray/src-tauri/`, since `bun run test`
   does not reach the Rust side. CI runs all three on every push and pull request, so a
-  failure here is a failure there. It COMPILES the Rust on **macOS and Windows both**,
+  failure here is a failure there. It runs the Rust ones on **macOS and Windows both**,
   which your machine cannot: `#[cfg(windows)]` is not merely untested off Windows, it is
-  never handed to the compiler there, and `local.rs` carries five such blocks. It RUNS the
-  Rust tests on macOS only — six of them are coupled to a POSIX filesystem, asserting on
-  `/home/dev` and asking whether `/usr/bin/true` is a file, so they cannot pass on Windows
-  until somebody makes them portable.
+  never handed to the compiler there, and `local.rs` carries five such blocks. So write a
+  Rust test that can pass on either — build paths from `std::env::temp_dir()` rather than
+  writing `/tmp/...` (which is not even absolute on Windows), create the files you assert
+  on instead of borrowing `/usr/bin/true`, and encode JSON rather than formatting a path
+  into a string literal, where a backslash is not an escape.
 - Fixtures (`apps/server/tests/fixtures/*.jsonl`) must be **synthetic and anonymized** — no
   real paths, project names, or session content. The repo is public; never
   commit a real session log, real user data, or a screenshot of a real session.

--- a/apps/tray/src-tauri/src/client.rs
+++ b/apps/tray/src-tauri/src/client.rs
@@ -1391,9 +1391,16 @@ mod tests {
     async fn a_stored_server_that_is_down_stays_stored() {
         let dir = std::env::temp_dir().join(format!("seedeep-tray-down-{}", std::process::id()));
         let store = connection::store_path(&dir);
-        // Port 1 needs no listener to be certain: it is reserved and privileged.
+        // A port the OS has just handed back, rather than port 1. The reasoning was "reserved and
+        // privileged, so nothing can be listening" — true, and not the same as "refuses". macOS
+        // refuses on port 1 at once; Windows says nothing and the connection runs into the timeout
+        // instead, which is a different message and a different branch. Binding and dropping proves
+        // the port is closed on the machine actually running this.
+        let closed = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = closed.local_addr().unwrap().port();
+        drop(closed);
         let target = Connection {
-            base_url: "http://127.0.0.1:1".into(),
+            base_url: format!("http://127.0.0.1:{port}"),
             fingerprint: None,
             token: Some("t".into()),
         };
@@ -1403,7 +1410,7 @@ mod tests {
 
         match status {
             Status::Offline { base_url, detail } => {
-                assert_eq!(base_url, "http://127.0.0.1:1");
+                assert_eq!(base_url, format!("http://127.0.0.1:{port}"));
                 // The panel prints this verbatim, so it is asserted as PROSE. The regression it
                 // guards: the innermost cause of a reqwest timeout is the phrase "deadline has
                 // elapsed" (measured on 0.13.4), which the panel used to show for the most likely

--- a/apps/tray/src-tauri/src/local.rs
+++ b/apps/tray/src-tauri/src/local.rs
@@ -214,6 +214,13 @@ fn is_local(base_url: &str) -> bool {
 /// so it takes an ephemeral one and gives it straight back; no crate is needed to enumerate
 /// interfaces, and nothing is asked of the network.
 fn names_this_machine(host: &str) -> bool {
+    // Rejected before the resolver, because the resolvers disagree about it: on Windows the empty
+    // host RESOLVES — to this machine — while macOS calls it an error, so without this the same
+    // malformed record is co-located on one platform and foreign on the other. Nothing is not a
+    // host anywhere, and the test said so before either resolver was asked.
+    if host.is_empty() {
+        return false;
+    }
     let Ok(addrs) = (host, 0u16).to_socket_addrs() else { return false };
     addrs.into_iter().any(|a| a.ip().is_loopback() || TcpListener::bind((a.ip(), 0)).is_ok())
 }
@@ -976,19 +983,19 @@ mod tests {
         std::process::id()
     }
 
+    // The bases come from `temp_dir()` rather than being written as `/home/dev`, and that is not
+    // cosmetic: `seedeep_home` makes the override ABSOLUTE, and `/tmp/elsewhere` is not an absolute
+    // path on Windows — it has no drive — so a literal turns the identity case into a resolution
+    // against the process's cwd and the assertion is about the machine that ran it.
     #[test]
     fn the_home_is_the_seedeep_directory_unless_the_variable_moves_it() {
-        assert_eq!(seedeep_home(PathBuf::from("/home/dev"), None), PathBuf::from("/home/dev/.seedeep"));
-        assert_eq!(
-            seedeep_home(PathBuf::from("/home/dev"), Some("/tmp/elsewhere".into())),
-            PathBuf::from("/tmp/elsewhere")
-        );
+        let home = std::env::temp_dir().join("seedeep-home");
+        let elsewhere = std::env::temp_dir().join("seedeep-elsewhere");
+        assert_eq!(seedeep_home(home.clone(), None), home.join(".seedeep"));
+        assert_eq!(seedeep_home(home.clone(), Some(elsewhere.clone().into())), elsewhere);
         // A script that exported the name and forgot the value must not point the tray at the
         // process's cwd — the same trap `config_root` documents for the tray's own files.
-        assert_eq!(
-            seedeep_home(PathBuf::from("/home/dev"), Some("".into())),
-            PathBuf::from("/home/dev/.seedeep")
-        );
+        assert_eq!(seedeep_home(home.clone(), Some("".into())), home.join(".seedeep"));
     }
 
     // Co-location is a fact about the address, and the four spellings of this machine all count.
@@ -1197,15 +1204,27 @@ mod tests {
     // `command -v` answers with a path, but an interactive shell is entitled to print its own
     // things first, and for a shell FUNCTION it prints the body instead. Only a file on disk is an
     // answer to where seedeep is.
+    // The file is CREATED rather than borrowed from the system, because `first_executable` asks the
+    // real filesystem and the two platforms have nothing in common to point it at: `/usr/bin/true`
+    // does not exist on Windows, and there a name also has to end in an extension `cmd` can run.
+    // `.exe` satisfies that and means nothing on unix, so one name serves both.
     #[test]
     fn only_a_real_file_counts_as_having_found_it() {
+        let dir = std::env::temp_dir().join(format!("seedeep-which-{}", std::process::id()));
+        fs::create_dir_all(&dir).unwrap();
+        let real = dir.join("seedeep.exe");
+        fs::write(&real, b"not really a program").unwrap();
+        let absent = dir.join("no-such-seedeep.exe");
+
         assert_eq!(first_executable(""), None);
         assert_eq!(first_executable("seedeep () {\n\techo hi\n}\n"), None);
-        assert_eq!(first_executable("/no/such/seedeep\n"), None);
+        assert_eq!(first_executable(&format!("{}\n", absent.display())), None, "a path is not a file");
+        // A login shell is entitled to print a motd, and the answer may be the second line.
         assert_eq!(
-            first_executable("Welcome back!\n  /usr/bin/true  \n/usr/bin/false\n"),
-            Some(PathBuf::from("/usr/bin/true"))
+            first_executable(&format!("Welcome back!\n  {}  \n{}\n", real.display(), absent.display())),
+            Some(real.clone())
         );
+        fs::remove_dir_all(&dir).ok();
     }
 
     /// Live: find the real seedeep through the user's own shell, start it, and stop it again.
@@ -1463,14 +1482,16 @@ mod tests {
         let cert = home.join("cert.pem");
         let body = base64::Engine::encode(&base64::engine::general_purpose::STANDARD, LEAF);
         fs::write(&cert, format!("-----BEGIN CERTIFICATE-----\n{body}\n-----END CERTIFICATE-----\n")).unwrap();
-        fs::write(
-            home.join("config.json"),
-            format!(
-                r#"{{"port":44842,"host":"0.0.0.0","auth":{{"token":"a-token"}},"tls":{{"commonName":"host.local","cert":"{}","key":"k"}}}}"#,
-                cert.display()
-            ),
-        )
-        .unwrap();
+        // Built with the JSON encoder rather than formatted into a string: a Windows path is full
+        // of backslashes, `\U` is not a JSON escape, and a hand-written literal produces a file the
+        // parser rejects — so `credentials()` returned nothing and the test blamed the code.
+        let config = serde_json::json!({
+            "port": 44842,
+            "host": "0.0.0.0",
+            "auth": { "token": "a-token" },
+            "tls": { "commonName": "host.local", "cert": cert, "key": "k" },
+        });
+        fs::write(home.join("config.json"), config.to_string()).unwrap();
 
         let known = LocalServer::new(home).credentials().expect("a config the tray can read");
 

--- a/apps/tray/src-tauri/src/main.rs
+++ b/apps/tray/src-tauri/src/main.rs
@@ -763,12 +763,13 @@ mod tests {
     // Under the home, not the home itself: one variable names one world, and the server keeps its
     // own state in the same directory — two apps writing over each other's files is what the
     // subdirectory rules out.
+    // From `temp_dir()` and not a `/tmp/...` literal: `config_root` makes the value ABSOLUTE, and
+    // a path with no drive is not absolute on Windows — the literal would be resolved against the
+    // process's cwd and the assertion would be about the machine that ran it.
     #[test]
     fn the_variable_wins_and_the_tray_gets_its_own_corner() {
-        assert_eq!(
-            config_root(Some("/tmp/dev-state".into()), PathBuf::from("/app/config")),
-            PathBuf::from("/tmp/dev-state/tray")
-        );
+        let dev = std::env::temp_dir().join("seedeep-dev-state");
+        assert_eq!(config_root(Some(dev.clone().into()), PathBuf::from("/app/config")), dev.join("tray"));
     }
 
     // A script that exported the name and forgot the value would otherwise scatter a token file

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable structural changes to seedeep are recorded here, newest first.
 
 ## Unreleased
 
+**The tray's Rust tests run on Windows too, and one of them was reporting a real defect.** Six could
+not pass there at all, and the CI job added a day earlier is what found them. Five were fixtures
+assuming a POSIX machine: `/tmp/...` is not an absolute path on Windows, so a literal turned an
+identity assertion into a resolution against the process's cwd; `/usr/bin/true` is not a file to
+point a lookup at, so the test creates one; a Windows path formatted into a JSON string literal is
+invalid, since `\U` is not an escape, so the config is encoded rather than written by hand; and
+"nothing is listening on port 1" is true everywhere while only macOS REFUSES there, Windows letting
+it run into the timeout instead — the port is now one the OS has just handed back and released.
+
+The sixth was the code. **An empty host RESOLVES on Windows, to this machine**, so
+`names_this_machine("")` answered yes there and no on macOS for the same malformed record. It is
+rejected before either resolver is asked now: nothing is not a host anywhere, which is what the test
+had been saying since before either resolver was consulted.
+
 **CI compiles the tray's Rust, on macOS and Windows both.** It compiled none of it before, on any
 platform: `apps/tray/src-tauri` was checked only because development happens on a Mac and somebody
 ran `cargo test`, and the `#[cfg(windows)]` half was checked by nothing at all until a tag built the


### PR DESCRIPTION
Six could not, and the job added yesterday is what found them. Five were fixtures
that assumed a POSIX machine:

- /tmp/... is not an ABSOLUTE path on Windows, and both seedeep_home and
  config_root make their override absolute -- so the literal turned an identity
  assertion into a resolution against the process's cwd. The bases come from
  temp_dir() now.
- first_executable asks the real filesystem, and /usr/bin/true is not on Windows
  where a name must also end in an extension cmd can run. The test creates its own
  file, named .exe, which satisfies that and means nothing on unix.
- A Windows path formatted into a JSON string literal is invalid -- \U is not an
  escape -- so the config the test wrote could not be parsed and credentials()
  returned nothing. It is encoded now.
- Nothing listens on port 1 anywhere, but only macOS REFUSES there; Windows says
  nothing and the connection runs into the timeout, which is a different branch and
  a different message. The port is one the OS has just handed back and released.

The sixth was the code, not the test. An empty host RESOLVES on Windows, to this
machine, so names_this_machine("") answered yes there and no on macOS for the same
malformed record. Rejected before either resolver is asked now.

Both legs of the job run cargo test again, which is what they were meant to do.
