### PR TITLE
The rehearsal becomes a check the merge waits for

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,8 +41,13 @@ on:
   # a pull request builds, smokes, survives and drives the executables while touching neither the
   # repository nor a registry. It is the same rehearsal `workflow_dispatch` offers, made automatic -
   # a rehearsal that depends on somebody remembering to run it is the one that was skipped.
+  # NO `paths:` here, and that is deliberate rather than an omission - the filter moved into the
+  # `changes` job below. A workflow that a path filter keeps from starting reports NOTHING, and a
+  # required check that is never reported sits at *Pending* and blocks the pull request forever
+  # (GitHub, *Troubleshooting required status checks*). A job skipped by its own `if:` reports
+  # SUCCESS instead. So the only way the rehearsal can be a required check without holding every
+  # unrelated pull request hostage is for the workflow to always start and decide inside itself.
   pull_request:
-    paths: ['package.json', '.github/workflows/release.yml', '.github/scripts/**']
 
 # A tag run must never be cancelled - it can be halfway through `gh release upload`, and a
 # half-populated draft is worse than a slow one. A pull request run is the opposite: `paths` are
@@ -63,7 +68,50 @@ jobs:
   # treats a SKIPPED dependency as a reason to skip, so a draft job that vanished on a manual run
   # would take both build jobs with it - and a manual run has to keep building, that is what it is
   # for. So the job always runs and only its one writing step is conditional.
+  # Does this pull request need the rehearsal? The filter a `paths:` used to apply, moved where a
+  # skip still REPORTS - see the trigger above for why that difference decides everything.
+  #
+  # It runs on every event, not only on pull requests, and answers `true` for the rest: a job listed
+  # in another job's `needs` takes its dependants down with it when it is skipped, so a `changes`
+  # that skipped on a tag would skip the entire release.
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      rehearse: ${{ steps.decide.outputs.rehearse }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          # The whole history, because the comparison is against the base branch's tip and a shallow
+          # clone has no common ancestor to compare with.
+          fetch-depth: 0
+      # Through the environment, never interpolated into the command: the reason the draft job
+      # gives for a ref name applies to a sha just the same.
+      - id: decide
+        env:
+          EVENT: ${{ github.event_name }}
+          BASE: ${{ github.event.pull_request.base.sha }}
+          HEAD: ${{ github.event.pull_request.head.sha }}
+        shell: bash
+        run: |
+          if [ "$EVENT" != pull_request ]; then
+            echo "rehearse=true" >> "$GITHUB_OUTPUT"
+            echo "not a pull request — the full workflow runs"
+            exit 0
+          fi
+          # `package.json` is where a release bumps the version, and it is the only place the version
+          # lives. The workflow and the scripts because the v0.28.0 defect was IN a gate script: a
+          # change to the machinery merged after a bump's run would otherwise reach the tag having
+          # been rehearsed by nothing.
+          changed=$(git diff --name-only "$BASE" "$HEAD")
+          echo "$changed"
+          if printf '%s\n' "$changed" | grep -qE '^(package\.json|\.github/workflows/release\.yml|\.github/scripts/)'; then
+            echo "rehearse=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "rehearse=false" >> "$GITHUB_OUTPUT"
+          fi
+
   draft:
+    needs: changes
     runs-on: ubuntu-latest
     steps:
       # Idempotent on purpose: re-running a tag's workflow must not fail on the release that the
@@ -286,7 +334,11 @@ jobs:
   # what `bun build --compile --target=…` buys and the tray cannot have (its matrix exists because
   # Tauri needs each platform's own SDK).
   server:
-    needs: draft
+    needs: [draft, changes]
+    # The one place the rehearsal's filter is applied. `smoke` and `windows` need this job, so a skip
+    # here carries them with it — and the tray has its own condition, since it is not rehearsed at
+    # all.
+    if: needs.changes.outputs.rehearse == 'true'
     runs-on: ubuntu-latest
     # Restated for the reason the tray's block gives: a job-level block replaces the workflow's.
     permissions:
@@ -528,6 +580,34 @@ jobs:
         shell: bash
         continue-on-error: true
         run: .github/scripts/server-lifecycle.sh "bin/seedeep-server_${VERSION}_windows-x64.exe"
+
+  # THE required check, and the only one from this workflow that should ever be in the ruleset.
+  #
+  # The matrix legs cannot be required directly: their names carry the matrix (`smoke (macos-15-intel,
+  # macos-x64)`), so the ruleset would break the day a target is added or renamed. This job's name is
+  # fixed, and it says one thing — did the rehearsal hold.
+  #
+  # `always()` because a job that is skipped or that inherits a failure would otherwise not report at
+  # all, which for a required check is indistinguishable from "still running". It reads the results
+  # itself instead: `success` and `skipped` both pass (a pull request that touches nothing relevant
+  # skips the lot, and that is a pass), `failure` and `cancelled` do not.
+  rehearsal:
+    name: Release rehearsal
+    if: always() && github.event_name == 'pull_request'
+    needs: [changes, server, smoke, windows]
+    runs-on: ubuntu-latest
+    steps:
+      - env:
+          RESULTS: ${{ toJSON(needs) }}
+        shell: bash
+        run: |
+          echo "$RESULTS"
+          bad=$(printf '%s' "$RESULTS" | jq -r 'to_entries[] | select(.value.result == "failure" or .value.result == "cancelled") | "\(.key)=\(.value.result)"')
+          if [ -n "$bad" ]; then
+            echo "rehearsal: FAIL — $bad" >&2
+            exit 1
+          fi
+          echo "rehearsal: OK — nothing the release depends on failed"
 
   # The npm channel: the same six executables, each wrapped in a package npm resolves by `os`/`cpu`,
   # under one `seedeep` wrapper whose postinstall puts the binary where `bin` already points. Node is

--- a/apps/tray/tests/release-workflow.test.ts
+++ b/apps/tray/tests/release-workflow.test.ts
@@ -181,15 +181,42 @@ test('only the emulated leg is allowed to fail, and only its steps say so', () =
 // skipped.
 test('the release gates rehearse on the pull request that bumps the version', () => {
   const triggers = WORKFLOW.slice(0, WORKFLOW.indexOf('\njobs:'));
-  const paths = /pull_request:\n\s+paths: \[(.+)\]/.exec(triggers)?.[1] ?? '';
+  // NO `paths:` on the trigger. A workflow a path filter keeps from starting reports nothing, and a
+  // required check that is never reported sits at Pending and blocks the pull request forever. The
+  // filter lives in `changes`, where a skip still reports success.
+  assert.doesNotMatch(triggers, /pull_request:\n\s+paths:/);
   // The version's own file, and the machinery that gates it — the v0.28.0 defect was in a script,
   // and a script change merged after the bump's run would otherwise reach the tag unrehearsed.
-  for (const p of ['package.json', 'release.yml', '.github/scripts']) {
-    assert.ok(paths.includes(p), `the rehearsal does not fire on ${p}: ${paths}`);
+  const changes = job('changes');
+  // The literal strings as the job's own grep spells them, escapes included — a `.includes` here
+  // rather than a regex, so this test is not a second place where the escaping can be got wrong.
+  for (const p of ['package\\.json', 'release\\.yml', '\\.github/scripts/']) {
+    assert.ok(changes.includes(p), `the rehearsal does not fire on ${p}`);
   }
+  // Never conditional on the event: a job that skips takes everything that needs it down with it,
+  // so a `changes` skipped on a tag would skip the whole release.
+  assert.doesNotMatch(changes.split('steps:')[0] ?? '', /if:/);
   // A pull request run must be cancellable and a tag run must NOT: cancelling a tag halfway through
-  // `gh release upload` leaves a half-populated draft.
+  // an upload leaves a half-populated draft.
   assert.match(triggers, /cancel-in-progress: \$\{\{ github\.event_name == 'pull_request' \}\}/);
+});
+
+// The check the ruleset requires, and the reason it can exist at all: the matrix legs carry their
+// matrix in their names, so requiring them directly would break the day a target is added. This one
+// has a fixed name and answers one question.
+test('one stable check speaks for the whole rehearsal', () => {
+  const rehearsal = job('rehearsal');
+  const head = rehearsal.split('steps:')[0] ?? '';
+  assert.match(head, /name: Release rehearsal/, 'the ruleset requires this string');
+  // `always()`, or a skipped/inherited-failure job reports nothing — which a required check cannot
+  // tell apart from "still running".
+  assert.match(head, /if: always\(\) && github\.event_name == 'pull_request'/);
+  for (const dep of ['changes', 'server', 'smoke', 'windows']) {
+    assert.match(head, new RegExp(`needs: \\[[^\\]]*\\b${dep}\\b`), `${dep} is not covered by it`);
+  }
+  // Both verdicts, and only these two: `skipped` has to pass (a pull request touching nothing
+  // relevant skips the lot) while `cancelled` must not be mistaken for one.
+  assert.match(rehearsal, /"failure" or \.value\.result == "cancelled"/);
 });
 
 // The rehearsal builds the server and not the tray. `ci.yml` already compiles the tray's Rust on

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable structural changes to seedeep are recorded here, newest first.
 
 ## Unreleased
 
+**The rehearsal became a check the merge actually waits for.** It ran on every release pull request
+already, and nothing required it: a pull request could be merged with the gates red, which is the
+same hole the rehearsal was built to close, one step up. The obstacle was the path filter — a
+workflow a `paths:` trigger keeps from starting reports NOTHING, and a required check that is never
+reported sits at *Pending* and blocks the pull request forever, so requiring the matrix legs would
+have frozen every unrelated pull request. A job skipped by its own `if:` reports success instead.
+
+So the filter moved off the trigger and into a first job, `changes`, which reads the diff and
+decides; `server` (and through it `smoke` and `windows`) runs only when it says so. One summary job
+with a fixed name, **`Release rehearsal`**, reads their results and is the single check the ruleset
+requires — the matrix legs cannot be required directly, since their names carry the matrix and would
+break the day a target is added.
+
 **The release gates now rehearse on the pull request that bumps the version, and the Windows
 assertion they got wrong is fixed.** v0.28.0 was tagged, built, and never published: `stop` was
 asserted to remove the server's run-state record, which is true on POSIX and false on Windows —

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -159,8 +159,17 @@ the whole matrix is provable without cutting a release.
 ruleset forbids moving or deleting one, so a gate that first runs *after* the tag spends a version
 number every time it catches something — v0.28.0 was exactly that: the gate worked, the release
 stayed a draft, nobody could download anything, and the number was burnt anyway. So `release.yml`
-also runs on a **pull request that touches `package.json`**, which is the file a release bumps and
-the only place the version lives. That run builds every executable and puts them through the same
+also runs on **every pull request**, and a first job (`changes`) decides from the diff whether the
+rest of it is needed — `package.json`, which is the file a release bumps and the only place the
+version lives, plus `release.yml` and `.github/scripts/**`, because the v0.28.0 defect was in a gate
+script and a change to the machinery merged after a bump's run would otherwise reach the tag having
+been rehearsed by nothing. **The filter is a job and not a `paths:` trigger for one reason**: a
+workflow a path filter keeps from starting reports nothing at all, and a required check that is
+never reported sits at *Pending* and blocks the pull request forever, while a job skipped by its own
+`if:` reports success. That difference is what lets one check — **`Release rehearsal`**, a summary
+job with a fixed name that reads the results of `server`, `smoke` and `windows` — be the one thing
+the `main` ruleset requires. The matrix legs cannot be required directly: their names carry the
+matrix, so the ruleset would break the day a target is added or renamed. That run builds every executable and puts them through the same
 gates, and publishes nothing: every writing step and both attestations are `if: ref_type == 'tag'`.
 `workflow_dispatch` offers the same rehearsal on demand — this makes it automatic, since the version
 that depended on somebody remembering to run it is the one that got skipped. **The rehearsal builds


### PR DESCRIPTION
The rehearsal already ran on every release pull request, and **nothing required it** — a pull request could be merged with the gates red, which is the same hole the rehearsal exists to close, one step up. Spotted while reviewing #48: most of its checks showed *not required*.

## Why the obvious fix does not work

Adding `Release / smoke (...)` to the ruleset would have frozen every unrelated pull request. A workflow that a `paths:` trigger keeps from starting reports **nothing**, and a required check that is never reported sits at *Pending* and blocks the merge forever — GitHub's *Troubleshooting required status checks* says so explicitly. A job skipped by its own `if:` reports **success** instead. That difference is the whole design.

There is a second reason: the matrix legs carry the matrix in their names, so the ruleset would break the day a target is added or renamed.

## What changes

| Piece | Role |
|---|---|
| trigger | no more `paths:` — the workflow starts on every pull request |
| `changes` | reads the diff and decides: `package.json`, `release.yml`, `.github/scripts/**`. Never conditional itself — a skipped job takes its dependants with it, so a `changes` that skipped on a tag would skip the entire release |
| `server` | runs only when `changes` says so; `smoke` and `windows` follow it |
| **`Release rehearsal`** | one summary job, fixed name, `needs: [changes, server, smoke, windows]`. `always()`, because a job that is skipped or inherits a failure reports nothing — indistinguishable, to a required check, from "still running". It reads the results itself: `success` and `skipped` pass (a pull request touching nothing relevant skips the lot, and that is a pass), `failure` and `cancelled` do not |

## Order matters

**Adding the check to the ruleset comes after this merges.** A required check that does not exist yet blocks every pull request — including this one. Once it is on `main`, `Release rehearsal` goes into the `main` ruleset, and from that point a release pull request cannot be merged with the gates red.

Suite 1709 green, lint and typecheck clean. This pull request touches `release.yml`, so it rehearses itself.