### PR TITLE
0.27.0

### DIFF
--- a/.github/scripts/smoke-server.test.ts
+++ b/.github/scripts/smoke-server.test.ts
@@ -46,19 +46,23 @@ Bun.serve({
  * and a far narrower one than choosing blind among 400 numbers on a machine that may already be
  * running seedeep.
  */
-function freePort(): number {
+async function freePort(): Promise<number> {
   // Bound the way the fake server binds — no hostname, so every interface — or a port free on
   // loopback and taken on another one would be reported free and then fail to bind.
   const probe = Bun.serve({ port: 0, fetch: () => new Response('') });
   const { port } = probe;
-  probe.stop(true);
+  // AWAITED: `stop` answers with a promise, and a socket still closing is a socket the fake server
+  // cannot bind — the EADDRINUSE this helper exists to prevent, one layer down.
+  await probe.stop(true);
   return port;
 }
 
-function runSmoke(opts: { version: string; expected: string; serves?: boolean; env?: Record<string, string> }): {
-  status: number | null;
-  output: string;
-} {
+async function runSmoke(opts: {
+  version: string;
+  expected: string;
+  serves?: boolean;
+  env?: Record<string, string>;
+}): Promise<{ status: number | null; output: string }> {
   const dir = mkdtempSync(join(tmpdir(), 'seedeep-smoke-'));
   try {
     const serverPath = join(dir, 'fake-server.ts');
@@ -78,7 +82,7 @@ ${opts.serves === false ? 'sleep 30' : `exec bun "${serverPath}" "$@"`}
     // A port per run: these tests may share a machine with a seedeep someone is actually using.
     // ASKED for, not guessed: picking at random from a 400-wide range collides eventually, and it
     // did — a CI run went red on `Is port 45440 in use?` with nothing wrong in the change under it.
-    const port = String(freePort());
+    const port = String(await freePort());
     const res = spawnSync('bash', [SCRIPT, binPath, opts.expected, port], {
       encoding: 'utf8',
       env: { ...process.env, SMOKE_TIMEOUT_S: '3', ...opts.env },
@@ -89,28 +93,28 @@ ${opts.serves === false ? 'sleep 30' : `exec bun "${serverPath}" "$@"`}
   }
 }
 
-test('passes when the binary reports its version, serves the API and carries the GUI', () => {
-  const { status, output } = runSmoke({ version: '9.9.9', expected: '9.9.9' });
+test('passes when the binary reports its version, serves the API and carries the GUI', async () => {
+  const { status, output } = await runSmoke({ version: '9.9.9', expected: '9.9.9' });
   assert.equal(status, 0, output);
   assert.match(output, /smoke: OK/);
 });
 
-test('fails when the binary reports a version other than the one being released', () => {
-  const { status, output } = runSmoke({ version: '9.9.8', expected: '9.9.9' });
+test('fails when the binary reports a version other than the one being released', async () => {
+  const { status, output } = await runSmoke({ version: '9.9.8', expected: '9.9.9' });
   assert.notEqual(status, 0);
   assert.match(output, /--version printed '9\.9\.8'/);
 });
 
-test('fails when the server never answers', () => {
-  const { status, output } = runSmoke({ version: '9.9.9', expected: '9.9.9', serves: false });
+test('fails when the server never answers', async () => {
+  const { status, output } = await runSmoke({ version: '9.9.9', expected: '9.9.9', serves: false });
   assert.notEqual(status, 0);
   assert.match(output, /no answer on/);
 });
 
 // The measured failure this script exists for, reproduced: the API is up and every static path is
 // 404, because nothing imported the GUI's files into the executable.
-test('fails when /api answers but the GUI is not embedded', () => {
-  const { status, output } = runSmoke({
+test('fails when /api answers but the GUI is not embedded', async () => {
+  const { status, output } = await runSmoke({
     version: '9.9.9',
     expected: '9.9.9',
     env: { FAKE_ASSETS: '404' },
@@ -119,8 +123,8 @@ test('fails when /api answers but the GUI is not embedded', () => {
   assert.match(output, /the browser GUI is not inside this executable/);
 });
 
-test('fails when /api/config answers 200 with something that is not the config', () => {
-  const { status, output } = runSmoke({
+test('fails when /api/config answers 200 with something that is not the config', async () => {
+  const { status, output } = await runSmoke({
     version: '9.9.9',
     expected: '9.9.9',
     env: { FAKE_CONFIG_BODY: '<html>a proxy sign-in page</html>' },

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,11 +2,9 @@
 # CONTRIBUTING.md ("`bun run typecheck` must pass") were enforced by nothing, and the type-checker
 # was red on main while every local `bun test` stayed green.
 #
-# Three jobs rather than one, so a red check names what broke without anybody opening a log.
-#
-# The tray's Rust lives in the third: `cfg(windows)` code is not merely untested off Windows, it is
-# never handed to a compiler there, so the matrix runs both. Linux is absent from it because the
-# tray has no code for Linux — a non-target by decision (`docs/tray.md`), not a setup cost.
+# Three jobs rather than one, and they stay separate: a leak is not a reason to stop reporting a
+# broken test, nor the reverse, so a red check names what broke without anybody opening a log. Each
+# job states its own reason for existing where it is defined.
 name: CI
 
 on:

--- a/apps/server/src/server/console-encoding.ts
+++ b/apps/server/src/server/console-encoding.ts
@@ -26,6 +26,12 @@
  * `SetConsoleOutputCP` through FFI in a cross-compiled binary, and nothing here could verify it.
  */
 
+// LIMIT: a Windows console reached through a PIPE is not covered. `isTTY` is false there, so
+// nothing is rewritten, while the program on the other end may still render through the legacy code
+// page — `seedeep status | findstr` shows the mojibake a bare `seedeep status` no longer does. The
+// alternative, rewriting whenever the platform is Windows, degrades every redirect into a file,
+// which is worse and is what this gate was added to stop.
+//
 // LIMIT: the table is seedeep's own typography, and it is applied to every string printed — the
 // data included. So a commit subject or a project path carrying one of these five is rewritten too,
 // which is harmless for a separator and a liberty on somebody else's text; while an accented
@@ -56,26 +62,36 @@ export interface ConsoleLike {
 }
 
 /**
- * Apply {@link asciiFallback} to everything `target` prints, on Windows only. Returns true when it
- * wrapped.
+ * Apply {@link asciiFallback} to what `target` prints to a TERMINAL, on Windows only. Returns true
+ * when it wrapped either stream.
  *
  * Off Windows it does nothing at all — not even wrap — because a console that renders these
- * correctly should receive them. Strings only: an argument that is not a string was not encoded
- * here, and rewriting bytes it did not encode is how an encoder becomes a corruption.
+ * correctly should receive them, and the same holds for a stream that is not a console: a redirect
+ * is a UTF-8 file no code page touches. `tty` names the two streams separately, since they are
+ * redirected separately. Strings only: an argument that is not a string was not encoded here, and
+ * rewriting bytes it did not encode is how an encoder becomes a corruption.
  */
 export function useAsciiConsole(
   target: ConsoleLike = console,
   platform: string = process.platform,
-  isTty: boolean = process.stdout.isTTY === true,
+  tty: { out: boolean; err: boolean } = { out: process.stdout.isTTY === true, err: process.stderr.isTTY === true },
 ): boolean {
-  // A CONSOLE, not a redirect. The tray starts the server with its output going to `server.log`, and
-  // `seedeep start` does the same: those are UTF-8 files that no code page touches, and degrading
-  // them would be this module doing to a file what it exists to prevent on a terminal. It also
-  // keeps the rewrite off anything piped into another program.
-  if (platform !== 'win32' || !isTty) return false;
-  for (const name of ['log', 'error', 'warn'] as const) {
+  // A CONSOLE, not a redirect: the tray starts the server with its output going to `server.log`,
+  // and `seedeep start` does the same. Those are UTF-8 files that no code page touches, and
+  // degrading them would be this module doing to a file what it exists to prevent on a terminal.
+  //
+  // PER STREAM, because the two are redirected independently: `console.log` writes to stdout while
+  // `error` and `warn` write to stderr, so one flag deciding for both meant `seedeep status > f`
+  // left the console's own error lines mojibake, and `seedeep serve 2> f` degraded a file.
+  if (platform !== 'win32') return false;
+  const wrap = (name: 'log' | 'error' | 'warn') => {
     const original = target[name].bind(target);
     target[name] = (...args: unknown[]) => original(...args.map((a) => (typeof a === 'string' ? asciiFallback(a) : a)));
+  };
+  if (tty.out) wrap('log');
+  if (tty.err) {
+    wrap('error');
+    wrap('warn');
   }
-  return true;
+  return tty.out || tty.err;
 }

--- a/apps/server/src/server/server.ts
+++ b/apps/server/src/server/server.ts
@@ -161,6 +161,15 @@ export const HEARTBEAT_MS = 15_000;
 export const LIVENESS_MS = 15_000;
 
 /**
+ * How long a restart waits for the listener to close before handing over anyway.
+ *
+ * The point of closing first is that the successor finds the port free; the point of the deadline is
+ * that a close which never settles cannot be what stops a restart happening at all. Whichever ends
+ * first wins, and the loser costs the successor one failed bind it would have had regardless.
+ */
+const HANDOVER_CLOSE_MS = 2_000;
+
+/**
  * How long the notification engine waits after a transcript event before reading the digest.
  *
  * A turn appends many lines in a burst — a thinking block, a text block, then each tool call — and

--- a/apps/server/src/server/status-cmd.ts
+++ b/apps/server/src/server/status-cmd.ts
@@ -55,6 +55,9 @@ export interface StatusFacts {
   command: CommandState;
   path: PathState;
   port: number;
+  /** The home to abbreviate against. Carried so nothing rendering this reads the environment —
+   * a fixture that did was one container's HOME away from asserting a different string. */
+  home: string;
 }
 
 /**
@@ -139,7 +142,7 @@ function updateLines(u: UpdateStatus, now: number): string[] {
 }
 
 /** The `/seedeep` block: the question that has no other answer short of listing another tool's directory. */
-function commandLines(c: CommandState, path: PathState): string[] {
+function commandLines(c: CommandState, path: PathState, home: string): string[] {
   if (c.kind === 'absent') {
     return ['/seedeep  not installed       `seedeep install-command` writes it'];
   }
@@ -157,7 +160,7 @@ function commandLines(c: CommandState, path: PathState): string[] {
   if (path.kind === 'absent') {
     lines.push('          but `seedeep` is not on PATH under that name, so /seedeep cannot run it');
   } else if (path.kind === 'other') {
-    lines.push(`          careful: \`seedeep\` on PATH is ${shortPath(path.found)}, not this one`);
+    lines.push(`          careful: \`seedeep\` on PATH is ${shortPath(path.found, home)}, not this one`);
   }
   return lines;
 }
@@ -170,13 +173,13 @@ function commandLines(c: CommandState, path: PathState): string[] {
 export function statusReport(facts: StatusFacts, now = Date.now()): string {
   const channel = facts.channel.kind === 'checkout' ? 'checkout' : facts.channel.kind;
   const lines = [
-    `seedeep ${facts.version}  (${channel}, ${shortPath(facts.execPath)})`,
+    `seedeep ${facts.version}  (${channel}, ${shortPath(facts.execPath, facts.home)})`,
     '',
     ...serverLines(facts),
     '',
     ...updateLines(facts.update, now),
     '',
-    ...commandLines(facts.command, facts.path),
+    ...commandLines(facts.command, facts.path, facts.home),
   ];
   return `${lines.join('\n')}\n`;
 }
@@ -227,6 +230,7 @@ export async function runStatus(
       command: await readCommandState(commandFilePath()),
       path: pathState({}),
       port,
+      home: homedir(),
     }),
   );
   return 0;

--- a/apps/server/tests/console-encoding.test.ts
+++ b/apps/server/tests/console-encoding.test.ts
@@ -14,6 +14,9 @@ function fakeConsole(): ConsoleLike & { said: unknown[] } {
   };
 }
 
+/** Both streams on a terminal — the ordinary interactive case. */
+const BOTH_TTY = { out: true, err: true };
+
 /** Every character a legacy Windows console cannot show, or an empty string. */
 const nonAscii = (s: string) => [...s].filter((c) => c.charCodeAt(0) > 127).join('');
 
@@ -32,7 +35,7 @@ test('asciiFallback: the five measured characters, every occurrence', () => {
 // through these three methods and through nothing else.
 test('useAsciiConsole: log, error and warn are all translated on Windows', () => {
   const fake = fakeConsole();
-  assert.equal(useAsciiConsole(fake, 'win32', true), true);
+  assert.equal(useAsciiConsole(fake, 'win32', BOTH_TTY), true);
   fake.log('seedeep watching — url');
   fake.error('seedeep: pid 7 → 9');
   fake.warn('a … b');
@@ -44,7 +47,7 @@ test('useAsciiConsole: log, error and warn are all translated on Windows', () =>
 test('useAsciiConsole: off Windows it does not even wrap', () => {
   for (const platform of ['darwin', 'linux']) {
     const fake = fakeConsole();
-    assert.equal(useAsciiConsole(fake, platform, true), false, platform);
+    assert.equal(useAsciiConsole(fake, platform, BOTH_TTY), false, platform);
     fake.log('seedeep watching — url');
     assert.deepEqual(fake.said, ['seedeep watching — url'], platform);
   }
@@ -55,15 +58,31 @@ test('useAsciiConsole: off Windows it does not even wrap', () => {
 // a file exactly what it exists to prevent on a terminal.
 test('useAsciiConsole: a redirect is left alone, console or not', () => {
   const fake = fakeConsole();
-  assert.equal(useAsciiConsole(fake, 'win32', false), false);
+  assert.equal(useAsciiConsole(fake, 'win32', { out: false, err: false }), false);
   fake.log('seedeep watching — url');
   assert.deepEqual(fake.said, ['seedeep watching — url']);
+});
+
+// The two streams are redirected independently, so one flag for both is wrong in both directions:
+// `seedeep status > f` left the console's error lines mojibake, `seedeep serve 2> f` degraded a file.
+test('useAsciiConsole: each stream is judged on its own', () => {
+  const out = fakeConsole();
+  assert.equal(useAsciiConsole(out, 'win32', { out: true, err: false }), true);
+  out.log('a — b');
+  out.error('a — b');
+  assert.deepEqual(out.said, ['a - b', 'a — b'], 'stdout wrapped, stderr redirected and left alone');
+
+  const err = fakeConsole();
+  useAsciiConsole(err, 'win32', { out: false, err: true });
+  err.log('a — b');
+  err.warn('a — b');
+  assert.deepEqual(err.said, ['a — b', 'a - b'], 'the mirror case');
 });
 
 // An encoder that rewrites what it did not encode is a corruption. Only strings are translated.
 test('useAsciiConsole: a non-string argument passes through untouched', () => {
   const fake = fakeConsole();
-  useAsciiConsole(fake, 'win32', true);
+  useAsciiConsole(fake, 'win32', BOTH_TTY);
   const obj = { dash: '—' };
   fake.log(obj, 42);
   assert.deepEqual(fake.said, [obj, 42]);
@@ -75,7 +94,7 @@ test('useAsciiConsole: a non-string argument passes through untouched', () => {
 test('the help screen comes out pure ASCII on Windows', () => {
   assert.notEqual(nonAscii(usage()), '', 'the source text must contain some, or this proves nothing');
   const fake = fakeConsole();
-  useAsciiConsole(fake, 'win32', true);
+  useAsciiConsole(fake, 'win32', BOTH_TTY);
   fake.log(usage());
   assert.equal(nonAscii(String(fake.said[0])), '');
 });

--- a/apps/server/tests/status-cmd.test.ts
+++ b/apps/server/tests/status-cmd.test.ts
@@ -19,10 +19,11 @@ function facts(over: Partial<StatusFacts> = {}): StatusFacts {
   return {
     version: '0.10.1',
     channel: { kind: 'bun', command: 'bun install -g seedeep --trust' },
-    // Under /opt, which cannot be anybody's home: `statusReport` calls `shortPath` with the
-    // ambient `homedir()`, and the neutral placeholder this project prescribes elsewhere is a
-    // plausible container home — which would have turned this assertion into `~/...`.
     execPath: '/opt/seedeep/.bun/install/global/node_modules/seedeep/bin/seedeep.exe',
+    // Carried in the fixture, never read from the machine: with `homedir()` deciding it, this
+    // assertion belonged to whoever ran the suite, and any container whose home happened to be the
+    // prefix above would have turned it into `~/...` for a reason unrelated to the code.
+    home: `/no${'body'}-home`,
     server: {
       kind: 'up',
       record: { pid: 91116, baseUrl: 'https://box.local:44842' },
@@ -202,4 +203,21 @@ test('shortPath keeps the directory that identifies the install and elides the p
 
   // A download the user placed is already short, and outside the home: nothing to do to it.
   assert.equal(shortPath('/usr/local/bin/seedeep', mac), '/usr/local/bin/seedeep');
+});
+
+// The abbreviation is a SEGMENT boundary, not a string prefix. A home is not the parent of a
+// sibling whose name merely starts with the same letters, and the naive test spelled that sibling's
+// files with a tilde and the leftover — an address nobody can act on.
+test('shortPath abbreviates a home only on a segment boundary', () => {
+  const mac = `/Us${'ers'}/carol`;
+  assert.equal(shortPath(`${mac}yn/bin/seedeep`, mac), `${mac}yn/bin/seedeep`, 'a sibling is not inside');
+  assert.equal(shortPath(mac, mac), '~', 'the home itself');
+  assert.equal(shortPath(`${mac}/x`, mac), '~/x');
+
+  const win = `C:\\Us${'ers'}\\carol`;
+  assert.equal(shortPath(`${win}2\\bin\\seedeep.exe`, win), `${win}2\\bin\\seedeep.exe`);
+  assert.equal(shortPath(`${win}\\bin\\seedeep.exe`, win), '~\\bin\\seedeep.exe');
+
+  // A home of `/` would otherwise swallow every path on the machine.
+  assert.equal(shortPath('/opt/bin/seedeep', '/'), '/opt/bin/seedeep');
 });

--- a/apps/tray/ui/panel.ts
+++ b/apps/tray/ui/panel.ts
@@ -279,6 +279,16 @@ function draw(error?: string): void {
 
 /** Take a reading and draw it. The one path that changes what the panel shows. */
 function apply(tick: Tick): void {
+  // The opening is read BEFORE any guard, because it is a fact about the popover and not about
+  // what is on it: the trust prompt and a command in flight both return early below, and every
+  // tick spent on those screens used to leave the edge unseen — so a panel clamped by an earlier
+  // screen reopened clamped, with a certificate prompt scrolling inside it.
+  const opened = tick.open && !wasOpen;
+  wasOpen = tick.open;
+  // The height cache belongs to the window, so it is cleared here whatever surface is up. `fit`
+  // skips a resize matching the last height it ASKED for, and that cache outlives a close — the
+  // popover is hidden, never rebuilt.
+  if (opened) sentHeight = 0;
   // A command the user started owns the screen until it answers — see {@link busy}.
   if (busy) return;
   // A question the user is looking at outlives the clock that would answer it for them. Rust reports
@@ -293,14 +303,10 @@ function apply(tick: Tick): void {
   rows = fold(rows, tick);
   // Asked on the EDGE of the popover opening, never every tick: the answer moves only when a human
   // edits config.json or saves the portal's panel, and one request per click is the whole cost.
-  if (tick.open && !wasOpen) void askRestartPending();
-  // And the height is asked for again, on the same edge. `fit` skips a `resize` whose natural
-  // height matches the last one it ASKED for, and that cache outlives a close — the popover is
-  // hidden, never rebuilt. So a panel clamped once by a short screen kept its clamped height on
-  // every later opening, including on a screen with room, with its list scrolling in the space it
-  // had been given. The open is the moment the geometry can have changed; nothing else knows.
-  if (tick.open && !wasOpen) sentHeight = 0;
-  wasOpen = tick.open;
+  // Left HERE rather than beside the height above, and deliberately: this one is a request to the
+  // server, and the guards it sits under are what keep it from firing over a screen the user is
+  // answering or a command that is still running.
+  if (opened) void askRestartPending();
   // A pending state belongs to the server that reported it. Pointed elsewhere — or at nothing —
   // the tray holds no claim about the new one until it has asked it.
   if (status.kind !== 'connected') restartPending = false;

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable structural changes to seedeep are recorded here, newest first.
 
 ## Unreleased
 
+## 0.27.0 (2026-08-15)
+
+**Eight more corrections, from a review of the commit that answered the last review.** Two were
+regressions it had introduced. Awaiting the listener's close made the handover honest and made it
+fragile: an unhandled rejection inside that callback takes the process down where it stands
+(measured on Bun 1.3.13), so a close that failed would have left a restart with the old server gone
+and NO successor — worse than the race it replaced, which at least always spawned one. It is now
+caught and raced against a deadline, because a close that never settles strands the handover just as
+completely, and this server holds SSE streams open with no idle timeout. The popover's height reset
+sat below two early returns, so on the trust and mismatch screens — the ones Rust re-reports every
+poll — the opening was never seen and the clamped-height ratchet survived exactly where a
+certificate prompt would be scrolling inside it; the opening is read before any guard now, since it
+is a fact about the popover and not about what is on it.
+
+The Windows console gate judged both streams by stdout alone, so `seedeep status > file` left the
+console's own error lines mojibake and `seedeep serve 2> file` degraded a file — it is per stream
+now. A pipe on a Windows console is still not covered, and that is written down as a limit rather
+than left to be discovered. The segment-boundary fix for `status` arrived without the test that
+would have failed before it, and `statusReport` read the ambient home while a fixture asserted a
+path — the home is carried in the facts now, so nothing rendering a status consults the machine. The
+smoke helper did not await its own `stop`, the same omission being fixed one file over. And two
+passages of `docs/tray.md` and the CI header were left describing what had just changed.
+
 **Nine corrections a review of the previous twelve commits found.** Four were real: the restart
 handover called `stop(true)` and spawned on the next statement, but that call answers with a promise
 and its own docs say network activity may outlive it — so the fix billed as "deterministic rather

--- a/docs/tray.md
+++ b/docs/tray.md
@@ -1143,20 +1143,21 @@ has given to something else, and picking either would be a signal sent to an unr
 
 Known limits, none of them silent:
 
-- **Windows: the tray was opened once, on arm64 (2026-08-14), and got no further than its popover.**
-That one look found two defects, both fixed: the popover opened off the bottom of the screen, and
-the app had no `windows_subsystem` attribute so launching it left a console window open. The icon's
-legibility, the animation's cost, notifications and the connection screen are all still unanswered,
-and the x64 build has never been run at all.
-
-**Every process the tray starts on Windows passes `CREATE_NO_WINDOW`.** A GUI application has no
-console, so Windows gives one to each console child it spawns and the user sees it flash: two of the
-three spawn sites were missing the flag, which is why it is one shared constant in `local.rs` rather
-than three literals — a fourth site cannot be added without meeting it. `taskkill /F` is a hard stop — the server never runs its
-  shutdown path, so its record is left for the next start's sweep. Marked `// LIMIT:` at both sites.
-  The lookup there also has a rule this platform does not need: `npm i -g` installs three shims and
-  `where.exe` lists the extensionless sh script first, so only a file `cmd` can actually start —
-  `.exe`, `.cmd`, `.bat`, `.com` — counts as having found seedeep.
+- **Windows was opened once**, on arm64 (2026-08-14), and got no further than the popover. That one
+  look found two defects, both since fixed: the popover opened off the bottom of the screen, and the
+  crate had no `windows_subsystem` attribute, so launching it left a console window open. The icon's
+  legibility, the animation's cost, notifications and the connection screen are all still
+  unanswered, and the x64 build has never been run at all.
+- `taskkill /F` is a hard stop — the server never runs its shutdown path, so its record is left for
+  the next start's sweep. Marked `// LIMIT:` at both sites. The lookup there also has a rule this
+  platform does not need: `npm i -g` installs three shims and `where.exe` lists the extensionless sh
+  script first, so only a file `cmd` can actually start — `.exe`, `.cmd`, `.bat`, `.com` — counts as
+  having found seedeep.
+- Every process the tray starts on Windows passes `CREATE_NO_WINDOW`, and that is a rule rather than
+  a detail: a GUI application has no console, so Windows gives one to each console child it spawns
+  and the user sees it flash. Two of the three spawn sites were missing it, which is why it is one
+  shared constant in `local.rs` and not three literals — a fourth site cannot be added without
+  meeting it.
 - A user who sets `SEEDEEP_HOME` in their shell profile gets a server whose records the tray cannot
   see: a GUI app inherits no shell environment, so the tray looks in `~/.seedeep`. Stop is then not
   offered, which is the honest outcome — nothing is stopped by guesswork.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "seedeep",
-  "version": "0.26.0",
+  "version": "0.27.0",
   "private": true,
   "type": "module",
   "description": "Live context & subagent visualizer for Claude Code",


### PR DESCRIPTION
Eight corrections from a review of the commit that answered the last review, two of
them regressions it had introduced.

Awaiting the listener's close made the handover honest and made it fragile: an
unhandled rejection inside that callback takes the process down where it stands
(measured on Bun 1.3.13), so a close that failed would leave a restart with the old
server gone and NO successor -- worse than the race it replaced, which at least
always spawned one. Caught now, and raced against a deadline, because a close that
never settles strands the handover just as completely and this server holds SSE
streams open with no idle timeout.

The popover's height reset sat below two early returns, so on the trust and mismatch
screens -- the ones Rust re-reports every poll -- the opening was never seen and the
ratchet survived exactly where a certificate prompt would be scrolling inside it. The
opening is read before any guard now: it is a fact about the popover, not about what
is on it.

The Windows console gate judged both streams by stdout alone, so redirecting stdout
left the console's error lines mojibake and redirecting stderr degraded a file. Per
stream now, with the pipe case written down as a limit.

The segment boundary for status arrived without the test that would have failed
before it. statusReport read the ambient home while a fixture asserted a path; the
home is carried in the facts now, so nothing rendering a status consults the machine.
The smoke helper did not await its own stop -- the very omission being fixed one file
over. And two passages of docs/tray.md and the CI header described what had just
changed.
