### PR TITLE
0.27.1

### DIFF
--- a/apps/server/src/server/server.ts
+++ b/apps/server/src/server/server.ts
@@ -170,6 +170,47 @@ export const LIVENESS_MS = 15_000;
 const HANDOVER_CLOSE_MS = 2_000;
 
 /**
+ * Close the listener, then hand the machine to the successor: spawn it and leave.
+ *
+ * **Nothing `close` does may stop the spawn**, and that is the whole reason this is a function with
+ * a test rather than three lines in a handler. Awaiting the close is what makes the port free before
+ * the successor asks for it, and awaiting it BARE is a worse bug than the race it replaced: an
+ * unhandled rejection inside a timer callback takes the process down where it stands (measured on
+ * Bun 1.3.13), so a close that failed would end a restart with the old server gone and no successor
+ * at all — where the un-awaited version at least always spawned one.
+ *
+ * The deadline covers the other ending. This server holds SSE streams open with `idleTimeout: 0`,
+ * and a close that never settles strands the handover just as completely as one that throws. Late is
+ * recoverable: the successor pays one failed bind, exactly as it did before any of this. Never is
+ * not.
+ *
+ * Exported for the test, which is the only thing that can prove a promise's failure does not reach
+ * the two calls after it.
+ */
+export async function handOver(
+  close: () => Promise<void>,
+  spawn: () => void,
+  exit: (code: number) => void,
+  deadlineMs = HANDOVER_CLOSE_MS,
+): Promise<void> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    await Promise.race([
+      Promise.resolve()
+        .then(close)
+        .catch(() => {}),
+      new Promise<void>((done) => {
+        timer = setTimeout(done, deadlineMs);
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+  spawn();
+  exit(0);
+}
+
+/**
  * How long the notification engine waits after a transcript event before reading the digest.
  *
  * A turn appends many lines in a burst — a thinking block, a text block, then each tool call — and
@@ -837,15 +878,7 @@ export async function startServer(deps: ServerDeps): Promise<RunningServer> {
         // asked for the restart is one of them: the port would still be held. The response above
         // has already gone out — `restart-cmd` treats a connection dropped here as this request's
         // normal ending.
-        setTimeout(async () => {
-          // AWAITED. `stop` answers with a promise (`bun-types`, `serve.d.ts`) and its own docs say
-          // "it may take some time before all network activity stops" — so spawning on the next
-          // statement would be the same bet the old code made, just a shorter one. The point of
-          // this handover is that it does not depend on which of two processes is quicker.
-          await server.stop(true);
-          spawnSelfFn();
-          exitFn(0);
-        }, 80);
+        setTimeout(() => void handOver(() => server.stop(true), spawnSelfFn, exitFn), 80);
         return json(req, { ok: true });
       }
 

--- a/apps/server/tests/server.test.ts
+++ b/apps/server/tests/server.test.ts
@@ -7,7 +7,7 @@ import { test } from 'node:test';
 import { mergeRoster } from '../src/core/roster.ts';
 import type { SessionRecord } from '../src/core/types.ts';
 import { defaultConfig, type SeedDeepConfig } from '../src/server/config.ts';
-import { isLoopback, parseMarks, selfSpawnPlan, startServer } from '../src/server/server.ts';
+import { handOver, isLoopback, parseMarks, selfSpawnPlan, startServer } from '../src/server/server.ts';
 import type { Channel } from '../src/server/update-cmd.ts';
 import { VERSION } from '../src/server/version.ts';
 
@@ -1654,4 +1654,48 @@ test('POST /api/restart frees the port before it spawns the successor', async ()
   } finally {
     srv.stop();
   }
+});
+
+// The correction to a correction. Awaiting the close is what frees the port before the successor
+// asks for it, and awaiting it bare is worse than the race it replaced: an unhandled rejection in a
+// timer callback takes the process down where it stands, so a close that failed would end a restart
+// with the old server gone and no successor at all. Both endings are asserted, because neither is
+// visible from the handler that calls this.
+test('the handover spawns the successor even when the close fails', async () => {
+  const done: string[] = [];
+  await handOver(
+    () => Promise.reject(new Error('the listener would not close')),
+    () => done.push('spawn'),
+    () => done.push('exit'),
+  );
+  assert.deepEqual(done, ['spawn', 'exit'], 'a rejected close must not reach these');
+});
+
+test('the handover gives up on a close that never settles', async () => {
+  const done: string[] = [];
+  const began = Date.now();
+  await handOver(
+    () => new Promise<void>(() => {}),
+    () => done.push('spawn'),
+    () => done.push('exit'),
+    30,
+  );
+  assert.deepEqual(done, ['spawn', 'exit']);
+  assert.ok(Date.now() - began >= 25, 'it waited for the deadline rather than skipping the close');
+});
+
+test('the handover waits for a close that does settle, and does not wait longer', async () => {
+  const done: string[] = [];
+  const began = Date.now();
+  await handOver(
+    async () => {
+      await new Promise((r) => setTimeout(r, 10));
+      done.push('closed');
+    },
+    () => done.push('spawn'),
+    () => done.push('exit'),
+    5_000,
+  );
+  assert.deepEqual(done, ['closed', 'spawn', 'exit'], 'the port is free before the successor asks');
+  assert.ok(Date.now() - began < 1_000, 'the deadline is a ceiling, never a delay');
 });

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable structural changes to seedeep are recorded here, newest first.
 
 ## Unreleased
 
+## 0.27.1 (2026-08-15)
+
+**The guard 0.27.0 claimed to have on its restart was never in the file.** The edit that added it
+silently matched nothing; only the constant it referenced landed, unused, and the release notes said
+it was fixed because nobody checked the code. So 0.27.0 shipped `await server.stop(true)` bare — and
+an unhandled rejection inside a timer callback takes the process down where it stands (measured on
+Bun 1.3.13), which would end a restart with the old server gone and no successor at all, where the
+un-awaited 0.26.0 version at least always spawned one.
+
+The handover is now a named function with three tests, and that is the point of it: a close that
+REJECTS still hands over, a close that never settles gives up at a deadline — this server holds SSE
+streams open with no idle timeout — and a close that settles is waited for, since freeing the port
+before the successor asks for it is the whole reason any of this is awaited. Two of those endings
+are invisible from the handler that calls it, which is why the last two attempts at this were
+written without noticing they were wrong.
+
 ## 0.27.0 (2026-08-15)
 
 **Eight more corrections, from a review of the commit that answered the last review.** Two were

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "seedeep",
-  "version": "0.27.0",
+  "version": "0.27.1",
   "private": true,
   "type": "module",
   "description": "Live context & subagent visualizer for Claude Code",


### PR DESCRIPTION
The guard 0.27.0 claimed to have on its restart was never in the file. The edit that
added it matched nothing and said nothing; only the constant it referenced landed,
unused, and the notes reported the fix because nobody read the code back. So 0.27.0
shipped a bare await on the listener's close -- and an unhandled rejection inside a
timer callback takes the process down where it stands, which ends a restart with the
old server gone and no successor at all. The un-awaited 0.26.0 version at least
always spawned one.

The handover is a named function now, with three tests, and that is its purpose: a
close that REJECTS still hands over; a close that never settles gives up at a
deadline, since this server holds SSE streams open with no idle timeout; and a close
that settles is waited for, because freeing the port before the successor asks for it
is why any of this is awaited at all. Two of those endings cannot be seen from the
handler that calls it, which is how two attempts in a row were written wrong and
believed.
