### PR TITLE
A tick does not rebuild the panel under a pointer that is pressed

### DIFF
--- a/apps/tray/tests/panel-tick.test.ts
+++ b/apps/tray/tests/panel-tick.test.ts
@@ -226,3 +226,42 @@ test('starting the server from the field ends it', async () => {
 
   assert.equal(find('conn-input').length, 0, 'the form is still over a server that is running');
 });
+
+// A DOM click exists only when the press and the release land on the same element, and the live view
+// is redrawn unconditionally once a second. Roughly one press in ten therefore had its button
+// swapped out underneath it and produced nothing — reported on the settings button, Windows 11,
+// 2026-08-15. The reading is still taken while a pointer is down; only the drawing waits.
+/** The node the panel currently has on screen — identity is the assertion, not its contents. */
+function drawn(): unknown {
+  return (root as { children: unknown[] }).children[0];
+}
+
+test('a tick does not rebuild the panel under a pointer that is pressed', async () => {
+  await atScreen(CONNECTED);
+  const before = drawn();
+  assert.ok(before, 'the live view is up');
+
+  doc._fire('pointerdown', {});
+  await tick(CONNECTED);
+  assert.equal(drawn(), before, 'the surface was replaced under a press');
+
+  // The release does not draw either — that would race the click it exists to protect. The next
+  // tick does, which is at most a second away on a surface whose whole cadence is a second.
+  doc._fire('pointerup', {});
+  assert.equal(drawn(), before, 'nothing is scheduled on the release');
+  await tick(CONNECTED);
+  assert.notEqual(drawn(), before, 'the tick after the release draws again');
+});
+
+// A press released outside the panel, or taken away by the OS, must not leave the panel frozen —
+// that would be a worse bug than the one the hold fixes.
+test('a cancelled press does not freeze the panel', async () => {
+  await atScreen(CONNECTED);
+  const before = drawn();
+  doc._fire('pointerdown', {});
+  await tick(CONNECTED);
+  assert.equal(drawn(), before);
+  doc._fire('pointercancel', {});
+  await tick(CONNECTED);
+  assert.notEqual(drawn(), before, 'a cancelled press releases the hold');
+});

--- a/apps/tray/ui/panel.ts
+++ b/apps/tray/ui/panel.ts
@@ -120,6 +120,26 @@ let restartPending = false;
 let wasOpen = false;
 
 /**
+ * Whether a pointer is down on the panel right now.
+ *
+ * A DOM `click` exists only when the press and the release land on the SAME element, and the live
+ * view is drawn with `Surface.put` — an unconditional replace, every tick, because its data really
+ * does change each second. The settings button lives in that view's footer. With the popover open the poll ticks once a second and a click lasts
+ * about a tenth of that, so roughly one press in ten had its button swapped out underneath it and
+ * produced nothing at all — no action, no error, nothing to notice but a button that "sometimes does
+ * not work". Reported on Windows 11, 2026-08-15, on the settings button.
+ *
+ * The reading is still taken and still kept; only the DRAWING waits, which is the same bargain every
+ * other guard in {@link apply} strikes — the URL field, the trust prompt, the settings view. The
+ * next tick draws it, at most a second later, on a surface whose whole cadence is a second.
+ *
+ * Nothing is scheduled on the release, deliberately. Drawing there would race the click it exists to
+ * protect: `pointerup`, `mouseup` and `click` are dispatched in one sequence, and a callback queued
+ * in the middle of it can land before the handler the press was aimed at.
+ */
+let pressed = false;
+
+/**
  * Ask the server whether it is honouring `config.json`, and redraw only if the answer changed.
  *
  * Never over the settings view: nothing there moves on this clock, and a redraw would wipe a
@@ -296,6 +316,10 @@ function apply(tick: Tick): void {
   // that has to get through is a status that has stopped being connected, which `show` turns back
   // into the live path — everything else waits for the user to come back to the sessions.
   if (view === 'settings' && status.kind === 'connected') return;
+  // A click the user is in the middle of outlives the clock, for the same reason the field and the
+  // prompt above do: `show` swaps the surface, and a button replaced between the press and the
+  // release never becomes a click at all. Flushed by the release — see {@link pressed}.
+  if (pressed) return;
   show();
 }
 
@@ -529,3 +553,16 @@ void listen<Tick>('tick', (event) => apply(event.payload));
 window.addEventListener('focus', () => {
   if (!busy) void refresh();
 });
+
+// On `document` rather than on the panel, and both endings handled: a press that begins on a button
+// and is released off it, or cancelled by the OS taking the pointer away, has to clear the hold just
+// the same — a panel frozen because nobody said the click was over would be a worse bug than the one
+// this fixes. `pointer*` and not `mouse*`: it is the family a webview reports for every input.
+document.addEventListener('pointerdown', () => {
+  pressed = true;
+});
+for (const ending of ['pointerup', 'pointercancel'] as const) {
+  document.addEventListener(ending, () => {
+    pressed = false;
+  });
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable structural changes to seedeep are recorded here, newest first.
 
 ## Unreleased
 
+**A button in the tray's panel sometimes did nothing when clicked.** A DOM click exists only when
+the press and the release land on the SAME element, and the live view is redrawn with an
+unconditional replace once a second — its data really does change that often. A press lasts about a
+tenth of that, so roughly one in ten had its button swapped out underneath it and produced no
+action, no error, and nothing to notice: reported on the settings button, whose home is that view's
+footer. The connection screens were never affected, since they draw only when their status changes.
+A tick arriving while a pointer is down now takes its reading and withholds only the DRAWING — the
+same bargain the URL field, the trust prompt and the settings view already strike against the same
+clock — and the next tick draws it, at most a second later. Nothing is scheduled on the release,
+deliberately: `pointerup`, `mouseup` and `click` are dispatched in one sequence, and drawing in the
+middle of it would race the click the hold exists to protect.
+
 **Two tests picked ports in ways that made `main` go red at random.** Both were found by the runs on
 `main` itself, which are a second execution of the same commit a pull request already passed — a
 flake shows up there and nowhere else. The tray's offline test asserted WHICH friendly sentence a


### PR DESCRIPTION
A DOM click exists only when the press and the release land on the SAME element,
and the live view is drawn with Surface.put -- an unconditional replace, every
second, because its data really does change that often. A press lasts about a tenth
of that, so roughly one in ten had its button swapped out underneath it and produced
no action, no error, and nothing to notice. Reported on the settings button, which
lives in that view's footer.

The connection screens were never affected: they go through putIfChanged and draw
only when their status changes. This is the live view's problem alone.

The reading is still taken and still kept; only the DRAWING waits, which is the same
bargain the URL field, the trust prompt and the settings view already strike against
the same clock. The next tick draws it, at most a second later, on a surface whose
whole cadence is a second.

Nothing is scheduled on the release, deliberately: pointerup, mouseup and click are
dispatched in one sequence, and a callback queued in the middle of it can land before
the handler the press was aimed at -- which would race the very click this protects.
A cancelled press releases the hold too, since a panel frozen because nobody said the
click was over would be worse than the bug being fixed.
