### PR TITLE
Nine corrections a review of the previous twelve commits found

### DIFF
--- a/.github/scripts/smoke-server.test.ts
+++ b/.github/scripts/smoke-server.test.ts
@@ -47,7 +47,9 @@ Bun.serve({
  * running seedeep.
  */
 function freePort(): number {
-  const probe = Bun.serve({ port: 0, hostname: '127.0.0.1', fetch: () => new Response('') });
+  // Bound the way the fake server binds — no hostname, so every interface — or a port free on
+  // loopback and taken on another one would be reported free and then fail to bind.
+  const probe = Bun.serve({ port: 0, fetch: () => new Response('') });
   const { port } = probe;
   probe.stop(true);
   return port;

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,13 +2,11 @@
 # CONTRIBUTING.md ("`bun run typecheck` must pass") were enforced by nothing, and the type-checker
 # was red on main while every local `bun test` stayed green.
 #
-# Two jobs rather than one, because the two failures mean different things and one must not hide
-# the other: `scan` guards what must never enter a public history, `check` guards whether the code
-# is correct. A leak is not a reason to stop reporting a broken test.
+# Three jobs rather than one, so a red check names what broke without anybody opening a log.
 #
-# The tray's Rust tests (`bun run test:tray`) are deliberately NOT here: building the Tauri crate on
-# a Linux runner needs system webkit packages, and a pipeline that is red for its own dependencies
-# teaches people to ignore red. Run them locally on macOS until that job is worth its setup.
+# The tray's Rust lives in the third: `cfg(windows)` code is not merely untested off Windows, it is
+# never handed to a compiler there, so the matrix runs both. Linux is absent from it because the
+# tray has no code for Linux — a non-target by decision (`docs/tray.md`), not a setup cost.
 name: CI
 
 on:

--- a/apps/server/src/server/console-encoding.ts
+++ b/apps/server/src/server/console-encoding.ts
@@ -26,10 +26,12 @@
  * `SetConsoleOutputCP` through FFI in a cross-compiled binary, and nothing here could verify it.
  */
 
-// LIMIT: seedeep's OWN typography only. The data it prints verbatim — commit subjects, card titles,
-// project paths, file names — can carry anything, and an accented directory or a curly apostrophe
-// still garbles on a legacy code page. Covering that needs the console's code page set to UTF-8
-// (`SetConsoleOutputCP` through FFI), which is declined above, not a longer table.
+// LIMIT: the table is seedeep's own typography, and it is applied to every string printed — the
+// data included. So a commit subject or a project path carrying one of these five is rewritten too,
+// which is harmless for a separator and a liberty on somebody else's text; while an accented
+// directory or a curly apostrophe, which are not in the table, still garbles. Both halves of that
+// need the console's code page set to UTF-8 (`SetConsoleOutputCP` through FFI), which is declined
+// above — a longer table would fix neither.
 /** What a legacy Windows console cannot show, and what it is spelled as instead. */
 const ASCII: ReadonlyArray<readonly [string, string]> = [
   ['—', '-'],
@@ -61,8 +63,16 @@ export interface ConsoleLike {
  * correctly should receive them. Strings only: an argument that is not a string was not encoded
  * here, and rewriting bytes it did not encode is how an encoder becomes a corruption.
  */
-export function useAsciiConsole(target: ConsoleLike = console, platform: string = process.platform): boolean {
-  if (platform !== 'win32') return false;
+export function useAsciiConsole(
+  target: ConsoleLike = console,
+  platform: string = process.platform,
+  isTty: boolean = process.stdout.isTTY === true,
+): boolean {
+  // A CONSOLE, not a redirect. The tray starts the server with its output going to `server.log`, and
+  // `seedeep start` does the same: those are UTF-8 files that no code page touches, and degrading
+  // them would be this module doing to a file what it exists to prevent on a terminal. It also
+  // keeps the rewrite off anything piped into another program.
+  if (platform !== 'win32' || !isTty) return false;
   for (const name of ['log', 'error', 'warn'] as const) {
     const original = target[name].bind(target);
     target[name] = (...args: unknown[]) => original(...args.map((a) => (typeof a === 'string' ? asciiFallback(a) : a)));

--- a/apps/server/src/server/server.ts
+++ b/apps/server/src/server/server.ts
@@ -828,8 +828,12 @@ export async function startServer(deps: ServerDeps): Promise<RunningServer> {
         // asked for the restart is one of them: the port would still be held. The response above
         // has already gone out — `restart-cmd` treats a connection dropped here as this request's
         // normal ending.
-        setTimeout(() => {
-          server.stop(true);
+        setTimeout(async () => {
+          // AWAITED. `stop` answers with a promise (`bun-types`, `serve.d.ts`) and its own docs say
+          // "it may take some time before all network activity stops" — so spawning on the next
+          // statement would be the same bet the old code made, just a shorter one. The point of
+          // this handover is that it does not depend on which of two processes is quicker.
+          await server.stop(true);
           spawnSelfFn();
           exitFn(0);
         }, 80);

--- a/apps/server/src/server/status-cmd.ts
+++ b/apps/server/src/server/status-cmd.ts
@@ -75,7 +75,13 @@ export interface StatusFacts {
  * them untouched — the reason this was never noticed there.
  */
 export function shortPath(p: string, home = homedir()): string {
-  const tilde = home && p.startsWith(home) ? `~${p.slice(home.length)}` : p;
+  // On a SEGMENT boundary, never a bare prefix. A home directory is not the parent of a sibling
+  // whose name merely starts with the same letters — `carolyn` beside `carol` — and the naive test
+  // spelled that sibling's files `~yn/bin/seedeep`, an address nobody can act on. Under a home of
+  // `/` it would have done that to every path on the machine.
+  const rest = home !== '' && p.startsWith(home) ? p.slice(home.length) : null;
+  const inside = rest !== null && (rest === '' || rest.startsWith('/') || rest.startsWith('\\'));
+  const tilde = inside ? `~${rest}` : p;
   const cut = /^(.*?)([/\\])node_modules[/\\].*[/\\]([^/\\]+)$/.exec(tilde);
   return cut ? `${cut[1]}${cut[2]}…${cut[2]}${cut[3]}` : tilde;
 }

--- a/apps/server/tests/console-encoding.test.ts
+++ b/apps/server/tests/console-encoding.test.ts
@@ -32,7 +32,7 @@ test('asciiFallback: the five measured characters, every occurrence', () => {
 // through these three methods and through nothing else.
 test('useAsciiConsole: log, error and warn are all translated on Windows', () => {
   const fake = fakeConsole();
-  assert.equal(useAsciiConsole(fake, 'win32'), true);
+  assert.equal(useAsciiConsole(fake, 'win32', true), true);
   fake.log('seedeep watching — url');
   fake.error('seedeep: pid 7 → 9');
   fake.warn('a … b');
@@ -44,16 +44,26 @@ test('useAsciiConsole: log, error and warn are all translated on Windows', () =>
 test('useAsciiConsole: off Windows it does not even wrap', () => {
   for (const platform of ['darwin', 'linux']) {
     const fake = fakeConsole();
-    assert.equal(useAsciiConsole(fake, platform), false, platform);
+    assert.equal(useAsciiConsole(fake, platform, true), false, platform);
     fake.log('seedeep watching — url');
     assert.deepEqual(fake.said, ['seedeep watching — url'], platform);
   }
 });
 
+// The tray starts the server with its output going to `server.log`, and `seedeep start` does the
+// same. Those are UTF-8 files no code page touches, so degrading them would be this module doing to
+// a file exactly what it exists to prevent on a terminal.
+test('useAsciiConsole: a redirect is left alone, console or not', () => {
+  const fake = fakeConsole();
+  assert.equal(useAsciiConsole(fake, 'win32', false), false);
+  fake.log('seedeep watching — url');
+  assert.deepEqual(fake.said, ['seedeep watching — url']);
+});
+
 // An encoder that rewrites what it did not encode is a corruption. Only strings are translated.
 test('useAsciiConsole: a non-string argument passes through untouched', () => {
   const fake = fakeConsole();
-  useAsciiConsole(fake, 'win32');
+  useAsciiConsole(fake, 'win32', true);
   const obj = { dash: '—' };
   fake.log(obj, 42);
   assert.deepEqual(fake.said, [obj, 42]);
@@ -65,7 +75,7 @@ test('useAsciiConsole: a non-string argument passes through untouched', () => {
 test('the help screen comes out pure ASCII on Windows', () => {
   assert.notEqual(nonAscii(usage()), '', 'the source text must contain some, or this proves nothing');
   const fake = fakeConsole();
-  useAsciiConsole(fake, 'win32');
+  useAsciiConsole(fake, 'win32', true);
   fake.log(usage());
   assert.equal(nonAscii(String(fake.said[0])), '');
 });

--- a/apps/server/tests/status-cmd.test.ts
+++ b/apps/server/tests/status-cmd.test.ts
@@ -19,7 +19,10 @@ function facts(over: Partial<StatusFacts> = {}): StatusFacts {
   return {
     version: '0.10.1',
     channel: { kind: 'bun', command: 'bun install -g seedeep --trust' },
-    execPath: '/home/dev/.bun/install/global/node_modules/seedeep/bin/seedeep.exe',
+    // Under /opt, which cannot be anybody's home: `statusReport` calls `shortPath` with the
+    // ambient `homedir()`, and the neutral placeholder this project prescribes elsewhere is a
+    // plausible container home — which would have turned this assertion into `~/...`.
+    execPath: '/opt/seedeep/.bun/install/global/node_modules/seedeep/bin/seedeep.exe',
     server: {
       kind: 'up',
       record: { pid: 91116, baseUrl: 'https://box.local:44842' },
@@ -39,7 +42,7 @@ function facts(over: Partial<StatusFacts> = {}): StatusFacts {
 test('a healthy machine reports the four things and asks for nothing', () => {
   const out = statusReport(facts(), NOW);
   // The install's own directory, not the `bin/seedeep.exe` every channel shares.
-  assert.match(out, /seedeep 0\.10\.1\s+\(bun, \/home\/dev\/\.bun\/install\/global\/…\/seedeep\.exe\)/);
+  assert.match(out, /seedeep 0\.10\.1\s+\(bun, \/opt\/seedeep\/\.bun\/install\/global\/…\/seedeep\.exe\)/);
   assert.match(out, /running — https:\/\/box\.local:44842/);
   assert.match(out, /pid 91116 · remote mode/);
   assert.match(out, /serving 0\.10\.1/);

--- a/apps/tray/src-tauri/src/client.rs
+++ b/apps/tray/src-tauri/src/client.rs
@@ -1391,12 +1391,12 @@ mod tests {
     async fn a_stored_server_that_is_down_stays_stored() {
         let dir = std::env::temp_dir().join(format!("seedeep-tray-down-{}", std::process::id()));
         let store = connection::store_path(&dir);
-        // A port the OS has just handed back and released. It is CLOSED, which is all this needs;
-        // whether the kernel then refuses or stays silent is the platform's business and not
-        // something to assert on — see the two sentences below.
-        let closed = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
-        let port = closed.local_addr().unwrap().port();
-        drop(closed);
+        // Port 1 needs no listener to be certain: it is reserved and privileged, and no ephemeral
+        // allocation can ever land on it. Asking the OS for a free port and releasing it looked
+        // safer and is not — it leaves a window in which anything on a busy runner can take the
+        // number, and this test's own client draws from that same range. What was wrong here was
+        // never the port; it was asserting WHICH sentence a closed one produces.
+        let port = 1;
         let target = Connection {
             base_url: format!("http://127.0.0.1:{port}"),
             fingerprint: None,

--- a/apps/tray/src-tauri/src/main.rs
+++ b/apps/tray/src-tauri/src/main.rs
@@ -751,7 +751,7 @@ fn main() {
 
 #[cfg(test)]
 mod tests {
-    use super::{config_root, panel_geometry, panel_top, PANEL_MARGIN, PANEL_MIN_H};
+    use super::{config_root, panel_geometry, PANEL_MARGIN, PANEL_MIN_H};
     use std::path::PathBuf;
 
     // The default, and the only one a user ever takes: the app's own directory, untouched.
@@ -860,17 +860,6 @@ mod tests {
         assert!(geom.grows_up);
         assert_eq!(geom.height, PANEL_MIN_H);
         assert!(geom.top < 0.0, "it overhangs the top rather than vanishing: {}", geom.top);
-    }
-
-    // The ratchet, as arithmetic. Asking the clamped rule for a height at open time made the
-    // clamped result the NEXT open's stand-in, so the panel could only ever shrink — and `fit()`
-    // caches the height it asked for, so unchanged content never calls `resize` to undo it. The
-    // click uses `panel_top` with the height the window HAS, so nothing feeds back into itself.
-    #[test]
-    fn the_open_time_placement_does_not_clamp() {
-        let (t, h, area) = TASKBAR_BOTTOM;
-        assert!(panel_geometry(2000.0, t, h, area).height < 2000.0, "the fitting rule does clamp");
-        assert_eq!(panel_top(2000.0, t, h, true), t - 2000.0, "the placement rule does not");
     }
 
     // No monitor answered. Expressed as its own branch and not as an infinite work area: infinities

--- a/apps/tray/tests/panel-tick.test.ts
+++ b/apps/tray/tests/panel-tick.test.ts
@@ -29,9 +29,12 @@ let deliver: ((event: { payload: unknown }) => void) | undefined;
 let pending: unknown;
 
 mock.module('@tauri-apps/api/core', () => ({
-  invoke: async (name: string) => {
+  invoke: async (name: string, args?: unknown) => {
     if (name === 'tick' || name === 'look_again') return pending;
-    if (name === 'resize') return 200;
+    if (name === 'resize') {
+      resizes.push(args as { height: number });
+      return 200;
+    }
     if (name === 'restart_pending') return false;
     if (name === 'connect') {
       if ('err' in connectAnswer) throw new Error(connectAnswer.err);
@@ -49,6 +52,9 @@ mock.module('@tauri-apps/api/event', () => ({
 mock.module('@tauri-apps/api/app', () => ({ getVersion: async () => '0.0.0-test' }));
 
 await import('../ui/panel.ts');
+
+/** Every `resize` the panel asked Rust for, so a test can assert that it did or did not ask. */
+const resizes: Array<{ height: number }> = [];
 
 /** What `connect` answers with, so both endings of a submitted URL can be driven. */
 let connectAnswer: { ok: Status } | { err: string } = { err: 'not asked' };
@@ -264,4 +270,20 @@ test('a cancelled press does not freeze the panel', async () => {
   doc._fire('pointercancel', {});
   await tick(CONNECTED);
   assert.notEqual(drawn(), before, 'a cancelled press releases the hold');
+});
+
+// `fit` skips a resize whose natural height matches the last one it ASKED for, and that cache
+// outlives a close — the popover is hidden, never rebuilt. So a panel clamped once by a short screen
+// kept its clamped height on every later opening, list scrolling in the space it had been given.
+// The opening is the moment the geometry can have changed, and nothing else knows.
+test('reopening the popover asks for the height again', async () => {
+  await atScreen(CONNECTED);
+  resizes.length = 0;
+  // Same content, still open: nothing to ask for.
+  await tick(CONNECTED);
+  assert.deepEqual(resizes, [], 'an unchanged panel does not cross into Rust');
+
+  await tick(CONNECTED, false);
+  await tick(CONNECTED, true);
+  assert.equal(resizes.length, 1, 'the opening asks again, whatever it asked last time');
 });

--- a/apps/tray/ui/panel.ts
+++ b/apps/tray/ui/panel.ts
@@ -294,6 +294,12 @@ function apply(tick: Tick): void {
   // Asked on the EDGE of the popover opening, never every tick: the answer moves only when a human
   // edits config.json or saves the portal's panel, and one request per click is the whole cost.
   if (tick.open && !wasOpen) void askRestartPending();
+  // And the height is asked for again, on the same edge. `fit` skips a `resize` whose natural
+  // height matches the last one it ASKED for, and that cache outlives a close — the popover is
+  // hidden, never rebuilt. So a panel clamped once by a short screen kept its clamped height on
+  // every later opening, including on a screen with room, with its list scrolling in the space it
+  // had been given. The open is the moment the geometry can have changed; nothing else knows.
+  if (tick.open && !wasOpen) sentHeight = 0;
   wasOpen = tick.open;
   // A pending state belongs to the server that reported it. Pointed elsewhere — or at nothing —
   // the tray holds no claim about the new one until it has asked it.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable structural changes to seedeep are recorded here, newest first.
 
 ## Unreleased
 
+**Nine corrections a review of the previous twelve commits found.** Four were real: the restart
+handover called `stop(true)` and spawned on the next statement, but that call answers with a promise
+and its own docs say network activity may outlive it — so the fix billed as "deterministic rather
+than lucky" was still a bet, and is awaited now. The popover's height ratchet was moved rather than
+removed: `fit` skips a resize whose natural height matches the last one it ASKED for, and that cache
+outlives a close, so a panel clamped once by a short screen kept its clamped height on every later
+opening; the opening clears it. `status` abbreviated a home directory on a bare string prefix, so a
+sibling whose name merely STARTS with the home's — `carolyn` beside `carol` — came out as `~yn/…`,
+an address nobody can act on; and under a home of `/` it would have been every path on the machine.
+It tests a segment boundary now. And the Windows console encoder wrapped
+every write, including the server's redirect into `server.log` — a UTF-8 file that no code page
+touches — so it now applies to a terminal only.
+
+The rest were the record rather than the code. `docs/tray.md` still described the popover applying
+both position and size at open, which a commit in that range had deliberately stopped, and still
+called the tray's Windows side unverified after the README had been rewritten to say it was opened;
+it also never carried the rule that every process the tray starts there passes `CREATE_NO_WINDOW`.
+The CI workflow's own header said the tray's Rust tests were deliberately absent, one commit after
+adding them. A test asserted a one-line function against its own body and was deleted. One asserted
+a placeholder path everyone is told to use while reading the ambient home, so a container named
+that would have failed it. And the smoke probe bound loopback
+while the server it hands the port to binds every interface.
+
 **A button in the tray's panel sometimes did nothing when clicked.** A DOM click exists only when
 the press and the release land on the SAME element, and the live view is redrawn with an
 unconditional replace once a second — its data really does change that often. A press lasts about a

--- a/docs/tray.md
+++ b/docs/tray.md
@@ -389,11 +389,13 @@ anchoring below them put the panel's top edge at the bottom of the screen, which
 and, since the room below was then a few pixels, collapsed it to the 90 pt floor with the content
 scrolling inside. One cause, both symptoms, observed on Windows 11 arm64 on 2026-08-14.
 
-Two consequences worth naming, because both were defects in the first attempt at this. The anchored
-edge is the icon's, not the window's: growing downward the top never moves, growing upward the panel
-has to move as well as grow, and the click that opens it applies BOTH the position and the size —
-a panel placed as if it had been clamped while keeping its old height hangs over the icon it opened
-from. And the monitor is looked up from the ICON's point, never the window's: the window may be off
+Two consequences worth naming, because both were defects in earlier attempts at this. The anchored
+edge is the icon's, not the window's: growing downward the top never moves, while growing upward the
+panel has to move as well as grow. The click that opens it therefore PLACES but never sizes — it
+does not know the content height, and a clamped guess would become the next opening's stand-in and
+ratchet the panel down for good; the webview measures itself and `resize` fits it, and the opening
+clears the height cache so a panel clamped on a short screen asks again on a taller one. And the
+monitor is looked up from the ICON's point, never the window's: the window may be off
 the screen, which is the state this repairs, and a lookup that found no monitor there would drop the
 direction back to downward and put it there again. `panel_geometry` is pure and carries the tests,
 including the one that holds the macOS behaviour still and the two that hold the inverted range in
@@ -1141,7 +1143,16 @@ has given to something else, and picking either would be a signal sent to an unr
 
 Known limits, none of them silent:
 
-- **Windows is compiled but unverified.** `taskkill /F` is a hard stop — the server never runs its
+- **Windows: the tray was opened once, on arm64 (2026-08-14), and got no further than its popover.**
+That one look found two defects, both fixed: the popover opened off the bottom of the screen, and
+the app had no `windows_subsystem` attribute so launching it left a console window open. The icon's
+legibility, the animation's cost, notifications and the connection screen are all still unanswered,
+and the x64 build has never been run at all.
+
+**Every process the tray starts on Windows passes `CREATE_NO_WINDOW`.** A GUI application has no
+console, so Windows gives one to each console child it spawns and the user sees it flash: two of the
+three spawn sites were missing the flag, which is why it is one shared constant in `local.rs` rather
+than three literals — a fourth site cannot be added without meeting it. `taskkill /F` is a hard stop — the server never runs its
   shutdown path, so its record is left for the next start's sweep. Marked `// LIMIT:` at both sites.
   The lookup there also has a rule this platform does not need: `npm i -g` installs three shims and
   `where.exe` lists the extensionless sh script first, so only a file `cmd` can actually start —


### PR DESCRIPTION
Four were real.

The restart handover called stop(true) and spawned on the very next statement. That
call answers with a promise and its own docs say network activity may outlive it, so
the fix billed as deterministic rather than lucky was still a bet -- a shorter one.
It is awaited now.

The popover's height ratchet was MOVED, not removed. fit() skips a resize whose
natural height matches the last one it asked for, and that cache outlives a close
because the webview is hidden and never rebuilt -- so a panel clamped once by a short
screen kept its clamped height on every later opening, list scrolling in the room it
had been given. The opening clears the cache: it is the moment the geometry can have
changed, and nothing else knows.

status abbreviated a home on a bare string prefix, so a sibling whose name merely
starts with the same letters came out as a tilde followed by the remainder -- an
address nobody can act on -- and under a home of a single slash it would have been
every path on the machine. It tests a segment boundary now.

The Windows console encoder wrapped every write, the server's redirect into
server.log included. That is a UTF-8 file no code page touches, and degrading it
would be this module doing to a file what it exists to prevent on a terminal.

The rest were the record rather than the code: two passages of docs/tray.md that
described what the code had stopped doing and a state the README had superseded, plus
the CREATE_NO_WINDOW rule it never carried; the CI header that said the tray's Rust
was deliberately absent one commit after adding it; a test asserting a one-line
function against its own body, deleted; a fixture reading the ambient home while
asserting a placeholder path; and a smoke probe binding loopback while the server it
serves binds every interface.
