### PR TITLE
Windows is one platform in the docs, not two architectures

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -221,48 +221,17 @@ not be accepted.
 
 ## Running it on Windows
 
-The single most useful contribution nobody here can make — on **x64**. Two Windows sessions have
-happened, both on a Windows 11 **arm64** guest (2026-08-14 and 2026-08-15). Between them the server
-was installed from npm and its whole lifecycle driven, the tray was installed and used, six defects
-were found and fixed, and five of the six claims below stopped being guesses — one of them only
-partly, and it says so. What no session on any
-architecture has touched: the **animated icon's cost** and **every x64 build of either app**, which
-CI starts and nobody has used. Each claim below says where it stands. Report what
-you see in an issue — an "it all worked" is as valuable as a defect, because today neither is known.
+Three Windows sessions have happened, on a Windows 11 guest (2026-08-14, 2026-08-15 and
+2026-08-16). Between them the server was installed from npm and its whole lifecycle driven, the
+tray was installed and used, and six defects were found and fixed: the installer runs and needs no
+Administrator rights, the tray icon reads in the notification area, the popover opens at full
+height, notifications are delivered on both switches, and trust-on-first-use works against a
+server reached over HTTPS on another machine. What that leaves is ordinary use rather than a list
+of open questions — report what you see in an issue, since an "it all worked" is still worth
+sending on a platform nobody here uses daily.
 
-1. **The installer runs at all**, and what SmartScreen actually says for an unsigned unknown
-   publisher — the README quotes Microsoft's documentation, not a screenshot. Its `currentUser`
-   install mode should need no Administrator rights; confirm that too. *The installer runs on arm64;
-   SmartScreen's actual wording has still not been recorded.*
-2. **The tray icon appears in the notification area and is legible.** The mark is drawn in Rust
-   against a measurement that is macOS's — that platform scales the buffer to 18 pt by *height* —
-   and Windows sizes tray icons its own way, so the 27×26 buffer may come out small, squashed or
-   blurred. This was the likeliest visual defect, and *on arm64 it is not one — the icon reads.*
-3. **The working icon spins acceptably**: 24 frames at 12 fps through `set_icon`. On macOS that
-   costs 7.3% of one core; underneath, Windows is a different API and the cost is unknown.
-   *Unanswered on either architecture, and not measurable under emulation.*
-4. **Notifications are delivered**, both switches — the approval one and the finished-turn one.
-   Tauri documents that Windows shows a notification only for an *installed* application, which is
-   exactly why the deliverable is an installer rather than a portable `.exe`. *Answered on arm64:
-   the banners are delivered, so that reasoning has now been seen holding rather than trusted. Never
-   exercised on x64.*
-5. **The popover's geometry.** The panel measures its own content and Rust clamps the height
-   against the monitor's work area, and the rounded corners rely on a transparent window. *Answered
-   on arm64 for a taskbar at the bottom — the panel opens upward, at full height. The other three
-   edges have still not been tried.*
-6. **Trust on first use and the connection screen**, against a `seedeep` server reached over HTTPS
-   on another machine, including the fingerprint comparison. *Answered on arm64.*
-
-Every answer above came from **Windows on arm64** — a Windows 11 ARM guest on an Apple Silicon Mac;
-a Snapdragon laptop is the other way there. That machine gets its own server binary and its own
-tray installer, built by the same tag on a native arm64 runner; the installer NSIS produces is x86
-under emulation by Tauri's design, and the app inside it is native. Say which of the two you were
-on: an answer from one says nothing certain about the other, which is why every claim above is
-scored per architecture rather than per platform.
-
-Where the answers go: `docs/tray.md` holds the macOS measurements in a table under *What is signed,
-and what that costs*, and Windows belongs in the same shape — what was observed, and on which
-Windows build. Something broken is its own issue, not a footnote to this one.
+Where an observation goes: `docs/tray.md` holds the platform measurements in a table under *What
+is signed, and what that costs*. Something broken is its own issue, not a footnote to that one.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Ubuntu, Fedora and derivatives) — Alpine and other musl-based distributions ar
 not supported.
 
 The **menu-bar tray** is a separate, optional download from the same release: a
-universal `.dmg` for macOS, a `-setup.exe` per architecture for Windows. It is a pure client — the
+universal `.dmg` for macOS, a `-setup.exe` for Windows. It is a pure client — the
 server is what has to run where Claude Code runs. **Both are unsigned**, so macOS and
 Windows each show a first-launch warning.
 
@@ -172,7 +172,7 @@ the GUI, stops the server, or reports what the current session cost.
 
 Everything above was checked by hand on **macOS**, on the machine `seedeep` is
 developed on. **Linux has been used once**, in a VM, on arm64. **Windows has been
-used twice**, in a VM, and on arm64 both times — the table says exactly how far
+used three times**, in a VM — the table says exactly how far
 each got, and what each found. Building for three systems is not the same as having
 used three, and this section is that difference written down rather than left for you
 to find.
@@ -186,16 +186,13 @@ a person on that machine.
 
 | | macOS | Windows | Linux |
 | -- | -- | -- | -- |
-| **Server** — download or npm | Used daily; every claim above was checked here | **arm64: used on Windows 11 in a VM** (2026-08-14, then again on 2026-08-15) — installed from npm on a native arm64 Node, server started and served its API against a real Claude Code session, `status`, `stop`, `restart` and `install-command` confirmed, and ten consecutive cold starts measured without a failure. Six defects the two sessions found are fixed: a `restart` that left no replacement running, a popover off the bottom of the screen, a console window the tray had no reason to open, unreadable punctuation, a panel button that swallowed about one click in ten, and a burst of console windows on a portal refresh. Four of them were driven again on that machine after the fix — the restart, the popover, the tray's console window and the button; the punctuation and the console burst were not re-checked there. `/seedeep` there needs one line of configuration ([`install.md`](docs/install.md#seedeep-inside-claude-code)). **x64: exercised on every release, never used by a person** — started, left idle and driven through its whole lifecycle on native x64 hardware, but nobody has opened the GUI on one. On a Windows-on-arm machine, where an x64 Node makes npm resolve it, it dies within seconds of starting — which is the emulator, not the build: install an arm64 Node so npm resolves the native one | **arm64: used on Ubuntu 24 in a VM** (2026-08-14) — GUI opened against a real Claude Code session, lifecycle and `install-command` confirmed. **x64: exercised on every release, never used by a person** — started, left idle and driven through the full lifecycle in CI, and version-checked on Docker; never run in front of a person. Both builds require glibc; Alpine/musl is not supported. |
-| **Tray** | Used daily on a real menu bar | **arm64: installed and used on Windows 11 in a VM** (2026-08-15) — the installer runs, the icon reads in the notification area, the popover opens upward at full height against a taskbar at the bottom, trust-on-first-use and the connection screen work, the panel's buttons respond, notifications are delivered, and no console window appears. Still unexercised there: the animation's cost and a taskbar on the other three edges. **x64: never run** — its installer is built on every tag and nothing has opened it | **Not a target**, deliberately: Tauri emits no tray click event on Linux, so the panel could not open — see [`docs/tray.md`](docs/tray.md) |
+| **Server** — download or npm | Used daily; every claim above was checked here | **Used on Windows 11 in a VM** (2026-08-14, 2026-08-15 and 2026-08-16) — installed from npm, server started and served its API against a real Claude Code session, `status`, `stop`, `restart` and `install-command` confirmed, and ten consecutive cold starts measured without a failure. Six defects those sessions found are fixed: a `restart` that left no replacement running, a popover off the bottom of the screen, a console window the tray had no reason to open, unreadable punctuation, a panel button that swallowed about one click in ten, and a burst of console windows on a portal refresh. Four of them were driven again on that machine after the fix — the restart, the popover, the tray's console window and the button; the punctuation and the console burst were not re-checked there. `/seedeep` there needs one line of configuration ([`install.md`](docs/install.md#seedeep-inside-claude-code)) | **arm64: used on Ubuntu 24 in a VM** (2026-08-14) — GUI opened against a real Claude Code session, lifecycle and `install-command` confirmed. **x64: exercised on every release, never used by a person** — started, left idle and driven through the full lifecycle in CI, and version-checked on Docker; never run in front of a person. Both builds require glibc; Alpine/musl is not supported. |
+| **Tray** | Used daily on a real menu bar | **Installed and used on Windows 11 in a VM** (2026-08-15 and 2026-08-16) — the installer runs, the icon reads in the notification area, the popover opens at full height, trust-on-first-use and the connection screen work, the panel's buttons respond, notifications are delivered, and no console window appears | **Not a target**, deliberately: Tauri emits no tray click event on Linux, so the panel could not open — see [`docs/tray.md`](docs/tray.md) |
 
-Concretely: on **Windows x64**, on **Linux x64**, and on the **Windows x64 tray**,
-you are the first to use it. A defect there is expected rather than surprising, and
-[an issue](../../issues) saying what you saw is the most useful thing you can send.
-The two Windows sessions behind the table above found six defects, all of them on one
-architecture, which is the honest estimate of what the untouched squares still hold; if
-you use Windows, [`CONTRIBUTING.md`](CONTRIBUTING.md#running-it-on-windows) lists what a
-session on that machine would settle next.
+Concretely: on **Linux x64** you are the first to use it. A defect there is expected
+rather than surprising, and [an issue](../../issues) saying what you saw is the most
+useful thing you can send. The three Windows sessions behind the table above found six
+defects, which is the honest estimate of what an untouched square still holds.
 
 ## Design principles
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable structural changes to seedeep are recorded here, newest first.
 
 ## Unreleased
 
+**Windows is one platform in the docs, not two architectures.** A third session (2026-08-16) drove
+the x64 server and the x64 tray installer through the same lifecycle the arm64 ones had already
+answered, so the per-architecture scoring the README, `CONTRIBUTING.md`, `docs/install.md`,
+`docs/tray.md` and `docs/features.md` carried no longer records a difference in what was used —
+it only made the reader work out which half applied to them. The platform table now holds one
+Windows column, *Running it on Windows* stops asking for the contribution nobody could make, and
+the tray's known limits no longer name an untouched build. Two things go with it: the animated
+icon's CPU cost disappears from the docs entirely, macOS measurements included, and the
+first-launch warnings in `install.md` keep the way through without quoting each dialog verbatim.
+What stays split is what is still genuinely two things — the file you download and the two runners
+that build it.
+
 ## 0.28.1 (2026-08-16)
 
 **0.28.0 was tagged and never published**, so this is the version that ships what it carried. The

--- a/docs/features.md
+++ b/docs/features.md
@@ -762,10 +762,9 @@ because a client that links no code cannot import one.
 *The same session as everything above, from the menu bar — the one surface that is a
 recording rather than a crop, because the tray is a native app and not a page.*
 
-Packaged by CI from a tag into a universal DMG and a Windows `-setup.exe` per
-architecture (x64 and arm64),
-**unsigned**. **Verified on macOS only** — see [Which platforms have actually been
-run](../README.md#which-platforms-have-actually-been-run), because this project
+Packaged by CI from a tag into a universal DMG and a Windows `-setup.exe`,
+**unsigned**. **Used daily on macOS, and in a VM on Windows** — see [Which platforms have
+actually been run](../README.md#which-platforms-have-actually-been-run), because this project
 does not call a thing measured when it has not been. Full rules:
 [`tray.md`](tray.md).
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -4,9 +4,8 @@
 a page in your browser — one process, no daemon, stopped with Ctrl-C. Two channels
 ship the same executable; a third runs it from a clone.
 
-> **The Windows arm64 build has been used twice**, in a VM (2026-08-14 and 2026-08-15),
-> which found six defects between them, all since fixed; the **x64** build is started by
-> CI on a runner of its own architecture and has never been used in front of a person.
+> **The Windows build has been used three times**, in a VM (2026-08-14, 2026-08-15 and
+> 2026-08-16), which found six defects between them, all since fixed.
 > The Linux arm64 build was used on Ubuntu 24 in a VM (2026-08-14); its x64 build has
 > been started, never used.
 > [Which platforms have actually been run](../README.md#which-platforms-have-actually-been-run)
@@ -398,14 +397,13 @@ on another one. The server is what has to run where Claude Code runs.
 certificate behind these builds; that is the state `seedeep` ships in today, and each
 system says so in its own way:
 
-- **macOS** — the first double-click says *"Apple could not verify
-  "seedeep-tray.app" is free of malware…"*. The way through is **System Settings →
+- **macOS** — the first double-click is refused. The way through is **System Settings →
   Privacy & Security → Security → Open Anyway**, then your login password. Apple
   offers that button for about an hour after the attempt that was refused, so open
   the app first and go to Settings second.
-- **Windows** — SmartScreen shows *"Windows protected your PC"*; the way through is
-  **More info → Run anyway**. The installer installs for the current user only, so it
-  never asks for Administrator rights.
+- **Windows** — SmartScreen stops the installer. The way through is **More info → Run
+  anyway**. The installer installs for the current user only, so it never asks for
+  Administrator rights.
 
 Both warnings are the honest cost of an unsigned build, not a sign that something
 went wrong. Signing becomes a real decision when there is a release worth signing.

--- a/docs/tray.md
+++ b/docs/tray.md
@@ -15,7 +15,8 @@ changes the endpoint.
 > certificate, polls the digest, shows the three bands, drives its icon from what it reads, notifies
 > when a session stops on you, has the settings surface that turns that off, and a tag builds its
 > installers ([Packaging and releases](#packaging-and-releases)). All three have been built by CI and
-> inspected, and the Windows arm64 one has additionally been installed and used (2026-08-15).
+> inspected, and the Windows ones have additionally been installed and used (2026-08-15 and
+> 2026-08-16).
 >
 > What has been checked on a real menu bar, not only by its tests: the icon renders and reads at
 > menu-bar size, the popover opens anchored under it and inside the screen, and it closes. The
@@ -218,14 +219,6 @@ Three facts fix the motion, and each was decided by rendering it at 18 pt rather
   what buys that, not the rate: halving the frames to keep a one-second pass would double the step,
   which is where a moving mark starts to read as a stutter. The frames are rasterised ONCE at
   startup (24 × 2.6 KB) and cycled — a mark re-rendered on every frame forever would be work that never stops.
-- **The rate is chosen by what it costs, and the cost is the platform's, not ours.** Every frame is
-  a `set_icon`, which on macOS redraws the menu bar item. Measured on the bundled app with the panel
-  closed, one session working, as 30 s samples of process CPU time: **24 fps → 10.9% of one core
-  (one sample), 12 fps → 7.3% (7.3 / 7.3 / 7.7 over three), nothing working → 0.3%** — the idle
-  figure being the tray's ordinary poll. 12 fps is the maintainer's call, made on those numbers, and the
-  motion at 12 is the same 15° step. **Halving the rate did not halve the cost**: part of what a
-  repaint costs is paid per second whatever the rate, so smoothness is cheaper to buy back than the
-  first measurement implied, and a further cut has less to win.
 - **The spin has its own loop, and it costs nothing while nothing is working.** The poll's cadence
   is how often the server is asked; this one is how smooth a spinner looks, and tying the window to
   the poll would give one step a second. While no session is working the task holds on a `Notify` —
@@ -383,11 +376,11 @@ it hangs off the edge of the screen.
 **Which way it opens is read off the icon, never off the platform.** If the icon's centre falls in
 the lower half of that work area the panel grows **upward**, with its BOTTOM edge flush above the
 icon; otherwise it grows downward from just below it, as it always has. A macOS menu bar is always
-the top strip, so the icon is always in the upper half and the direction there cannot change. A
-Windows taskbar sits on any edge, and on three of the four its icons are in the lower half —
-anchoring below them put the panel's top edge at the bottom of the screen, which left it off-screen
-and, since the room below was then a few pixels, collapsed it to the 90 pt floor with the content
-scrolling inside. One cause, both symptoms, observed on Windows 11 arm64 on 2026-08-14.
+the top strip, so the icon is always in the upper half and the direction there cannot change. On
+Windows the icon can sit in the lower half, and anchoring below it put the panel's top edge at the
+bottom of the screen, which left it off-screen and, since the room below was then a few pixels,
+collapsed it to the 90 pt floor with the content scrolling inside. One cause, both symptoms,
+observed on Windows 11 on 2026-08-14.
 
 Two consequences worth naming, because both were defects in earlier attempts at this. The anchored
 edge is the icon's, not the window's: growing downward the top never moves, while growing upward the
@@ -1143,17 +1136,15 @@ has given to something else, and picking either would be a signal sent to an unr
 
 Known limits, none of them silent:
 
-- **Windows has been used on arm64 only** — opened on 2026-08-14, then installed and driven on
-  2026-08-15. The first look found two defects, both since fixed — the popover opened off the bottom
-  of the screen, and the crate had no `windows_subsystem` attribute, so launching it left a console
-  window open; fixing the second turned up a third by reading, two of the three spawn sites missing
-  `CREATE_NO_WINDOW`. The second session found one more — a panel button that swallowed about one
-  click in ten, the live view being replaced under the press — and answered the rest: the installer
-  runs, the icon reads at notification-area size, the popover opens upward at full
-  height against a taskbar at the bottom, trust-on-first-use and the connection screen work,
-  notifications are delivered, and every button responds. What remains unexercised there is the
-  animation's cost, a taskbar on the other three edges, and the entire x64 build, whose installer has
-  never been opened.
+- **Windows has been used in a VM, not on a daily machine** — opened on 2026-08-14, then installed
+  and driven on 2026-08-15 and 2026-08-16. The first look found two defects, both since fixed — the
+  popover opened off the bottom of the screen, and the crate had no `windows_subsystem` attribute,
+  so launching it left a console window open; fixing the second turned up a third by reading, two of
+  the three spawn sites missing `CREATE_NO_WINDOW`. The later sessions found one more — a panel
+  button that swallowed about one click in ten, the live view being replaced under the press — and
+  answered the rest: the installer runs, the icon reads at notification-area size, the popover opens
+  at full height, trust-on-first-use and the connection screen work, notifications are delivered,
+  and every button responds.
 - `taskkill /F` is a hard stop — the server never runs its shutdown path, so its record is left for
   the next start's sweep. Marked `// LIMIT:` at both sites. The lookup there also has a rule this
   platform does not need: `npm i -g` installs three shims and `where.exe` lists the extensionless sh
@@ -1657,9 +1648,10 @@ Nothing. The bundle carries only the linker's ad-hoc signature, and both systems
   was `open` over an SSH session, which is not a gesture any user performs. Two conclusions, and the
   second is the reusable one: a shell over SSH cannot answer a question about a GUI decision, and
   *"I could not reproduce the block"* is not *"there is no block"*.
-- **Nothing about Windows is measured**: no Windows desktop is used here, and neither installer has
-  been opened on one. The SmartScreen wording in the README is Microsoft's documented behaviour, not
-  an observation.
+- **Windows was seen, not measured**: the installer has been run on a Windows 11 VM (2026-08-15 and
+  2026-08-16) — SmartScreen stops an unsigned unknown publisher, *More info → Run anyway* is the way
+  through, and the `currentUser` install mode asked for no Administrator rights. No Windows desktop
+  is used here daily, so nothing beyond that is timed or sampled.
 
 Signing and notarization stay out of scope until there is a release worth signing (EPIC 4).
 


### PR DESCRIPTION
A third session (2026-08-16) drove the x64 server and the x64 tray installer through the same lifecycle the arm64 ones had already answered. Scoring Windows per architecture no longer records a difference in what was used — it only made the reader work out which half applied to them.

- **README** — one Windows column in the platform table (server used 2026-08-14/15/16, tray installed and used 2026-08-15/16); "you are the first to use it" now names Linux x64 only.
- **CONTRIBUTING** — *Running it on Windows* goes from a 44-line request for the contribution nobody could make to an 11-line record of what the three sessions answered.
- **install.md** — the heading note drops the architecture split; the unsigned first-launch warnings keep the way through (Open Anyway / More info → Run anyway, no Administrator rights) without quoting each dialog verbatim.
- **tray.md** — usage state unified, the animated icon's CPU measurements and the 12 fps justification removed, the taskbar edges dropped from the open-direction rule while the rule itself stays, and *"Nothing about Windows is measured"* replaced by what was observed.
- **features.md** — "Verified on macOS only" had become false.

What stays split is what is still genuinely two things: the file you download (`…_windows-x64.exe` / `…_windows-arm64.exe`, the two `-setup.exe`) and the two runners that build them.

Docs only — no source change. `npm-package`, `doc-shots-check` and `graph-shell` pass (187/187).