### PR TITLE
Two tests picked ports in ways that made main go red at random

### DIFF
--- a/.github/scripts/smoke-server.test.ts
+++ b/.github/scripts/smoke-server.test.ts
@@ -39,6 +39,20 @@ Bun.serve({
  * `serve` is what the fake does with anything that is not `--version`, which is exactly the shape
  * the real binary has — so a script that stops calling one of them is caught here.
  */
+/**
+ * A port nothing is listening on, from the OS rather than from a guess.
+ *
+ * Bound and released: the window between here and the fake server binding it is a race in theory,
+ * and a far narrower one than choosing blind among 400 numbers on a machine that may already be
+ * running seedeep.
+ */
+function freePort(): number {
+  const probe = Bun.serve({ port: 0, hostname: '127.0.0.1', fetch: () => new Response('') });
+  const { port } = probe;
+  probe.stop(true);
+  return port;
+}
+
 function runSmoke(opts: { version: string; expected: string; serves?: boolean; env?: Record<string, string> }): {
   status: number | null;
   output: string;
@@ -60,7 +74,9 @@ ${opts.serves === false ? 'sleep 30' : `exec bun "${serverPath}" "$@"`}
     chmodSync(binPath, 0o755);
 
     // A port per run: these tests may share a machine with a seedeep someone is actually using.
-    const port = String(45100 + Math.floor(Math.random() * 400));
+    // ASKED for, not guessed: picking at random from a 400-wide range collides eventually, and it
+    // did — a CI run went red on `Is port 45440 in use?` with nothing wrong in the change under it.
+    const port = String(freePort());
     const res = spawnSync('bash', [SCRIPT, binPath, opts.expected, port], {
       encoding: 'utf8',
       env: { ...process.env, SMOKE_TIMEOUT_S: '3', ...opts.env },

--- a/apps/tray/src-tauri/src/client.rs
+++ b/apps/tray/src-tauri/src/client.rs
@@ -1391,11 +1391,9 @@ mod tests {
     async fn a_stored_server_that_is_down_stays_stored() {
         let dir = std::env::temp_dir().join(format!("seedeep-tray-down-{}", std::process::id()));
         let store = connection::store_path(&dir);
-        // A port the OS has just handed back, rather than port 1. The reasoning was "reserved and
-        // privileged, so nothing can be listening" — true, and not the same as "refuses". macOS
-        // refuses on port 1 at once; Windows says nothing and the connection runs into the timeout
-        // instead, which is a different message and a different branch. Binding and dropping proves
-        // the port is closed on the machine actually running this.
+        // A port the OS has just handed back and released. It is CLOSED, which is all this needs;
+        // whether the kernel then refuses or stays silent is the platform's business and not
+        // something to assert on — see the two sentences below.
         let closed = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
         let port = closed.local_addr().unwrap().port();
         drop(closed);
@@ -1414,9 +1412,18 @@ mod tests {
                 // The panel prints this verbatim, so it is asserted as PROSE. The regression it
                 // guards: the innermost cause of a reqwest timeout is the phrase "deadline has
                 // elapsed" (measured on 0.13.4), which the panel used to show for the most likely
-                // remote failure of all — a machine that had gone to sleep.
-                assert!(detail.contains("probably not running"), "{detail}");
+                // remote failure of all — a machine that had gone to sleep. THAT is the assertion,
+                // and it holds whichever way the connection ends.
                 assert!(!detail.contains("deadline"), "{detail}");
+                // Which of the two sentences appears is the kernel's answer, not seedeep's: macOS
+                // REFUSES on a closed port and the connect branch fires, while Windows drops the
+                // packets and the same port runs into the timeout instead — the reason this test
+                // passed on one machine and failed on the next until it stopped asserting an OS's
+                // manners. Both sentences are seedeep's, and neither leaks a library's phrasing.
+                assert!(
+                    detail.contains("probably not running") || detail.contains("may be asleep"),
+                    "{detail}"
+                );
             }
             other => panic!("expected Offline, got {other:?}"),
         }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable structural changes to seedeep are recorded here, newest first.
 
 ## Unreleased
 
+**Two tests picked ports in ways that made `main` go red at random.** Both were found by the runs on
+`main` itself, which are a second execution of the same commit a pull request already passed — a
+flake shows up there and nowhere else. The tray's offline test asserted WHICH friendly sentence a
+closed port produces, and that is the kernel's answer: macOS refuses and the connect branch fires,
+Windows drops the packets and the same port reaches the timeout. It asserts what belongs to seedeep
+now — that the prose is one of its own two sentences and never leaks the library's "deadline has
+elapsed". The smoke script's test chose its port at random from a 400-wide range and eventually
+collided, failing on `Is port 45440 in use?` with nothing wrong in the change beneath it; it asks
+the OS for a free one now.
+
 **The tray's Rust tests run on Windows too, and one of them was reporting a real defect.** Six could
 not pass there at all, and the CI job added a day earlier is what found them. Five were fixtures
 assuming a POSIX machine: `/tmp/...` is not an absolute path on Windows, so a literal turned an


### PR DESCRIPTION
Both were found by the runs on main, which execute the same commit a pull request
has already passed -- a flake appears there and nowhere else.

The tray's offline test asserted WHICH sentence a closed port produces. That is the
kernel's answer, not seedeep's: macOS refuses and the connect branch fires, Windows
drops the packets and the same port reaches the timeout instead. It now asserts what
is actually seedeep's -- that the prose is one of its own two sentences, and never
the library's "deadline has elapsed", which is the regression it was written for.

The smoke script's test chose a port at random from a 400-wide range, which collides
eventually and did: a run went red on `Is port 45440 in use?` with nothing wrong in
the change beneath it. It asks the OS for a free port now.
