### PR TITLE
0.27.2

### DIFF
--- a/apps/server/src/server/browser.ts
+++ b/apps/server/src/server/browser.ts
@@ -17,5 +17,5 @@ export function openBrowser(url: string, run: (argv: string[]) => void = default
 
 function defaultRun(argv: string[]): void {
   const [cmd, ...rest] = argv;
-  spawn(cmd!, rest, { stdio: 'ignore', detached: true }).unref();
+  spawn(cmd!, rest, { stdio: 'ignore', detached: true, windowsHide: true }).unref();
 }

--- a/apps/server/src/server/command-liveness.ts
+++ b/apps/server/src/server/command-liveness.ts
@@ -179,7 +179,7 @@ function lsof(paths: readonly string[]): Promise<string | null> {
     const child = execFile(
       'lsof',
       ['-F', 'pn', '--', ...paths],
-      { timeout: PROBE_TIMEOUT_MS, maxBuffer: 1_000_000 },
+      { timeout: PROBE_TIMEOUT_MS, maxBuffer: 1_000_000, windowsHide: true },
       (err, stdout, stderr) => resolve(lsofVerdict(err, stdout, stderr)),
     );
     child.on('error', () => resolve(null));

--- a/apps/server/src/server/git.ts
+++ b/apps/server/src/server/git.ts
@@ -36,7 +36,14 @@ function git(cwd: string, args: string[]): Promise<string | null> {
     };
     let child: ReturnType<typeof spawn>;
     try {
-      child = spawn('git', ['--no-optional-locks', ...args], { cwd, stdio: ['ignore', 'pipe', 'ignore'] });
+      // `windowsHide`, like every subprocess this server starts: after a restart the server is
+      // detached and therefore has NO console, so Windows gives a new one to each console child
+      // — and this spawns one git per commit, so a portal refresh flashed a burst of them.
+      child = spawn('git', ['--no-optional-locks', ...args], {
+        cwd,
+        stdio: ['ignore', 'pipe', 'ignore'],
+        windowsHide: true,
+      });
     } catch {
       return finish(null);
     }

--- a/apps/server/src/server/open-cmd.ts
+++ b/apps/server/src/server/open-cmd.ts
@@ -218,6 +218,7 @@ export function spawnDetachedServer(
   const child = spawn(exe, [...entry, 'serve', '--no-open', '--port', String(port)], {
     detached: true,
     stdio: ['ignore', fd, fd],
+    windowsHide: true,
   });
   // The child holds its own duplicate; this process has no reason to keep the descriptor open.
   closeSync(fd);

--- a/apps/server/src/server/self-update-cmd.ts
+++ b/apps/server/src/server/self-update-cmd.ts
@@ -176,7 +176,7 @@ export async function runSelfUpdatePreview(
 export function runToCompletion(argv: string[]): Promise<number> {
   const [cmd, ...rest] = argv as [string, ...string[]];
   return new Promise((resolve) => {
-    const child = spawn(cmd, rest, { stdio: 'inherit' });
+    const child = spawn(cmd, rest, { stdio: 'inherit', windowsHide: true });
     // A package manager that is not on PATH is a failed install, not a crash of this process: 127 is
     // what a shell reports for it, and the caller already prints the command that failed.
     child.on('error', () => resolve(127));
@@ -190,7 +190,7 @@ async function askInstalledVersion(): Promise<string | null> {
   // directory, so a path resolved before it ran can name an inode that no longer exists.
   const exe = ownExecPath();
   return new Promise((resolve) => {
-    const child = spawn(exe, ['--version'], { stdio: ['ignore', 'pipe', 'ignore'] });
+    const child = spawn(exe, ['--version'], { stdio: ['ignore', 'pipe', 'ignore'], windowsHide: true });
     let out = '';
     child.stdout.on('data', (chunk: Buffer) => {
       out += chunk.toString();

--- a/apps/server/src/server/server.ts
+++ b/apps/server/src/server/server.ts
@@ -189,7 +189,7 @@ const HANDOVER_CLOSE_MS = 2_000;
  */
 export async function handOver(
   close: () => Promise<void>,
-  spawn: () => void,
+  handOff: () => void,
   exit: (code: number) => void,
   deadlineMs = HANDOVER_CLOSE_MS,
 ): Promise<void> {
@@ -206,7 +206,7 @@ export async function handOver(
   } finally {
     if (timer) clearTimeout(timer);
   }
-  spawn();
+  handOff();
   exit(0);
 }
 
@@ -404,8 +404,10 @@ function mergeNotificationsPost(stored: NotifyConfig, given: Record<string, unkn
 export interface SelfSpawnPlan {
   /** argv for `Bun.spawn` — this executable, then the flags this process was given. */
   cmd: string[];
-  /** `detached` is present on Windows and absent everywhere else; see {@link selfSpawnPlan}. */
-  options: { stdio: ['inherit', 'inherit', 'inherit']; detached?: true };
+  /** `detached` is present on Windows and absent everywhere else; see {@link selfSpawnPlan}.
+   * `windowsHide` is the rule every subprocess here obeys — no console child of a console-less
+   * parent may flash a window at the user. */
+  options: { stdio: ['inherit', 'inherit', 'inherit']; detached?: true; windowsHide: true };
 }
 
 /**
@@ -441,6 +443,7 @@ export function selfSpawnPlan(
     cmd: [...selfInvocation(execPath, main, fromSource), ...argv.slice(2)],
     options: {
       stdio: ['inherit', 'inherit', 'inherit'],
+      windowsHide: true,
       ...(platform === 'win32' ? { detached: true as const } : {}),
     },
   };

--- a/apps/server/src/server/tls.ts
+++ b/apps/server/src/server/tls.ts
@@ -61,7 +61,7 @@ async function fileExists(path: string): Promise<boolean> {
 function runCmd(cmd: string, args: string[]): Promise<void> {
   return new Promise((resolve, reject) => {
     let errOut = '';
-    const child = spawn(cmd, args, { stdio: ['ignore', 'ignore', 'pipe'] });
+    const child = spawn(cmd, args, { stdio: ['ignore', 'ignore', 'pipe'], windowsHide: true });
     child.stderr?.on('data', (d: Buffer) => {
       errOut += d.toString();
     });

--- a/apps/server/tests/windows-hide.test.ts
+++ b/apps/server/tests/windows-hide.test.ts
@@ -1,0 +1,36 @@
+import assert from 'node:assert/strict';
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { test } from 'node:test';
+
+const SERVER_SRC = join(import.meta.dirname, '..', 'src', 'server');
+
+/**
+ * Every subprocess this server starts must pass `windowsHide`.
+ *
+ * Not a style rule. On Windows a process with no console is given one for each console child it
+ * spawns, and the user sees it flash — and a seedeep started by `seedeep start` or by a restart IS
+ * console-less, because it is spawned detached. `git.ts` runs one git per commit, so a portal
+ * refresh flashed a burst of them (observed on Windows 11, 2026-08-15). Six spawn sites existed and
+ * none passed the flag.
+ *
+ * A source scan rather than a behavioural test, for the same reason the tray keeps `CREATE_NO_WINDOW`
+ * in one shared constant: what has to be true is that a SEVENTH site cannot be added without meeting
+ * the rule, and no runtime assertion on this machine can say that. The layer-boundary test in this
+ * suite reads the source the same way.
+ */
+test('every module that spawns a subprocess passes windowsHide', () => {
+  const offenders: string[] = [];
+  for (const name of readdirSync(SERVER_SRC).filter((f) => f.endsWith('.ts'))) {
+    // Comments stripped for BOTH questions, and that is not tidiness: the first version asked
+    // whether the file mentioned `windowsHide` anywhere, so deleting the option from the call left
+    // the test green on the strength of the comment explaining it. A guard that survives the
+    // removal it guards against is decoration.
+    const code = readFileSync(join(SERVER_SRC, name), 'utf8').replace(/^\s*(?:\/\/|\*|\/\*).*$/gm, '');
+    // `Bun.spawn(` counts and `spawnSelfFn(` does not: the lookbehind excludes a longer identifier,
+    // never a namespace.
+    const spawns = /(?<!\w)(?:spawn|execFile|execFileSync|spawnSync)\s*\(/.test(code);
+    if (spawns && !code.includes('windowsHide')) offenders.push(name);
+  }
+  assert.deepEqual(offenders, [], 'these start a subprocess and would open a console window on Windows');
+});

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable structural changes to seedeep are recorded here, newest first.
 
 ## Unreleased
 
+## 0.27.2 (2026-08-15)
+
+**A portal refresh flashed console windows on Windows, and only after a restart.** Same mechanism as
+the tray's flash one layer up: a process with no console is given a NEW one for each console child
+it spawns, and a seedeep started detached — by `seedeep start` or by a restart — has no console. The
+server starts subprocesses on eight sites and not one passed `windowsHide`; `git.ts` runs one git
+per commit, so a refresh spawned a burst of them at once. Reported on Windows 11, 2026-08-15.
+
+All eight pass it now — git, the liveness prober, openssl, both halves of `self-update`, the browser
+opener, the detached server and the restart's successor — and a test reads the source to keep it
+that way, because what has to be true is that a ninth site cannot be added without meeting the rule.
+That test failed its own first red-check: it asked whether the file MENTIONED `windowsHide`, so
+deleting the option from a call left it green on the strength of the comment explaining it.
+
 ## 0.27.1 (2026-08-15)
 
 **The guard 0.27.0 claimed to have on its restart was never in the file.** The edit that added it

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "seedeep",
-  "version": "0.27.1",
+  "version": "0.27.2",
   "private": true,
   "type": "module",
   "description": "Live context & subagent visualizer for Claude Code",


### PR DESCRIPTION
A portal refresh flashed console windows on Windows, and only after a restart. Same
mechanism as the tray's flash one layer up: a process with no console is given a NEW
one for each console child it spawns, and a seedeep started detached -- by
`seedeep start` or by a restart -- has no console. git.ts runs one git per commit, so
a refresh spawned a burst of them at once.

Eight spawn sites existed and none passed windowsHide. All do now: git, the liveness
prober, openssl, both halves of self-update, the browser opener, the detached server
and the restart's successor. A test reads the source to keep it that way, because
what has to be true is that a NINTH site cannot be added without meeting the rule,
and no runtime assertion on a Mac can say that.

That test failed its own first red-check and is worth the note: it asked whether the
file MENTIONED windowsHide, so deleting the option from a call left it green on the
strength of the comment explaining it. It reads the code with comments stripped now.
A guard that survives the removal it guards against is decoration.
