### PR TITLE
Rehearse the release gates before the tag, and stop asserting a limit seedeep documents

### DIFF
--- a/.github/scripts/server-lifecycle.sh
+++ b/.github/scripts/server-lifecycle.sh
@@ -18,7 +18,9 @@
 #   3. `restart` exits 0, the recorded pid CHANGES, and the server answers again. That last pair is
 #      the port race: a `restart` that killed the old server and failed to bind would leave the pid
 #      unchanged, or nothing answering, and both are caught here.
-#   4. `stop` exits 0, the record is gone, and nothing answers any more.
+#   4. `stop` exits 0 and nothing answers any more. The record going away is asserted on POSIX only:
+#      Windows has no SIGTERM, so the server never runs the shutdown path that takes its own record
+#      back and the file waits for the next start's sweep — a documented limit, not a defect.
 #
 # Liveness is read from the run-state records (`$SEEDEEP_HOME/servers/<pid>.json`) rather than from
 # what the commands print, for the same reason `status` is only checked for its exit code: the
@@ -130,12 +132,28 @@ echo "lifecycle: restarted — pid $first_pid replaced by $second_pid, still ans
   cat "$WORK/stop.log" >&2
   fail "\`stop\` did not exit 0"
 }
-waited=0
-until [ "$(recorded_pids | grep -c . || true)" = 0 ]; do
-  waited=$((waited + 1))
-  [ "$waited" -lt "$TIMEOUT_S" ] || fail "\`stop\` exited 0 but a run-state record is still there"
-  sleep 1
-done
+# The record going away is asserted only where the product takes it back. `stop` sends SIGTERM and
+# the server's handler removes its own record — but Windows has no SIGTERM, so the runtime terminates
+# the process, the shutdown path never runs, and the file is left for the next start's sweep.
+# `stop-cmd.ts` marks that `// LIMIT:`, and `docs/tray.md` documents the same for `taskkill /F`.
+# Asserting it there was asserting a behaviour seedeep says it does not have, and it is what failed
+# the v0.28.0 release run on both Windows legs while the product was behaving exactly as documented.
+case "${OSTYPE:-}" in
+  msys* | cygwin*)
+    echo "lifecycle: the run-state record is not checked after \`stop\` — no SIGTERM on Windows, so it outlives the process by design"
+    ;;
+  *)
+    waited=0
+    until [ "$(recorded_pids | grep -c . || true)" = 0 ]; do
+      waited=$((waited + 1))
+      [ "$waited" -lt "$TIMEOUT_S" ] || fail "\`stop\` exited 0 but a run-state record is still there"
+      sleep 1
+    done
+    ;;
+esac
+
+# What must hold on every platform, and the only part of `stop` a person can observe: nothing
+# answers any more. A stale record is bookkeeping; a server still serving after `stop` is a defect.
 [ "$(curl -s -o /dev/null -w '%{http_code}' "$BASE/api/config" || true)" = 200 ] &&
   fail "\`stop\` exited 0 but the server still answers on $BASE/api/config"
 

--- a/.github/scripts/server-lifecycle.sh
+++ b/.github/scripts/server-lifecycle.sh
@@ -18,9 +18,10 @@
 #   3. `restart` exits 0, the recorded pid CHANGES, and the server answers again. That last pair is
 #      the port race: a `restart` that killed the old server and failed to bind would leave the pid
 #      unchanged, or nothing answering, and both are caught here.
-#   4. `stop` exits 0 and nothing answers any more. The record going away is asserted on POSIX only:
-#      Windows has no SIGTERM, so the server never runs the shutdown path that takes its own record
-#      back and the file waits for the next start's sweep — a documented limit, not a defect.
+#   4. `stop` exits 0 and nothing answers any more. What happens to the RECORD is platform-specific
+#      and asserted both ways: on POSIX it is gone, because SIGTERM lets the server take it back; on
+#      Windows there is no SIGTERM, so it must still be there and the NEXT start must sweep it — a
+#      documented limit, and one whose disappearance would be worth knowing about too.
 #
 # Liveness is read from the run-state records (`$SEEDEEP_HOME/servers/<pid>.json`) rather than from
 # what the commands print, for the same reason `status` is only checked for its exit code: the
@@ -138,9 +139,34 @@ echo "lifecycle: restarted — pid $first_pid replaced by $second_pid, still ans
 # `stop-cmd.ts` marks that `// LIMIT:`, and `docs/tray.md` documents the same for `taskkill /F`.
 # Asserting it there was asserting a behaviour seedeep says it does not have, and it is what failed
 # the v0.28.0 release run on both Windows legs while the product was behaving exactly as documented.
+#
+# On Windows the contract is NOT "nothing is knowable" — it is that the record OUTLIVES the process
+# and the NEXT start's sweep clears it (`announce`, which exists so a recycled pid cannot inherit
+# somebody else's record). So the assertion is inverted rather than dropped, and both directions of
+# regression stay visible: a Bun that began delivering SIGTERM would leave those `// LIMIT:` comments
+# stale with nothing to notice, and a broken sweep would pile records up forever on the one platform
+# where the sweep is the only thing that cleans them.
+
+# What must hold everywhere first, and the only part of `stop` a person can observe: nothing answers
+# any more. A stale record is bookkeeping; a server still serving after `stop` is a defect.
+[ "$(curl -s -o /dev/null -w '%{http_code}' "$BASE/api/config" || true)" = 200 ] &&
+  fail "\`stop\` exited 0 but the server still answers on $BASE/api/config"
+
 case "${OSTYPE:-}" in
   msys* | cygwin*)
-    echo "lifecycle: the run-state record is not checked after \`stop\` — no SIGTERM on Windows, so it outlives the process by design"
+    stale=$(recorded_pids | grep -c . || true)
+    [ "$stale" = 1 ] ||
+      fail "on Windows \`stop\` should leave exactly one stale record for the next sweep, found $stale"
+    "$BIN" start --port "$PORT" >"$WORK/start2.log" 2>&1 || {
+      cat "$WORK/start2.log" >&2
+      fail "the \`start\` after a \`stop\` did not exit 0"
+    }
+    answers || fail "the \`start\` after a \`stop\` exited 0 but nothing answers"
+    swept=$(recorded_pids | grep -c . || true)
+    [ "$swept" = 1 ] ||
+      fail "the next \`start\` did not sweep the stale record — $swept records, expected 1"
+    echo "lifecycle: the record outlived \`stop\` (no SIGTERM on Windows) and the next \`start\` swept it"
+    "$BIN" stop --port "$PORT" >>"$WORK/stop.log" 2>&1 || fail "the second \`stop\` did not exit 0"
     ;;
   *)
     waited=0
@@ -151,10 +177,5 @@ case "${OSTYPE:-}" in
     done
     ;;
 esac
-
-# What must hold on every platform, and the only part of `stop` a person can observe: nothing
-# answers any more. A stale record is bookkeeping; a server still serving after `stop` is a defect.
-[ "$(curl -s -o /dev/null -w '%{http_code}' "$BASE/api/config" || true)" = 200 ] &&
-  fail "\`stop\` exited 0 but the server still answers on $BASE/api/config"
 
 echo "lifecycle: OK — start, status, restart and stop all behaved on $BIN"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,23 @@ on:
   push:
     tags: ['v*']
   workflow_dispatch:
+  # THE REHEARSAL, on the pull request that bumps the version - because a tag is irreversible. The
+  # `release tags` ruleset forbids moving or deleting one, so a gate that first runs AFTER the tag
+  # spends a version number every time it catches something. That is exactly what v0.28.0 was: the
+  # gate worked, held the release in a draft and let nobody download a thing, and the number was
+  # burnt anyway by an assertion the scripts had wrong. Building and driving the binaries on the
+  # bump's own pull request moves the discovery to before the irreversible step.
+  #
+  # `paths: package.json` because that is the file a release bumps, and it is the one place the
+  # version lives. It also fires on a dependency change, which is not waste - a dependency is
+  # precisely what breaks a compile that `bun test` cannot see.
+  #
+  # NOTHING here publishes: every writing step and both attestations are `if: ref_type == 'tag'`, so
+  # a pull request builds, smokes, survives and drives the executables while touching neither the
+  # repository nor a registry. It is the same rehearsal `workflow_dispatch` offers, made automatic -
+  # a rehearsal that depends on somebody remembering to run it is the one that was skipped.
+  pull_request:
+    paths: ['package.json']
 
 # The draft is created here and the assets are uploaded by each build job.
 permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,6 +127,15 @@ jobs:
 
   tray:
     needs: draft
+    # NOT on the rehearsal. Two reasons that point the same way. It adds nothing a pull request does
+    # not already have: `ci.yml` compiles the tray's Rust on macOS AND Windows and runs `cargo test`
+    # there, so what the rehearsal would add is the Tauri BUNDLER, and the gates being rehearsed are
+    # the server's. And it is the larger half of the untrusted code this workflow builds - three
+    # Cargo dependency trees and a `build.rs` per runner - which on a pull request would execute
+    # while the job holds the write-scoped token that only a tag used to produce. Skipping it here
+    # cuts the rehearsal's cost and its blast radius at once, and costs a release nothing: a tag
+    # still builds all three installers, and `publish` still waits for them.
+    if: github.event_name != 'pull_request'
     strategy:
       # Every leg is reported even when one fails: a release with half its installers is a thing to
       # know about in full, not one failure at a time.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,16 +30,29 @@ on:
   # burnt anyway by an assertion the scripts had wrong. Building and driving the binaries on the
   # bump's own pull request moves the discovery to before the irreversible step.
   #
-  # `paths: package.json` because that is the file a release bumps, and it is the one place the
-  # version lives. It also fires on a dependency change, which is not waste - a dependency is
-  # precisely what breaks a compile that `bun test` cannot see.
+  # `package.json` because that is the file a release bumps, and the one place the version lives; it
+  # also fires on a dependency change, which is not waste - a dependency is precisely what breaks a
+  # compile `bun test` cannot see. And the GATE MACHINERY ITSELF, because the v0.28.0 incident lived
+  # in `server-lifecycle.sh`: without those paths a change to the gates merged after the bump's run
+  # and before the tag is pushed would never be rehearsed at all, and would land straight on the
+  # irreversible step.
   #
   # NOTHING here publishes: every writing step and both attestations are `if: ref_type == 'tag'`, so
   # a pull request builds, smokes, survives and drives the executables while touching neither the
   # repository nor a registry. It is the same rehearsal `workflow_dispatch` offers, made automatic -
   # a rehearsal that depends on somebody remembering to run it is the one that was skipped.
   pull_request:
-    paths: ['package.json']
+    paths: ['package.json', '.github/workflows/release.yml', '.github/scripts/**']
+
+# A tag run must never be cancelled - it can be halfway through `gh release upload`, and a
+# half-populated draft is worse than a slow one. A pull request run is the opposite: `paths` are
+# matched against the WHOLE diff, so once `package.json` is in it every later push to that branch
+# starts another full matrix - nine jobs, three Tauri builds, and two legs that each sit through ten
+# 40-second idle windows. Four pushes to a bump pull request would otherwise queue four of those at
+# once, two of them on `windows-11-arm`.
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 # The draft is created here and the assets are uploaded by each build job.
 permissions:

--- a/apps/tray/tests/release-workflow.test.ts
+++ b/apps/tray/tests/release-workflow.test.ts
@@ -192,6 +192,17 @@ test('the release gates rehearse on the pull request that bumps the version', ()
   assert.match(triggers, /cancel-in-progress: \$\{\{ github\.event_name == 'pull_request' \}\}/);
 });
 
+// The rehearsal builds the server and not the tray. `ci.yml` already compiles the tray's Rust on
+// macOS and Windows and runs its tests there, so a pull request would only gain the Tauri bundler —
+// while paying three Cargo dependency trees and a `build.rs` per runner, all of it untrusted code
+// executing in a job that carries a write-scoped token. The gates being rehearsed are the server's.
+test('the tray is built for a tag, never for the rehearsal', () => {
+  const tray = job('tray');
+  assert.match(tray.split('strategy:')[0] ?? '', /if: github\.event_name != 'pull_request'/);
+  // And it stays a dependency of publish, so a tag cannot ship a release page missing its installers.
+  assert.match(job('publish'), /needs: \[tray, /);
+});
+
 // A rehearsal must stay a rehearsal: an attestation records, in a PUBLIC transparency log, that a
 // file was built from a commit — doing that for a build nobody ships publishes provenance for an
 // artifact that never existed. Walked per step rather than matched as one regex, for the reason the

--- a/apps/tray/tests/release-workflow.test.ts
+++ b/apps/tray/tests/release-workflow.test.ts
@@ -25,7 +25,13 @@ function job(name: string): string {
 // Everything that writes to the repository is gated on the ref TYPE, and that is what keeps a
 // manual run a rehearsal: it builds the same artifacts and attaches them to the workflow run.
 test('only a tag can write to the repository', () => {
-  const writers = [...WORKFLOW.matchAll(/gh release (create|upload|edit)/g)].map((m) => m[1]).sort();
+  // Comments stripped first: a writing site is a COMMAND, and this counted prose too — a comment
+  // that merely names `gh release upload` while explaining why a tag run must not be cancelled was
+  // enough to fail it, which is a false red about a file that writes exactly as much as before.
+  const commands = WORKFLOW.split('\n')
+    .filter((line) => !/^\s*#/.test(line))
+    .join('\n');
+  const writers = [...commands.matchAll(/gh release (create|upload|edit)/g)].map((m) => m[1]).sort();
   assert.deepEqual(writers, ['create', 'edit', 'upload', 'upload'], 'the draft, both halves, the flip');
   // Each writing site carries the gate on its own step, or on the job around it — `publish` is
   // gated once for the whole job, and the npm job likewise. This used to count the gates in the
@@ -175,13 +181,28 @@ test('only the emulated leg is allowed to fail, and only its steps say so', () =
 // skipped.
 test('the release gates rehearse on the pull request that bumps the version', () => {
   const triggers = WORKFLOW.slice(0, WORKFLOW.indexOf('\njobs:'));
-  assert.match(triggers, /pull_request:\n\s+paths: \['package\.json'\]/);
-  // And the rehearsal must stay a rehearsal: an attestation on a build nobody ships would put a
-  // provenance record in a public transparency log for an artifact that never existed.
-  const attestations = [
-    ...WORKFLOW.matchAll(/- if: github\.ref_type == 'tag'\n\s+uses: actions\/attest-build-provenance/g),
-  ];
-  assert.equal(attestations.length, 2, 'both attestations stay tag-only');
+  const paths = /pull_request:\n\s+paths: \[(.+)\]/.exec(triggers)?.[1] ?? '';
+  // The version's own file, and the machinery that gates it — the v0.28.0 defect was in a script,
+  // and a script change merged after the bump's run would otherwise reach the tag unrehearsed.
+  for (const p of ['package.json', 'release.yml', '.github/scripts']) {
+    assert.ok(paths.includes(p), `the rehearsal does not fire on ${p}: ${paths}`);
+  }
+  // A pull request run must be cancellable and a tag run must NOT: cancelling a tag halfway through
+  // `gh release upload` leaves a half-populated draft.
+  assert.match(triggers, /cancel-in-progress: \$\{\{ github\.event_name == 'pull_request' \}\}/);
+});
+
+// A rehearsal must stay a rehearsal: an attestation records, in a PUBLIC transparency log, that a
+// file was built from a commit — doing that for a build nobody ships publishes provenance for an
+// artifact that never existed. Walked per step rather than matched as one regex, for the reason the
+// gate-counting test above gives: a `name:` or a compound condition must not turn this red while the
+// gate is still right.
+test('provenance is attested only on a tag', () => {
+  const steps = WORKFLOW.split(/\n {6}- /).filter((s) => s.includes('attest-build-provenance'));
+  assert.equal(steps.length, 2, 'the server binaries and the tray installers');
+  for (const step of steps) {
+    assert.match(step, /if: github\.ref_type == 'tag'/, `an attestation runs off a tag:\n${step}`);
+  }
 });
 
 // The step after a failure is where the second finding lives: a binary that dies on its own is worth

--- a/apps/tray/tests/release-workflow.test.ts
+++ b/apps/tray/tests/release-workflow.test.ts
@@ -168,6 +168,22 @@ test('only the emulated leg is allowed to fail, and only its steps say so', () =
   assert.match(windows, /continue-on-error: \$\{\{ matrix\.runner == 'windows-11-arm' \}\}/);
 });
 
+// A tag cannot be moved or deleted, so a gate that first runs AFTER the tag spends a version number
+// every time it catches something — v0.28.0 was exactly that: the gate held the release in a draft,
+// nobody could download anything, and the number was burnt anyway. The rehearsal has to be
+// automatic, because the one that depended on remembering a manual dispatch is the one that was
+// skipped.
+test('the release gates rehearse on the pull request that bumps the version', () => {
+  const triggers = WORKFLOW.slice(0, WORKFLOW.indexOf('\njobs:'));
+  assert.match(triggers, /pull_request:\n\s+paths: \['package\.json'\]/);
+  // And the rehearsal must stay a rehearsal: an attestation on a build nobody ships would put a
+  // provenance record in a public transparency log for an artifact that never existed.
+  const attestations = [
+    ...WORKFLOW.matchAll(/- if: github\.ref_type == 'tag'\n\s+uses: actions\/attest-build-provenance/g),
+  ];
+  assert.equal(attestations.length, 2, 'both attestations stay tag-only');
+});
+
 // The step after a failure is where the second finding lives: a binary that dies on its own is worth
 // driving through the four verbs anyway, in the same run.
 test('a failed survival step does not skip the lifecycle that follows it', () => {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable structural changes to seedeep are recorded here, newest first.
 
 ## Unreleased
 
+**The release gates now rehearse on the pull request that bumps the version, and the Windows
+assertion they got wrong is fixed.** v0.28.0 was tagged, built, and never published: `stop` was
+asserted to remove the server's run-state record, which is true on POSIX and false on Windows —
+there is no SIGTERM there, so the runtime terminates the process, the shutdown path never runs and
+the file waits for the next start's sweep. `stop-cmd.ts` marks it `// LIMIT:` and `docs/tray.md`
+documents the same for `taskkill /F`; the script was asserting a behaviour seedeep says it does not
+have. It now checks the record on POSIX only, and everywhere checks the part a person can observe:
+after `stop`, nothing answers.
+
+The gate behaved correctly throughout — the release stayed a draft, npm was untouched, nobody could
+download anything — but a tag cannot be moved or deleted, so a version number was spent on a
+defective test. `release.yml` therefore also runs on a pull request touching `package.json`: the
+full build and every gate, publishing nothing (all writing steps and both attestations remain
+`if: ref_type == 'tag'`). The tag keeps its own run as a second net, and for the one thing a
+rehearsal cannot prove — there the assets are downloaded from the release, which is how a build that
+was never uploaded gets caught.
+
+**What the burnt run did measure, and it is the answer the job was built for.** One binary
+(`windows-x64`), two runners: **10/10 survived on x64 silicon**, **7/10 under Prism** — deaths at
+t+12s, t+11s, t+11s, `exit 139`, no request ever sent. Three in ten under emulation against the
+three in eight measured by hand on the VM, same timing signature. The `0xC0000005` attribution to
+Prism is confirmed and the x64 binary is cleared on the hardware it ships for. `restart` was
+confirmed on both, and the detached lifecycle ran green on all four POSIX targets.
+
 ## 0.28.0 (2026-08-16)
 
 **Every binary is now RUN, not merely started — and the crash nobody had measured gets a controlled

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -163,7 +163,12 @@ also runs on a **pull request that touches `package.json`**, which is the file a
 the only place the version lives. That run builds every executable and puts them through the same
 gates, and publishes nothing: every writing step and both attestations are `if: ref_type == 'tag'`.
 `workflow_dispatch` offers the same rehearsal on demand — this makes it automatic, since the version
-that depended on somebody remembering to run it is the one that got skipped. The gate on the tag
+that depended on somebody remembering to run it is the one that got skipped. **The rehearsal builds
+the server and not the tray**: `ci.yml` already compiles the tray's Rust on macOS and Windows and
+runs its tests, so a pull request would only gain the Tauri bundler while paying three Cargo
+dependency trees — and that is also the larger half of the untrusted code this workflow builds, which
+on a pull request executes in a job holding a token only a tag used to produce. A tag still builds
+all three installers, and `publish` still waits for them. The gate on the tag
 stays, as a second net and for the one thing a rehearsal cannot prove: there the assets are
 downloaded *from the release*, which is how a build that was never uploaded gets caught.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -155,6 +155,18 @@ the binary comes from the release itself, which also proves the upload happened 
 installer was built and never uploaded — and on a manual run it comes from the run's artifact, so
 the whole matrix is provable without cutting a release.
 
+**The gates rehearse before the tag, because a tag cannot be taken back.** The `release tags`
+ruleset forbids moving or deleting one, so a gate that first runs *after* the tag spends a version
+number every time it catches something — v0.28.0 was exactly that: the gate worked, the release
+stayed a draft, nobody could download anything, and the number was burnt anyway. So `release.yml`
+also runs on a **pull request that touches `package.json`**, which is the file a release bumps and
+the only place the version lives. That run builds every executable and puts them through the same
+gates, and publishes nothing: every writing step and both attestations are `if: ref_type == 'tag'`.
+`workflow_dispatch` offers the same rehearsal on demand — this makes it automatic, since the version
+that depended on somebody remembering to run it is the one that got skipped. The gate on the tag
+stays, as a second net and for the one thing a rehearsal cannot prove: there the assets are
+downloaded *from the release*, which is how a build that was never uploaded gets caught.
+
 **Starting is not surviving, and neither is being started in the foreground.** The check above is
 seconds of work, so a binary that dies at t+11s passes it; and `serve` is not how anybody runs
 seedeep. So each of the six legs goes on to run two more scripts against the same asset:


### PR DESCRIPTION
v0.28.0 was tagged, built and **never published**. Here is what went wrong and what changes.

## The assertion was wrong, not the product

`stop` was asserted to remove the server's run-state record. True on POSIX; false on Windows, where there is no SIGTERM — the runtime terminates the process, the shutdown path never runs, and the file waits for the next start's sweep. `stop-cmd.ts:72` marks it `// LIMIT:` and `docs/tray.md` documents the same for `taskkill /F`. Both Windows legs went red while the product behaved exactly as documented.

Now the record is checked **on POSIX only**, where the product really takes it back. Everywhere, the script checks the part a person can observe: after `stop`, nothing answers. A stale record is bookkeeping; a server still serving after a stop is a defect, and that assertion is unchanged.

## The gate worked — the flow around it did not

The release stayed a draft, npm was untouched, nobody could download anything. But a tag cannot be moved or deleted (`release tags` ruleset), so a version number was spent on a defective test.

`release.yml` now also runs on a **pull request touching `package.json`** — the file a release bumps, and the only place the version lives. That run builds every executable and puts them through every gate, and publishes nothing: all writing steps and both attestations stay `if: ref_type == 'tag'`, asserted by a test. `workflow_dispatch` already offered this rehearsal on demand; the one that depends on somebody remembering to run it is the one that got skipped.

The tag keeps its own run, as a second net and for the one thing a rehearsal cannot prove: there the assets are downloaded **from the release**, which is how a build that was never uploaded gets caught — the v0.6.0 failure.

## What the burnt run measured, which is what the job was built for

One binary (`seedeep-server_0.28.0_windows-x64.exe`), two runners, ten starts of 40s idle each:

| Runner | Result |
|---|---|
| `windows-latest` — x64 on x64 silicon | **10/10 survived** |
| `windows-11-arm` — same file under Prism | **7/10** — t+12s, t+11s, t+11s, `exit 139`, no request ever sent |

Three in ten under emulation against the three in eight measured by hand on the VM, same timing signature. **The `0xC0000005` attribution to Prism is confirmed, and the x64 binary is cleared on the hardware it ships for.** `restart` was confirmed on both legs, and the detached lifecycle ran green on all four POSIX targets — it had never been driven end-to-end on a real binary on any platform.

This PR touches `package.json`? No — so it will *not* trigger the rehearsal. The next release PR will be the first to use it.