### PR TITLE
docs: say what Windows arm64 actually answered, and what it did not

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -221,39 +221,44 @@ not be accepted.
 
 ## Running it on Windows
 
-The single most useful contribution nobody here can make. One Windows session has happened — a
-Windows 11 **arm64** guest, 2026-08-14 — and it found four defects in an evening: the server was
-installed from npm, started and served, and the tray was installed and its popover opened for the
-first time. Everything below is what that session did **not** settle, which is most of it: it never
-got past the popover, and the **x64** build of either app has still been started by CI and never used
-by a person. If you have Windows, one session settles six claims the code makes and the docs
-currently only reason about. Report what you see in an issue — a "it all worked" is as valuable as
-a defect, because today neither is known.
+The single most useful contribution nobody here can make — on **x64**. Two Windows sessions have
+happened, both on a Windows 11 **arm64** guest (2026-08-14 and 2026-08-15). Between them the server
+was installed from npm and its whole lifecycle driven, the tray was installed and used, six defects
+were found and fixed, and four of the six claims below stopped being guesses — two of them only
+partly, and each says so. What no session on any
+architecture has touched: **notifications**, the **animated icon's cost**, and **every x64 build of
+either app**, which CI starts and nobody has used. Each claim below says where it stands. Report what
+you see in an issue — an "it all worked" is as valuable as a defect, because today neither is known.
 
 1. **The installer runs at all**, and what SmartScreen actually says for an unsigned unknown
    publisher — the README quotes Microsoft's documentation, not a screenshot. Its `currentUser`
-   install mode should need no Administrator rights; confirm that too.
+   install mode should need no Administrator rights; confirm that too. *The installer runs on arm64;
+   SmartScreen's actual wording has still not been recorded.*
 2. **The tray icon appears in the notification area and is legible.** The mark is drawn in Rust
    against a measurement that is macOS's — that platform scales the buffer to 18 pt by *height* —
    and Windows sizes tray icons its own way, so the 27×26 buffer may come out small, squashed or
-   blurred. This is the likeliest visual defect.
+   blurred. This was the likeliest visual defect, and *on arm64 it is not one — the icon reads.*
 3. **The working icon spins acceptably**: 24 frames at 12 fps through `set_icon`. On macOS that
    costs 7.3% of one core; underneath, Windows is a different API and the cost is unknown.
+   *Unanswered on either architecture, and not measurable under emulation.*
 4. **Notifications are delivered**, both switches — the approval one and the finished-turn one.
    Tauri documents that Windows shows a notification only for an *installed* application, which is
    exactly why the deliverable is an installer rather than a portable `.exe`; that reasoning has
-   never been checked against a banner that actually appeared.
+   never been checked against a banner that actually appeared. *The one claim no Windows session has
+   touched at all — `Send a test notification` in the settings view is the direct route.*
 5. **The popover's geometry.** The panel measures its own content and Rust clamps the height
-   against the monitor's work area, and the rounded corners rely on a transparent window. Neither
-   has been seen on a desktop whose taskbar can sit on any edge.
+   against the monitor's work area, and the rounded corners rely on a transparent window. *Answered
+   on arm64 for a taskbar at the bottom — the panel opens upward, at full height. The other three
+   edges have still not been tried.*
 6. **Trust on first use and the connection screen**, against a `seedeep` server reached over HTTPS
-   on another machine, including the fingerprint comparison.
+   on another machine, including the fingerprint comparison. *Answered on arm64.*
 
-All six apply on **Windows on arm64** as well — a Snapdragon laptop, or a Windows 11 ARM guest on an
-Apple Silicon Mac. That machine gets its own server binary and its own tray installer, built by the
-same tag on a native arm64 runner; the installer NSIS produces is x86 under emulation by Tauri's
-design, and the app inside it is native. Say which of the two you were on: an answer from one says
-nothing certain about the other.
+Every answer above came from **Windows on arm64** — a Windows 11 ARM guest on an Apple Silicon Mac;
+a Snapdragon laptop is the other way there. That machine gets its own server binary and its own
+tray installer, built by the same tag on a native arm64 runner; the installer NSIS produces is x86
+under emulation by Tauri's design, and the app inside it is native. Say which of the two you were
+on: an answer from one says nothing certain about the other, which is why every claim above is
+scored per architecture rather than per platform.
 
 Where the answers go: `docs/tray.md` holds the macOS measurements in a table under *What is signed,
 and what that costs*, and Windows belongs in the same shape — what was observed, and on which

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -284,9 +284,10 @@ Windows build. Something broken is its own issue, not a footnote to this one.
   files. The pre-push hook prints that list and stops there, WARN-only: deciding
   whether a figure went false is a judgement — did what it *shows* change? —
   not something a file-level map can make for you. `--verify` settles it by
-  **re-cutting the suspects into a temp directory and comparing the pixels**, but it
-  costs minutes, so it belongs to a release rather than to every push. A release is not
-  itself a reason to re-cut: the Settings figures print the server's version, but a
+  **re-cutting the suspects into a temp directory it then deletes, and comparing the
+  pixels** — so it publishes nothing, and it costs minutes. Reach for it when what a
+  figure SHOWS is genuinely in doubt, not on a schedule: a release in particular is not
+  a reason to re-cut, nor to verify. The Settings figures print the server's version, but a
   figure documents the surface it photographs, not the version that was running, and a
   stale number there makes nothing it claims false. If you change a widget that a figure
   shows, say so in the PR — re-cutting needs the recorded bundle, which is not in the

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ the GUI, stops the server, or reports what the current session cost.
 
 Everything above was checked by hand on **macOS**, on the machine `seedeep` is
 developed on. **Linux has been used once**, in a VM, on arm64. **Windows has been
-used once too**, in a VM, on arm64 — and only so far: the table says exactly how far
+used twice**, in a VM, and on arm64 both times — the table says exactly how far
 each got, and what each found. Building for three systems is not the same as having
 used three, and this section is that difference written down rather than left for you
 to find.
@@ -186,16 +186,16 @@ a person on that machine.
 
 | | macOS | Windows | Linux |
 | -- | -- | -- | -- |
-| **Server** — download or npm | Used daily; every claim above was checked here | **arm64: used on Windows 11 in a VM** (2026-08-14) — installed from npm on a native arm64 Node, server started and served its API against a real Claude Code session, `status`, `stop` and `install-command` confirmed, and ten consecutive cold starts measured without a failure. Four defects it found — a `restart` that left no replacement running, a popover off the bottom of the screen, a console window the tray had no reason to open, and unreadable punctuation — are fixed and **await a build somebody can run**. `/seedeep` there needs one line of configuration ([`install.md`](docs/install.md#seedeep-inside-claude-code)). **x64: started on every release, never used** — and on a Windows-on-arm machine, where an x64 Node makes npm resolve it, it crashes within seconds of starting; install an arm64 Node so npm resolves the native build | **arm64: used on Ubuntu 24 in a VM** (2026-08-14) — GUI opened against a real Claude Code session, lifecycle and `install-command` confirmed. **x64: started on every release, never used** — version-checked in CI and on Docker, never run in front of a person. Both builds require glibc; Alpine/musl is not supported. |
-| **Tray** | Used daily on a real menu bar | **arm64: opened once** (2026-08-14), and it got no further than the popover — which appeared off the bottom of the screen, beside a console window the app had no reason to open. Both are fixed and await a build somebody can run; the icon's legibility, the notifications and the connection screen are still unanswered. **x64: never run** — its installer is built on every tag and nothing has opened it | **Not a target**, deliberately: Tauri emits no tray click event on Linux, so the panel could not open — see [`docs/tray.md`](docs/tray.md) |
+| **Server** — download or npm | Used daily; every claim above was checked here | **arm64: used on Windows 11 in a VM** (2026-08-14, then again on 2026-08-15) — installed from npm on a native arm64 Node, server started and served its API against a real Claude Code session, `status`, `stop`, `restart` and `install-command` confirmed, and ten consecutive cold starts measured without a failure. Six defects the two sessions found are fixed: a `restart` that left no replacement running, a popover off the bottom of the screen, a console window the tray had no reason to open, unreadable punctuation, a panel button that swallowed about one click in ten, and a burst of console windows on a portal refresh. Four of them were driven again on that machine after the fix — the restart, the popover, the tray's console window and the button; the punctuation and the console burst were not re-checked there. `/seedeep` there needs one line of configuration ([`install.md`](docs/install.md#seedeep-inside-claude-code)). **x64: started on every release, never used** — and on a Windows-on-arm machine, where an x64 Node makes npm resolve it, it crashes within seconds of starting; install an arm64 Node so npm resolves the native build | **arm64: used on Ubuntu 24 in a VM** (2026-08-14) — GUI opened against a real Claude Code session, lifecycle and `install-command` confirmed. **x64: started on every release, never used** — version-checked in CI and on Docker, never run in front of a person. Both builds require glibc; Alpine/musl is not supported. |
+| **Tray** | Used daily on a real menu bar | **arm64: installed and used on Windows 11 in a VM** (2026-08-15) — the installer runs, the icon reads in the notification area, the popover opens upward at full height against a taskbar at the bottom, trust-on-first-use and the connection screen work, the panel's buttons respond, and no console window appears. **Notifications are the one thing nothing has exercised**, along with the animation's cost and a taskbar on the other three edges. **x64: never run** — its installer is built on every tag and nothing has opened it | **Not a target**, deliberately: Tauri emits no tray click event on Linux, so the panel could not open — see [`docs/tray.md`](docs/tray.md) |
 
-Concretely: on **Windows x64**, on **Linux x64**, and on the **tray anywhere but macOS**,
+Concretely: on **Windows x64**, on **Linux x64**, and on the **Windows x64 tray**,
 you are the first to use it. A defect there is expected rather than surprising, and
 [an issue](../../issues) saying what you saw is the most useful thing you can send.
-The one Windows session behind the table above found four defects in an evening, which
-is the honest estimate of what the untouched squares still hold; if you use Windows,
-[`CONTRIBUTING.md`](CONTRIBUTING.md#running-it-on-windows) lists what a session on that
-machine would settle next.
+The two Windows sessions behind the table above found six defects, all of them on one
+architecture, which is the honest estimate of what the untouched squares still hold; if
+you use Windows, [`CONTRIBUTING.md`](CONTRIBUTING.md#running-it-on-windows) lists what a
+session on that machine would settle next.
 
 ## Design principles
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable structural changes to seedeep are recorded here, newest first.
 
 ## Unreleased
 
+**Windows on arm64 stopped being a platform the docs only reasoned about.** A second session there
+(2026-08-15, on 0.27.1) installed the tray and drove both halves, so four of the six claims
+`CONTRIBUTING.md` asks a Windows contributor to settle are now answered: the installer runs, the icon
+reads at notification-area size, the popover opens upward at full height against a taskbar at the
+bottom, and trust-on-first-use works. The README, `docs/install.md` and `docs/tray.md` said the fixes
+those sessions produced "await a build somebody can run" and that the tray "got no further than the
+popover" — both false since 0.27.1 shipped. **Notifications are the one claim nothing on any Windows
+has exercised**, and every x64 build of either app is still started by CI and used by nobody.
+
+The arm64 tray leg is measured now rather than assumed: it has run on every tag from 0.26.0, takes
+about 7 minutes — the shortest of the three — and its artifact is a `PE32 executable (GUI) Intel
+80386 … Nullsoft Installer self-extracting archive`, which is Tauri's documented "the installer is
+x86, the app inside is native" seen rather than trusted.
+
 ## 0.27.2 (2026-08-15)
 
 **A portal refresh flashed console windows on Windows, and only after a restart.** Same mechanism as

--- a/docs/install.md
+++ b/docs/install.md
@@ -4,10 +4,11 @@
 a page in your browser — one process, no daemon, stopped with Ctrl-C. Two channels
 ship the same executable; a third runs it from a clone.
 
-> **The Windows arm64 build has been used once**, in a VM (2026-08-14), which found four
-> defects in an evening; the **x64** build is started by CI on a runner of its own
-> architecture and has never been used in front of a person. The Linux arm64 build was
-> used on Ubuntu 24 in a VM (2026-08-14); its x64 build has been started, never used.
+> **The Windows arm64 build has been used twice**, in a VM (2026-08-14 and 2026-08-15),
+> which found six defects between them, all since fixed; the **x64** build is started by
+> CI on a runner of its own architecture and has never been used in front of a person.
+> The Linux arm64 build was used on Ubuntu 24 in a VM (2026-08-14); its x64 build has
+> been started, never used.
 > [Which platforms have actually been run](../README.md#which-platforms-have-actually-been-run)
 > says exactly what each of those covers.
 

--- a/docs/tray.md
+++ b/docs/tray.md
@@ -14,8 +14,8 @@ changes the endpoint.
 > **State of the code.** The tray is feature-complete and packaged: it finds a server, pins its
 > certificate, polls the digest, shows the three bands, drives its icon from what it reads, notifies
 > when a session stops on you, has the settings surface that turns that off, and a tag builds its
-> installers ([Packaging and releases](#packaging-and-releases)). The macOS and the Windows x64
-> installers have been built by CI and inspected; the Windows arm64 leg is new and has never run.
+> installers ([Packaging and releases](#packaging-and-releases)). All three have been built by CI and
+> inspected, and the Windows arm64 one has additionally been installed and used (2026-08-15).
 >
 > What has been checked on a real menu bar, not only by its tests: the icon renders and reads at
 > menu-bar size, the popover opens anchored under it and inside the screen, and it closes. The
@@ -1143,11 +1143,17 @@ has given to something else, and picking either would be a signal sent to an unr
 
 Known limits, none of them silent:
 
-- **Windows was opened once**, on arm64 (2026-08-14), and got no further than the popover. That one
-  look found two defects, both since fixed: the popover opened off the bottom of the screen, and the
-  crate had no `windows_subsystem` attribute, so launching it left a console window open. The icon's
-  legibility, the animation's cost, notifications and the connection screen are all still
-  unanswered, and the x64 build has never been run at all.
+- **Windows has been used on arm64 only** — opened on 2026-08-14, then installed and driven on
+  2026-08-15. The first look found two defects, both since fixed — the popover opened off the bottom
+  of the screen, and the crate had no `windows_subsystem` attribute, so launching it left a console
+  window open; fixing the second turned up a third by reading, two of the three spawn sites missing
+  `CREATE_NO_WINDOW`. The second session found one more — a panel button that swallowed about one
+  click in ten, the live view being replaced under the press — and answered the rest: the installer
+  runs, the icon reads at notification-area size, the popover opens upward at full
+  height against a taskbar at the bottom, trust-on-first-use and the connection screen work, and
+  every button responds. **Notifications remain the one thing nothing has
+  exercised**, along with the animation's cost, a taskbar on the other three edges, and the entire
+  x64 build, whose installer has never been opened.
 - `taskkill /F` is a hard stop — the server never runs its shutdown path, so its record is left for
   the next start's sweep. Marked `// LIMIT:` at both sites. The lookup there also has a rule this
   platform does not need: `npm i -g` installs three shims and `where.exe` lists the extensionless sh
@@ -1599,9 +1605,10 @@ mounts to `seedeep.app`
 beside the `Applications` symlink, `lipo` reports `x86_64 arm64`, and `CFBundleShortVersionString` is
 the `package.json` number; the Windows artifact is a `PE32 executable (GUI) … Nullsoft Installer
 self-extracting archive`. A cold runner with no Rust cache takes about 9 minutes on macOS and 14 on
-Windows. **The arm64 leg has never run**, so nothing here is measured about it — not the build time,
-not the artifact, not whether the runner's toolchain carries what Tauri needs. A
-`workflow_dispatch` run is what would settle that before a tag depends on it.
+Windows. **The arm64 leg runs on every tag from 0.26.0**, in about 7 minutes — the shortest of the
+three — and its artifact was inspected the same way: `PE32 executable (GUI) Intel 80386 … Nullsoft
+Installer self-extracting archive`, 4.1 MB. The installer really is x86 while the app inside it is
+arm64, which is the behaviour Tauri documents (below) seen rather than trusted.
 
 Windows is why this is CI and not a script on a laptop: Tauri's own recipe uses one runner per
 platform, and it documents building the Windows installer from a Mac as possible for NSIS only


### PR DESCRIPTION
The README, `docs/install.md`, `docs/tray.md` and `CONTRIBUTING.md` all still described the state before 0.27.1 — that the fixes the Windows sessions produced *"await a build somebody can run"*, that the tray *"got no further than the popover"*, and that the arm64 tray leg *"has never run"*. A second session on 2026-08-15 installed the tray and drove both halves, so all three are false.

## What the docs claim now

Only what was seen, and per architecture:

- the installer runs, the icon reads at notification-area size, the popover opens upward at full height against a taskbar at the bottom, trust-on-first-use and the connection screen work, every button responds, and no console window appears;
- **notifications are the one claim nothing on any Windows has exercised**, along with the animation's cost and a taskbar on the other three edges;
- **every x64 build of either app is still started by CI and used by nobody.**

`CONTRIBUTING.md` used to present all six of its Windows claims as open; each now says where it stands, two of them only partly answered.

## Two assumptions replaced by measurements

`docs/tray.md` said nothing was measured about the arm64 tray leg. Both figures come from the release runs and the published artifact:

- the leg has run on every tag from 0.26.0 and takes about **7 minutes**, the shortest of the three;
- its artifact is a `PE32 executable (GUI) Intel 80386 … Nullsoft Installer self-extracting archive`, 4.1 MB — Tauri's documented *"the installer is x86, the app inside is native"* inspected rather than trusted.

## Also here

One unrelated commit, kept separate: `doc-shots --verify` is not a release chore. The paragraph read as if verifying the figures belonged to a release, which scheduled a full re-cut for nothing — a figure documents the surface it photographs, not the version that was running.

Docs only; no code changes. `bun run test` 1691 pass / 0 fail, `typecheck` and `lint` clean.