### PR TITLE
0.28.0

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable structural changes to seedeep are recorded here, newest first.
 
 ## Unreleased
 
+## 0.28.0 (2026-08-16)
+
 **Every binary is now RUN, not merely started — and the crash nobody had measured gets a controlled
 experiment.** All six legs of `smoke` go on to run two new scripts against the asset they just
 started: `idle-survival.sh` with three starts and a 20-second idle window (the cheap regression — a

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "seedeep",
-  "version": "0.27.2",
+  "version": "0.28.0",
   "private": true,
   "type": "module",
   "description": "Live context & subagent visualizer for Claude Code",


### PR DESCRIPTION
The version bump and the changelog cut, in one diff — which is what the release rule asks for, and what was skipped for 0.18.0, 0.19.0 and 0.20.0 in a row, leaving sixteen already-shipped entries filed under `Unreleased` where nobody on a released build could tell which of them was in their copy.

- `package.json` → `0.28.0`, the only place the version lives.
- `## Unreleased` → `## 0.28.0 (2026-08-16)`, the tag commit's **local** date, with a fresh empty `Unreleased` above it.

Nothing else changes. The release itself is #46: the two new gates that run every binary rather than only starting it, and the `windows` job that puts the same x64 binary on x64 silicon and under Prism to settle the `0xC0000005` attribution. **This is the first tag whose own workflow exercises them**, so the run this tag produces is also the experiment.