### PR TITLE
0.28.1

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable structural changes to seedeep are recorded here, newest first.
 
 ## Unreleased
 
+## 0.28.1 (2026-08-16)
+
+**0.28.0 was tagged and never published**, so this is the version that ships what it carried. The
+release run built everything, held the release in a draft, and went red on both Windows legs — over
+an assertion in the gate itself, not a defect in the product: `stop` was asserted to remove the
+server's run-state record, which is true on POSIX and false on Windows, where there is no SIGTERM.
+That assertion is now inverted rather than dropped, so the record's survival AND the next start's
+sweep are both checked; and the whole class of "the gate is discovered after the irreversible step"
+is closed by the two entries below.
+
 **The rehearsal became a check the merge actually waits for.** It ran on every release pull request
 already, and nothing required it: a pull request could be merged with the gates red, which is the
 same hole the rehearsal was built to close, one step up. The obstacle was the path filter — a

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "seedeep",
-  "version": "0.28.0",
+  "version": "0.28.1",
   "private": true,
   "type": "module",
   "description": "Live context & subagent visualizer for Claude Code",


### PR DESCRIPTION
The version that ships what 0.28.0 carried. That tag was created, built everything, held its release in a draft and went red on both Windows legs — over an assertion in the gate rather than a defect in the product — and was never published. The draft has been deleted; the tag remains, since the ruleset forbids removing one.

- `package.json` → `0.28.1`, the only place the version lives.
- `## Unreleased` → `## 0.28.1 (2026-08-16)`, the tag commit's local date, with a fresh empty `Unreleased` above it.

## This is the first release PR that cannot be merged with the gates red

`Release rehearsal` is a required check as of an hour ago, and this PR touches `package.json` — so it builds all six executables and drives them through the survival and lifecycle gates on six platforms **before** anything is tagged. That is the whole point of the last three PRs: the v0.28.0 defect was found by a gate that ran *after* the irreversible step, and a tag cannot be moved or deleted.

What ships in it, all merged since 0.28.0:

| | |
|---|---|
| The Windows assertion | `stop` was asserted to remove the run-state record — true on POSIX, false on Windows, where there is no SIGTERM. Now inverted rather than dropped: the record must survive `stop` **and** the next `start` must sweep it |
| The rehearsal | `release.yml` runs on every pull request; a `changes` job reads the diff and decides whether the rest is needed |
| The required check | one summary job with a fixed name, since the matrix legs carry their matrix in their names and would break the ruleset the day a target is added |
| The platform table | both x64 rows said "never used"; they are exercised on every release now, and the rows say what is still true — nobody has used one in front of a screen |