### PR TITLE
A door for a question, not only for a bug

### DIFF
--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,27 @@
+name: Question
+description: Ask how something in seedeep works, or why it behaves the way it does.
+title: "[Question] "
+labels: ["question"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **Privacy notice:** seedeep reads your Claude Code session logs, which contain real file paths, project names, and prompt content. Redact any such information from screenshots and pasted output. Replace real paths with placeholders like `/home/dev/myproject` and real project names with generic ones.
+
+        seedeep is maintained by one person outside working hours, so an answer may take a while — see [CONTRIBUTING.md](https://github.com/duqaXxX/seedeep/blob/main/CONTRIBUTING.md#how-we-work-together).
+
+  - type: textarea
+    id: question
+    attributes:
+      label: Your question
+      description: What are you trying to understand? If seedeep showed you something you did not expect, say what it showed and what you thought it meant.
+      placeholder: "The context bar keeps growing after a compaction. Is that the same window being re-counted, or does compaction not shrink it?"
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Anything that helps answer it
+      description: Optional. The seedeep version (`seedeep --version`), your OS, or what you were doing at the time — only if it is relevant to the question.
+      placeholder: "seedeep 0.28.0 on macOS, watching a live session."

--- a/apps/server/public/lib/app.js
+++ b/apps/server/public/lib/app.js
@@ -117,6 +117,9 @@ function resolveVolByModel(volByModel, fallback) {
   }
   return [...merged.entries()].map(([model, tokens]) => ({ model, tokens })).sort((x, y) => y.tokens - x.tokens);
 }
+function reportsWindow(e) {
+  return Boolean(e.model) || e.fill > 0;
+}
 function createSessionTree(opts) {
   const windowFor2 = opts.windowFor;
   let mainModel = opts.mainModel ?? null;
@@ -254,29 +257,33 @@ function createSessionTree(opts) {
       } else if (e.model)
         sessionError = null;
       if (owner === null) {
-        mainFill = e.fill;
-        breakdown.input = e.delta.input;
-        breakdown.cacheRead = e.delta.cacheRead;
-        breakdown.cacheCreation = e.delta.cacheCreation;
+        if (reportsWindow(e)) {
+          mainFill = e.fill;
+          breakdown.input = e.delta.input;
+          breakdown.cacheRead = e.delta.cacheRead;
+          breakdown.cacheCreation = e.delta.cacheCreation;
+        }
         if (e.model) {
           mainModel = e.model;
           if (!mainModels.includes(e.model))
             mainModels.push(e.model);
         }
         if (currentTurn) {
-          currentTurn.fillEnd = e.fill;
-          currentTurn.breakdown = {
-            input: e.delta.input,
-            cacheRead: e.delta.cacheRead,
-            cacheCreation: e.delta.cacheCreation
-          };
+          if (reportsWindow(e)) {
+            currentTurn.fillEnd = e.fill;
+            currentTurn.breakdown = {
+              input: e.delta.input,
+              cacheRead: e.delta.cacheRead,
+              cacheCreation: e.delta.cacheCreation
+            };
+          }
           if (e.model)
             currentTurn.models.add(e.model);
           if (e.effort)
             currentTurn.efforts.add(e.effort);
         }
         const key = e.callId ?? `seq:${e.seq}`;
-        usageNewCall = !appliedUsageKeys.has(key);
+        usageNewCall = !appliedUsageKeys.has(key) && !e.noCall;
         if (usageNewCall) {
           appliedUsageKeys.add(key);
           apiCalls++;
@@ -307,11 +314,12 @@ function createSessionTree(opts) {
         }
       } else {
         const a = agentFor(owner);
-        a.fill = e.fill;
+        if (reportsWindow(e))
+          a.fill = e.fill;
         if (e.effort)
           a.efforts.add(e.effort);
         const key = e.callId ?? `seq:${e.seq}`;
-        usageNewCall = !a.appliedVolumeKeys.has(key);
+        usageNewCall = !a.appliedVolumeKeys.has(key) && !e.noCall;
         if (usageNewCall) {
           a.appliedVolumeKeys.add(key);
           a.volIn += e.delta.input;
@@ -349,6 +357,7 @@ function createSessionTree(opts) {
           command: e.command ?? null,
           startedAt: e.timestamp || null,
           state: "live",
+          cutoff: false,
           durationMs: null,
           messageCount: null,
           apiCalls: 0,
@@ -382,8 +391,11 @@ function createSessionTree(opts) {
         currentTurn.state = "done";
       }
     } else if (e.type === "turn-interrupted") {
-      if (owner === null && currentTurn)
+      if (owner === null && currentTurn && (!e.cutoff || currentTurn.apiCalls > 0)) {
         currentTurn.state = "interrupted";
+        if (e.cutoff)
+          currentTurn.cutoff = true;
+      }
     } else if (e.type === "turn-result") {
       if (owner === null && currentTurn) {
         currentTurn.result = e.outputFull;
@@ -799,6 +811,7 @@ function createSessionTree(opts) {
         kind: kindOf(t, agentsByTurn.has(t.index)),
         startedAt: t.startedAt,
         state,
+        cutoff: t.cutoff,
         durationMs: t.durationMs,
         messageCount: t.messageCount,
         apiCalls: t.apiCalls,
@@ -2454,6 +2467,9 @@ var EVENT_TYPES = Object.keys(LISTENED);
 
 // apps/server/src/client/replay.ts
 var REPLAY_STALE_MS = 30000;
+var RETRY_MS = 3000;
+var MAX_RETRY_MS = 30000;
+var MAX_STALE_REOPENS = 3;
 function startReplay(sessionId, handler, deps) {
   const covered = new Map;
   const liveMax = new Map;
@@ -2463,6 +2479,14 @@ function startReplay(sessionId, handler, deps) {
   let inFlight = true;
   let stopped = false;
   let resyncPending = false;
+  let sawEnd = false;
+  let retryTimer = null;
+  const baseRetryMs = deps.retryMs ?? RETRY_MS;
+  let nextRetryMs = baseRetryMs;
+  let progressed = false;
+  let staleReopens = 0;
+  let historyComplete = false;
+  const frontier = new Map;
   let floor = new Map;
   let skip = new Map;
   const buffer = [];
@@ -2474,7 +2498,10 @@ function startReplay(sessionId, handler, deps) {
   let lastFrameAt = now();
   const keyOf = (e) => e.agentId ?? "";
   function whole(key) {
-    const c = covered.get(key), l = liveMax.get(key);
+    const c = covered.get(key);
+    if (!historyComplete)
+      return c;
+    const l = liveMax.get(key);
     const lw = l === undefined ? undefined : l - 1;
     if (c === undefined)
       return lw;
@@ -2494,7 +2521,14 @@ function startReplay(sessionId, handler, deps) {
           s.n--;
           return;
         }
-        covered.set(key, Math.max(covered.get(key) ?? -1, e.seq));
+        const at = frontier.get(key);
+        if (at === undefined || e.seq > at) {
+          if (at !== undefined && at > (covered.get(key) ?? -1)) {
+            covered.set(key, at);
+            progressed = true;
+          }
+          frontier.set(key, e.seq);
+        }
       } else {
         const c = covered.get(key);
         if (c !== undefined && e.seq <= c)
@@ -2524,6 +2558,9 @@ function startReplay(sessionId, handler, deps) {
   function open(from) {
     buffering = true;
     inFlight = true;
+    sawEnd = false;
+    progressed = false;
+    frontier.clear();
     lastFrameAt = now();
     const src = new deps.EventSourceImpl(urlFor(sessionId, from));
     es = src;
@@ -2541,8 +2578,19 @@ function startReplay(sessionId, handler, deps) {
         deliver(e, "replay");
       });
     }
-    src.addEventListener("replay-end", () => finish());
-    src.addEventListener("error", () => finish());
+    src.addEventListener("replay-end", () => {
+      if (es !== src)
+        return;
+      sawEnd = true;
+      for (const [key, seq] of frontier)
+        covered.set(key, Math.max(covered.get(key) ?? -1, seq));
+      finish();
+    });
+    src.addEventListener("error", () => {
+      if (es !== src)
+        return;
+      finish();
+    });
   }
   function watchSilence() {
     if (stopped || !inFlight)
@@ -2555,22 +2603,64 @@ function startReplay(sessionId, handler, deps) {
     if (!inFlight)
       return;
     inFlight = false;
+    es?.close();
+    es = null;
+    if (!sawEnd && !stopped) {
+      staleReopens = progressed ? 0 : staleReopens + 1;
+      if (staleReopens < MAX_STALE_REOPENS) {
+        scheduleRetry();
+        return;
+      }
+    }
+    if (sawEnd)
+      historyComplete = true;
+    handOff();
+    if (stopped)
+      return;
+    if (resyncPending) {
+      resyncPending = false;
+      askedFromOutside();
+      doResync();
+      return;
+    }
+    nextRetryMs = baseRetryMs;
+  }
+  function handOff() {
     buffering = false;
     for (const e of buffer)
       deliver(e, "live");
     buffer.length = 0;
-    es?.close();
-    es = null;
     if (!handedOff) {
       handedOff = true;
       deps.onLive?.();
     }
-    if (resyncPending && !stopped) {
-      resyncPending = false;
+  }
+  function askedFromOutside() {
+    nextRetryMs = baseRetryMs;
+    staleReopens = 0;
+  }
+  function scheduleRetry() {
+    if (stopped || retryTimer !== null)
+      return;
+    const wait = nextRetryMs;
+    nextRetryMs = Math.min(nextRetryMs * 2, MAX_RETRY_MS);
+    retryTimer = setTimeout(() => {
+      retryTimer = null;
+      if (stopped || inFlight)
+        return;
+      if (deps.stillExists && !deps.stillExists()) {
+        handOff();
+        return;
+      }
       doResync();
-    }
+    }, wait);
+    retryTimer.unref?.();
   }
   function doResync() {
+    if (retryTimer !== null) {
+      clearTimeout(retryTimer);
+      retryTimer = null;
+    }
     floor = new Map;
     skip = new Map;
     const pairs = [];
@@ -2594,13 +2684,21 @@ function startReplay(sessionId, handler, deps) {
     stop() {
       stopped = true;
       clearInterval(watchdog);
-      finish();
+      if (retryTimer !== null) {
+        clearTimeout(retryTimer);
+        retryTimer = null;
+      }
+      if (inFlight)
+        finish();
+      else
+        handOff();
       if (unsubscribe)
         unsubscribe();
     },
     resync() {
       if (stopped)
         return;
+      askedFromOutside();
       if (inFlight) {
         resyncPending = true;
         return;
@@ -3483,11 +3581,11 @@ var HEARTBEAT_EVENT = "heartbeat";
 
 // apps/server/src/client/stream.ts
 var CLOSED = 2;
-var RETRY_MS = 3000;
+var RETRY_MS2 = 3000;
 var STALE_MS = 45000;
 function createStream(opts) {
   const url = opts.url ?? "/api/stream";
-  const retryMs = opts.retryMs ?? RETRY_MS;
+  const retryMs = opts.retryMs ?? RETRY_MS2;
   const staleMs = opts.staleMs ?? STALE_MS;
   const checkMs = opts.checkMs ?? Math.max(1, Math.round(staleMs / 3));
   const now = opts.now ?? (() => Date.now());
@@ -4874,7 +4972,7 @@ function verdictFrom(turn, ev, ctx) {
       cost: kTok(turn.cacheTotals.created)
     });
   }
-  if (turn.state === "interrupted" && ctx.prevInterrupted) {
+  if (turn.state === "interrupted" && !turn.cutoff && ctx.prevInterrupted) {
     findings.push({
       kind: "esc",
       severity: "warn",
@@ -4932,7 +5030,7 @@ function contexts(snap, evidence) {
   let checkedBefore = false;
   for (let i = 0;i < work.length; i++) {
     out.set(work[i].index, {
-      prevInterrupted: work[i - 1]?.state === "interrupted",
+      prevInterrupted: work[i - 1]?.state === "interrupted" && !work[i - 1]?.cutoff,
       next: work[i + 1] ?? null,
       checkedBefore
     });
@@ -10085,7 +10183,8 @@ function openTab(record, { activate = true } = {}) {
   const stopReplay = startReplay(sessionId, (e) => treeState.apply(e), {
     stream,
     EventSourceImpl: AuthEventSource,
-    onLive
+    onLive,
+    stillExists: () => roster.readings() === 0 || roster.current().some((r) => r.sessionId === sessionId)
   });
   openTabs.set(sessionId, { view, panel, stopReplay, ended: !open, label: tabLabel(record) });
   known.add(sessionId);

--- a/apps/server/src/client/app.ts
+++ b/apps/server/src/client/app.ts
@@ -399,6 +399,11 @@ function openTab(record: SessionRecord, { activate = true }: { activate?: boolea
     stream,
     EventSourceImpl: AuthEventSource,
     onLive,
+    // A read that was cut reopens itself; this is what stops it reopening forever against a
+    // session that no longer exists (deleted, project moved), which answers 404 and looks to an
+    // EventSource exactly like a dropped path. Before the first poll lands the roster is empty and
+    // knows nothing — say yes, so a tab opened at boot is never abandoned on no evidence.
+    stillExists: () => roster.readings() === 0 || roster.current().some((r) => r.sessionId === sessionId),
   });
   openTabs.set(sessionId, { view, panel, stopReplay, ended: !open, label: tabLabel(record) });
   // Handing out a tab IS the offer, whoever asked for it — auto, picker or restore. Recorded

--- a/apps/server/src/client/replay.ts
+++ b/apps/server/src/client/replay.ts
@@ -13,6 +13,27 @@ import type { EventSourceLike } from './stream.ts';
  */
 const REPLAY_STALE_MS = 30_000;
 
+/** First wait before reopening a read that was cut — the stream's own reconnect delay. */
+const RETRY_MS = 3_000;
+/**
+ * Ceiling for the wait, which then repeats at that rate rather than backing off further. A path
+ * that is merely down costs one request every 30s per open tab — the live stream already
+ * reconnects at 3s.
+ */
+const MAX_RETRY_MS = 30_000;
+
+/**
+ * Consecutive reopens that gain NOTHING before the read gives up.
+ *
+ * Not a cap on attempts — a cap on futility. A read that advances resets it, so a slow or flaky
+ * path is never penalised however many rounds it takes; only a read that dies at the same point
+ * every time counts against it, and that one is not coming back: a server-side throw on one line,
+ * a proxy cutting at a fixed byte count, a child file that will not open. Left looping, it holds
+ * the buffer and the loader for the life of the page while the buffer grows with every live event
+ * — the freeze this whole mechanism exists to end, arrived at from the other side.
+ */
+const MAX_STALE_REOPENS = 3;
+
 // Drive one session's replay, then hand off to the live feed without losing or
 // doubling an event. For an ACTIVE session (deps.stream given): subscribe to
 // live FIRST and buffer it, replay history, then flush the buffered live events
@@ -65,6 +86,14 @@ export function startReplay(
     checkMs?: number;
     /** Clock for the staleness decision — injected so a test can age a read without waiting. */
     now?: () => number;
+    /** First wait before reopening a read that was cut. Doubles up to {@link MAX_RETRY_MS}. */
+    retryMs?: number;
+    /**
+     * Whether the session still exists, asked before each reopen. A deleted session answers 404
+     * forever and an `EventSource` cannot read a status, so this is the only way to tell a
+     * permanent absence from a dropped path. Omitted → the reopen never gives up.
+     */
+    stillExists?: () => boolean;
   },
 ): { stop(): void; resync(): void } {
   const covered = new Map<string, number>(); // highest line a replay delivered whole
@@ -75,6 +104,30 @@ export function startReplay(
   let inFlight = true; // a replay connection is open and its events are still history
   let stopped = false; // the tab is gone: nothing may reopen a connection
   let resyncPending = false; // a resync was raised mid-read and still owes its tail
+  // Whether the CURRENT connection reached the end of the history. The only thing that separates
+  // a read that is done from a read that was cut, and the two are indistinguishable on screen.
+  let sawEnd = false;
+  let retryTimer: ReturnType<typeof setTimeout> | null = null;
+  const baseRetryMs = deps.retryMs ?? RETRY_MS;
+  let nextRetryMs = baseRetryMs; // grows per consecutive cut, reset by a read that completes
+  /** Whether the CURRENT read has advanced any file's `covered` — see {@link MAX_STALE_REOPENS}. */
+  let progressed = false;
+  let staleReopens = 0;
+  /**
+   * Whether any read has ever reached `replay-end`. Until one has, the tab's history may have a
+   * HOLE in it, and the live frontier is then proof of nothing: `whole()` must not read it as
+   * "every line below this is held". Latched true on the first complete read and left there — a
+   * later resync starts from a history that WAS complete, so the frontier means what it says again.
+   */
+  let historyComplete = false;
+  /**
+   * The line each file's CURRENT read is on — delivered, but not yet known to be whole: a line is
+   * several events sharing one seq, and the read can die between two of them. It becomes `covered`
+   * only when a higher seq arrives (nothing more of it can be coming) or the read reaches
+   * `replay-end`. Without this a read cut mid-line counted that line as held, and the reopen — which
+   * asks strictly PAST what is held — dropped its remaining events for good.
+   */
+  const frontier = new Map<string, number>();
   // What the tab held when the CURRENT connection was opened. A snapshot, because `covered`
   // advances as this very replay streams: measuring against a moving mark drops every event of
   // a line after its first. Empty for the initial replay, which holds nothing.
@@ -97,8 +150,13 @@ export function startReplay(
    * died between two events of the frontier itself.
    */
   function whole(key: string): number | undefined {
-    const c = covered.get(key),
-      l = liveMax.get(key);
+    const c = covered.get(key);
+    // A history that has never been read to the end may have a hole in the middle, and a live line
+    // proves only itself. Answering `liveMax - 1` there asks the server to start past everything
+    // the read never delivered — the gap is then permanent, and the reopen that fills it reaches
+    // `replay-end` and calls the tab complete.
+    if (!historyComplete) return c;
+    const l = liveMax.get(key);
     const lw = l === undefined ? undefined : l - 1;
     if (c === undefined) return lw;
     if (lw === undefined) return c;
@@ -116,7 +174,15 @@ export function startReplay(
           s.n--;
           return;
         } // already applied live
-        covered.set(key, Math.max(covered.get(key) ?? -1, e.seq));
+        const at = frontier.get(key);
+        // A higher seq proves the line below it is complete — nothing more of it can arrive.
+        if (at === undefined || e.seq > at) {
+          if (at !== undefined && at > (covered.get(key) ?? -1)) {
+            covered.set(key, at);
+            progressed = true; // this read gained ground; it has earned another reopen
+          }
+          frontier.set(key, e.seq);
+        }
       } else {
         const c = covered.get(key);
         if (c !== undefined && e.seq <= c) return; // a replay already delivered this line whole
@@ -149,6 +215,12 @@ export function startReplay(
   function open(from?: string): void {
     buffering = true;
     inFlight = true;
+    sawEnd = false;
+    progressed = false;
+    // Per READ, not per tab: it holds the line THIS connection is on. Carried over, a reopen that
+    // re-reads the line the last one died on would see its own seq as "not higher" and never
+    // promote it to `covered`, so the read could gain ground without ever being able to say so.
+    frontier.clear();
     lastFrameAt = now(); // a fresh read starts its own window; the previous one's silence is spent
     const src = new deps.EventSourceImpl(urlFor(sessionId, from));
     es = src;
@@ -169,54 +241,139 @@ export function startReplay(
         deliver(e, 'replay');
       });
     }
-    src.addEventListener('replay-end', () => finish());
-    src.addEventListener('error', () => finish()); // connection died before replay-end → still hand off
+    // Both carry the same `es !== src` gate as the data listeners above, and for a reason that only
+    // exists now that a cut read reopens: a socket already given up on can still dispatch what was
+    // queued before its close, and `inFlight` is true again by then. Ungated, a stale `replay-end`
+    // closed the NEW read and marked its half-history complete — with the retry disarmed, since the
+    // read had "ended".
+    src.addEventListener('replay-end', () => {
+      if (es !== src) return;
+      // Recorded BEFORE the handoff, because it is what `finish()` decides on: the one frame that
+      // says the history is all here. Every line this read delivered is now known whole.
+      sawEnd = true;
+      for (const [key, seq] of frontier) covered.set(key, Math.max(covered.get(key) ?? -1, seq));
+      finish();
+    });
+    src.addEventListener('error', () => {
+      if (es !== src) return;
+      finish(); // the connection died before replay-end → the history is short, so reopen
+    });
   }
 
   // The third way a read ends, and the only one a silently cut path produces: it just stops.
   // `replay-end` and `error` both require the connection to SAY something, and a peer that
   // vanished without a FIN says nothing — an SSE connection only receives, so nothing on this
-  // side ever fails. Left alone, `inFlight` stays true, every live event goes into `buffer` and
-  // none comes out, and `resync()` is a permanent no-op: the tab freezes behind a stream that
-  // still looks healthy.
+  // side ever fails. Without this the read would sit `inFlight` for good, and nothing would ever
+  // reopen it: the tab freezes behind a stream that still looks healthy.
   //
-  // LIMIT: handing off early leaves the tab's history SHORT, with nothing on screen saying so.
-  // The next resync fills it from the mark this read did reach — for an ENDED session that is the
-  // one `revive` performs if it is resumed (app.ts), and failing that the gap lasts until the tab
-  // is reopened. It is still the cheaper wrong — buffering forever has no exit — and at 30s
-  // against a measured worst gap of 6ms it should never trigger on a read that is merely slow.
+  // At 30s against a measured worst gap of 6ms it cannot fire on a read that is merely slow.
   function watchSilence(): void {
     if (stopped || !inFlight) return;
     if (now() - lastFrameAt < staleMs) return;
     finish();
   }
 
-  // 3. Finalize: flush what live sent while we were reading, then let live through directly.
-  //    Idempotent per connection — the first of replay-end / error / stop / silence wins.
+  // 3. End the current read. Idempotent per connection — the first of replay-end / error / stop /
+  //    silence wins. Whether it is also the end of the HISTORY is a different question, and the
+  //    whole of what this decides: a read that reached `replay-end` hands off, a read that was CUT
+  //    reopens instead.
   function finish(): void {
     if (!inFlight) return;
     inFlight = false;
+    es?.close();
+    es = null;
+    // A cut read holds a PARTIAL history, and until the rest of it arrives the tab must not be told
+    // anything is live. Keeping the buffer shut is not a detail — it is what makes the reopen
+    // sound. Applying those events would set the live frontier, and `whole()` reads that frontier
+    // as proof the tab holds every line below it: a tab holding lines 0..2 and a stray line 500
+    // would resume `from=:499` and lose the middle for good, then reach `replay-end` and call
+    // itself complete. The reader sees the loader a while longer, which is the truth.
+    //
+    // `stopped` flushes anyway: the tab is closing and there is no later read to wait for.
+    if (!sawEnd && !stopped) {
+      staleReopens = progressed ? 0 : staleReopens + 1;
+      // Futility, not attempts (see MAX_STALE_REOPENS): a read that will never get further is not
+      // worth another round, and holding the buffer for it is the freeze this replaced.
+      if (staleReopens < MAX_STALE_REOPENS) {
+        scheduleRetry();
+        return;
+      }
+    }
+    if (sawEnd) historyComplete = true;
+    handOff();
+    // A resync raised while this read was in flight is owed its tail now — after the buffer
+    // flush, so it asks from the tab's freshest position. Never once stopped: a closed tab
+    // must not resurrect its feed.
+    if (stopped) return;
+    if (resyncPending) {
+      resyncPending = false;
+      askedFromOutside();
+      doResync();
+      return;
+    }
+    nextRetryMs = baseRetryMs; // the path works; the next cut starts its backoff over
+  }
+
+  /**
+   * Release what the tab holds: flush the live events held back during the read, then let live
+   * through directly. Called once the history is complete — or once nothing more of it is coming.
+   */
+  function handOff(): void {
     buffering = false;
     for (const e of buffer) deliver(e, 'live');
     buffer.length = 0;
-    es?.close();
-    es = null;
     if (!handedOff) {
       handedOff = true;
       deps.onLive?.(); // history is done; the consumer may now treat events as live
     }
-    // A resync raised while this read was in flight is owed its tail now — after the buffer
-    // flush, so it asks from the tab's freshest position. Never once stopped: a closed tab
-    // must not resurrect its feed.
-    if (resyncPending && !stopped) {
-      resyncPending = false;
+  }
+
+  /**
+   * An ask from OUTSIDE — the live stream recovering, or the session being resumed — is new
+   * information, not another of this reader's own attempts, so it starts over: the backoff goes
+   * back to its first wait and the futility budget is refilled. Carrying the spent budget made the
+   * recovery path `app.ts` provides a dead letter: the ask opened one read and abandoned it on the
+   * first cut, with no retry at all.
+   */
+  function askedFromOutside(): void {
+    nextRetryMs = baseRetryMs;
+    staleReopens = 0;
+  }
+
+  /** Reopen a cut read after a growing wait. One pending at a time; `stop()` cancels it. */
+  function scheduleRetry(): void {
+    if (stopped || retryTimer !== null) return;
+    const wait = nextRetryMs;
+    nextRetryMs = Math.min(nextRetryMs * 2, MAX_RETRY_MS);
+    retryTimer = setTimeout(() => {
+      retryTimer = null;
+      // `inFlight` guards the race with an outside `resync()` that opened a read meanwhile: two
+      // concurrent connections would each answer from the same marks and double-deliver the tail.
+      if (stopped || inFlight) return;
+      // A session that is GONE answers 404 forever, and an EventSource cannot see a status code —
+      // it fires the same contentless `error` a dropped path does. The caller knows the difference
+      // (it holds the roster), so it is asked. Giving up hands off what the tab has: holding the
+      // loader for a history that is never coming is the one thing worse than showing it short.
+      if (deps.stillExists && !deps.stillExists()) {
+        handOff();
+        return;
+      }
       doResync();
-    }
+    }, wait);
+    // A timer that keeps a process alive is a Node/Bun concern (tests, the compiled binary);
+    // browsers have no unref and ignore this.
+    (retryTimer as unknown as { unref?: () => void }).unref?.();
   }
 
   // Ask for the tail of every file the tab has seen, from the last line it holds COMPLETE,
   // and arm the skip for the frontier line that read will re-send.
   function doResync(): void {
+    // Whoever gets here is opening the read a queued retry was going to open. Leaving it armed
+    // would open a second one over the same marks.
+    if (retryTimer !== null) {
+      clearTimeout(retryTimer);
+      retryTimer = null;
+    }
     floor = new Map();
     skip = new Map();
     // LIMIT: one `key:seq` pair per file the tab has seen, which for a Workflow run of ~100
@@ -242,9 +399,17 @@ export function startReplay(
 
   return {
     stop() {
-      stopped = true; // before finish(), which would otherwise run a deferred resync
+      stopped = true; // before finish(), which would otherwise run a deferred resync or a retry
       clearInterval(watchdog);
-      finish(); // flush what we have, then release the live subscription
+      if (retryTimer !== null) {
+        clearTimeout(retryTimer); // a reopen armed by an earlier cut must not outlive the tab
+        retryTimer = null;
+      }
+      // `finish()` returns at once when nothing is in flight, which is exactly what a pending
+      // reopen leaves behind — so a tab closed between two attempts released nothing and never
+      // told the view. A closing tab hands over what it holds either way.
+      if (inFlight) finish();
+      else handOff();
       if (unsubscribe) unsubscribe();
     },
     /**
@@ -259,6 +424,7 @@ export function startReplay(
       // feed. It was stated there and not here, so a call landing after stop() opened a read
       // anyway — and one nothing watches, since stop() has already cleared the watchdog.
       if (stopped) return;
+      askedFromOutside();
       if (inFlight) {
         resyncPending = true;
         return;

--- a/apps/server/src/core/session-tree.ts
+++ b/apps/server/src/core/session-tree.ts
@@ -232,6 +232,15 @@ export interface TurnNode {
   // token. Otherwise a /model — which opens an entry and never calls the model — would sit
   // there pulsing green until the next prompt.
   state: 'done' | 'interrupted' | 'live';
+  /**
+   * The round was CUT OFF, not stopped by hand — the session died and Claude Code's auto-continue
+   * receipt closed it on re-entry (see `TurnInterruptedEvent.cutoff`). Only meaningful alongside
+   * `state: 'interrupted'`, which is true of both: the round ended without finishing either way.
+   * What differs is WHO ended it, and everything that reads an interruption as the user's
+   * CORRECTION has to ask — the retrospective's "abandoned to Esc" and the verdict's "second
+   * correction in a row" are claims about a person, and a crash is not a correction.
+   */
+  cutoff: boolean;
   durationMs: number | null;
   messageCount: number | null;
   apiCalls: number;
@@ -484,6 +493,7 @@ interface TurnAcc {
   command: string | null;
   startedAt: string | null;
   state: 'done' | 'interrupted' | 'live';
+  cutoff: boolean; // interrupted by a dead session rather than by the user — see TurnNode.cutoff
   durationMs: number | null;
   messageCount: number | null;
   apiCalls: number;
@@ -610,6 +620,27 @@ function resolveVolByModel(
     merged.set(key, (merged.get(key) ?? 0) + t);
   }
   return [...merged.entries()].map(([model, tokens]) => ({ model, tokens })).sort((x, y) => y.tokens - x.tokens);
+}
+
+/**
+ * Whether a usage event describes a call that reached a model — the only kind that can say how
+ * full a window is right now.
+ *
+ * Claude Code stamps `<synthetic>` (which the parser reads as no model) on lines that reached
+ * none: the "No response requested." it writes when a killed session is resumed, and API-error
+ * lines. It gives them a `message.usage` block all the same — structurally a call's, and all
+ * zeros. Folded in as last-call state, that zero BECAME the window: the Context card read
+ * 0 / 1.0M · 0%, with the denominator intact (the model is guarded), until the next real call
+ * arrived. On a session resumed and then left idle, that is until the user types again.
+ *
+ * BOTH conditions, never `model === null` alone: a real call can arrive on a line that names no
+ * model (its tokens are resolved to the agent's own model rather than dropped — see
+ * `resolveVolByModel`), and a real call always reads at least its system prompt, so it can never
+ * report a zero window. The sums are deliberately left outside this guard: an all-zero line adds
+ * nothing to them, and it IS an API call as far as the call count is concerned.
+ */
+function reportsWindow(e: { model?: string | null; fill: number }): boolean {
+  return Boolean(e.model) || e.fill > 0;
 }
 
 /**
@@ -882,11 +913,14 @@ export function createSessionTree(opts: { windowFor: WindowFor; mainModel?: stri
       if (owner === null) {
         // Last-call state: set-shaped, therefore idempotent — a re-sent line rewrites the same
         // values. `breakdown` is the window's composition RIGHT NOW, so the last call is exactly
-        // what it must hold; do not turn it into a sum (see CacheTotals).
-        mainFill = e.fill;
-        breakdown.input = e.delta.input;
-        breakdown.cacheRead = e.delta.cacheRead;
-        breakdown.cacheCreation = e.delta.cacheCreation;
+        // what it must hold; do not turn it into a sum (see CacheTotals). Only a line that reached
+        // a model gets to write it (see `reportsWindow`).
+        if (reportsWindow(e)) {
+          mainFill = e.fill;
+          breakdown.input = e.delta.input;
+          breakdown.cacheRead = e.delta.cacheRead;
+          breakdown.cacheCreation = e.delta.cacheCreation;
+        }
         // The model is last-call state like the fill above, and for the same reason: it is
         // what the window is measured against RIGHT NOW. Idempotent — a re-sent line rewrites
         // the same value and `mainModels` refuses the duplicate.
@@ -895,22 +929,34 @@ export function createSessionTree(opts: { windowFor: WindowFor; mainModel?: stri
           if (!mainModels.includes(e.model)) mainModels.push(e.model);
         }
         if (currentTurn) {
-          currentTurn.fillEnd = e.fill;
-          currentTurn.breakdown = {
-            input: e.delta.input,
-            cacheRead: e.delta.cacheRead,
-            cacheCreation: e.delta.cacheCreation,
-          };
+          // The turn's own copy of the same state, under the same rule: `fillEnd` feeds the
+          // timeline's per-turn delta, so a zero here reads as a turn that FREED the whole window.
+          if (reportsWindow(e)) {
+            currentTurn.fillEnd = e.fill;
+            currentTurn.breakdown = {
+              input: e.delta.input,
+              cacheRead: e.delta.cacheRead,
+              cacheCreation: e.delta.cacheCreation,
+            };
+          }
           if (e.model) currentTurn.models.add(e.model);
           if (e.effort) currentTurn.efforts.add(e.effort);
         }
         // Everything SUMMED below is NOT idempotent, and the same usage arrives more than once
         // for two independent reasons: a call is written one line per content block (all
         // repeating its usage), and the stream re-sends the high-water line after a reconnect
-        // (stream.ts guards with `seq <`). Keying on the call id folds both away; the seq
-        // fallback keeps synthetic lines (no message.id) counted once each.
+        // (stream.ts guards with `seq <`). Keying on the call id folds both away; the seq fallback
+        // covers a line that carries no `message.id`. Synthetic lines are NOT that case — measured
+        // 2026-08-16 over 866 transcripts, all 21 carry one (a bare UUID rather than a `msg_…`) —
+        // so the fallback is for lines seedeep synthesises itself, not for Claude Code's.
         const key = e.callId ?? `seq:${e.seq}`;
-        usageNewCall = !appliedUsageKeys.has(key);
+        // `!e.noCall` is the whole of the receipt's exclusion, and it belongs HERE rather than on
+        // the counter: `newCall` is the one signal that says a fresh API call happened, and three
+        // surfaces read it — the header's count, the feed's row, the Trace's `api` span (plus the
+        // latency `usageCallMs`, measured from an anchor to a line that never called anything).
+        // Excluding it from the counter alone left them disagreeing on screen. A FAILED call is
+        // still a call and still raises all three; it reached the API.
+        usageNewCall = !appliedUsageKeys.has(key) && !e.noCall;
         if (usageNewCall) {
           appliedUsageKeys.add(key);
           apiCalls++;
@@ -957,10 +1003,15 @@ export function createSessionTree(opts: { windowFor: WindowFor; mainModel?: stri
         // above, so the two are comparable. Same per-call dedup as the main branch: one call is
         // written one line per content block, and the stream re-sends the high-water on reconnect.
         const a = agentFor(owner);
-        a.fill = e.fill;
+        // Same rule as the main branch, on the branch that draws the subagent's own context bar:
+        // a child transcript ending on a synthetic line showed the agent at 0%.
+        if (reportsWindow(e)) a.fill = e.fill;
         if (e.effort) a.efforts.add(e.effort);
         const key = e.callId ?? `seq:${e.seq}`;
-        usageNewCall = !a.appliedVolumeKeys.has(key);
+        // `!e.noCall` for the same reason as the main branch above, on the branch that owns the
+        // child's lane: `newCall` drives the Trace span, the feed row and the latency there too,
+        // and a receipt written into a child transcript is no more a call than one in the parent.
+        usageNewCall = !a.appliedVolumeKeys.has(key) && !e.noCall;
         if (usageNewCall) {
           a.appliedVolumeKeys.add(key);
           a.volIn += e.delta.input;
@@ -1020,6 +1071,7 @@ export function createSessionTree(opts: { windowFor: WindowFor; mainModel?: stri
           command: e.command ?? null,
           startedAt: e.timestamp || null,
           state: 'live',
+          cutoff: false,
           durationMs: null,
           messageCount: null,
           apiCalls: 0,
@@ -1055,7 +1107,16 @@ export function createSessionTree(opts: { windowFor: WindowFor; mainModel?: stri
         currentTurn.state = 'done';
       }
     } else if (e.type === 'turn-interrupted') {
-      if (owner === null && currentTurn) currentTurn.state = 'interrupted';
+      // A CUTOFF answers to the supersede path's rule (see where a new prompt closes the previous
+      // turn): it closes a round that did work, and leaves one that called nothing — a bare
+      // `/model` — to the 0-call → done presentation, which is also what keeps `kindOf` filing it
+      // as a local command. An Esc closes either way: the user stopped something.
+      if (owner === null && currentTurn && (!e.cutoff || currentTurn.apiCalls > 0)) {
+        currentTurn.state = 'interrupted';
+        // Recorded only where it is TRUE, never cleared: a round the user had already stopped by
+        // hand, and which a later cutoff closes again, was still stopped by hand.
+        if (e.cutoff) currentTurn.cutoff = true;
+      }
     } else if (e.type === 'turn-result') {
       if (owner === null && currentTurn) {
         currentTurn.result = e.outputFull; // last wins
@@ -1654,6 +1715,7 @@ export function createSessionTree(opts: { windowFor: WindowFor; mainModel?: stri
         kind: kindOf(t, agentsByTurn.has(t.index)),
         startedAt: t.startedAt,
         state,
+        cutoff: t.cutoff,
         durationMs: t.durationMs,
         messageCount: t.messageCount,
         apiCalls: t.apiCalls,

--- a/apps/server/src/core/types.ts
+++ b/apps/server/src/core/types.ts
@@ -351,13 +351,31 @@ export interface UsageEvent extends EventBase {
   /**
    * The call FAILED: Claude Code wrote it as an assistant line flagged `isApiErrorMessage`
    * (rate limit, auth, overloaded, prompt too long, connection dropped). Absent on a normal
-   * call. Keyed on that flag and NOT on `apiErrorStatus`, which only 27 of 63 real error
-   * lines carry — the statusless ones ("Not logged in", "Prompt is too long", "Connection
-   * closed mid-response") are the ones a user most needs to see. `message.model` on these
-   * lines is always `<synthetic>`, but the reverse does not hold: synthetic lines that are
-   * NOT errors exist (76 measured), so the model can never stand in for the flag.
+   * call. Keyed on that flag and NOT on `apiErrorStatus`, which fewer than half of them carry —
+   * the statusless ones ("Not logged in", "Prompt is too long", "Connection closed mid-response")
+   * are the ones a user most needs to see. `message.model` on these lines is always `<synthetic>`,
+   * but the reverse does not hold: synthetic lines that are NOT errors exist (see `noCall`), so
+   * the model can never stand in for the flag.
+   *
+   * Measured 2026-08-16 over 866 transcripts (528 sessions and their children): 9 error lines, 4
+   * carrying a status, all 9 `<synthetic>`. An earlier, undated count in this file read 63 and 27 —
+   * a bigger corpus than this machine now holds, which is why the RULES above are stated without
+   * leaning on either figure.
    */
   apiError?: { status: string | null; message: string };
+  /**
+   * NO call was made: Claude Code answered "No response requested." to a message that needed no
+   * answer — the `isMeta` "Continue from where you left off." it injects when it re-enters a
+   * session whose last round never finished. The line is `<synthetic>` and carries a full usage
+   * block, all zeros, so nothing about its shape says it is not a call.
+   *
+   * A FAILED call never carries this: it reached the API and is counted (see `apiError`). The two
+   * are told apart by `isApiErrorMessage`, which is structural — measured 2026-08-16 over 866
+   * transcripts (528 sessions and their children): 12 non-error synthetic lines, every one reading
+   * "No response requested.", every one followed by a new user message rather than by any further
+   * work, and all 21 synthetic lines of either kind carrying a zero usage block.
+   */
+  noCall?: true;
 }
 
 export interface AttributionEvent extends EventBase {
@@ -395,6 +413,14 @@ export interface TurnEndEvent extends EventBase {
 // (verified across real sessions), so it can link nothing — only its PRESENCE is the signal.
 export interface TurnInterruptedEvent extends EventBase {
   type: 'turn-interrupted';
+  /**
+   * The round was CUT OFF rather than interrupted by hand: Claude Code's auto-continue receipt (see
+   * `UsageEvent.noCall`), not an Esc. Same fact — this round is over — but not the same claim about
+   * an entry that never called anything: an Esc says the user stopped something, while a killed
+   * session says only that nothing more is coming. So a cutoff closes only a round that did work,
+   * exactly as a superseding prompt does, and leaves a bare `/model` to the 0-call presentation.
+   */
+  cutoff?: true;
 }
 
 // Main-session assistant line with stop_reason "end_turn": the turn's conclusion.

--- a/apps/server/src/core/verdict.ts
+++ b/apps/server/src/core/verdict.ts
@@ -356,7 +356,9 @@ function verdictFrom(turn: TurnNode, ev: TurnEvidence, ctx: TurnContext): TurnVe
   // the old rule penalised correct usage on 72% of its own hits. Looking only BACKWARD is
   // deliberate: a turn that is the first of a streak IS a lone Esc at the moment it closes, and a
   // forward-looking rule would make a finding appear retroactively on a turn already rendered.
-  if (turn.state === 'interrupted' && ctx.prevInterrupted) {
+  // `!turn.cutoff`: the finding names a CORRECTION the user made twice running, and a session that
+  // died mid-round corrected nothing. `prevInterrupted` answers to the same rule, one level up.
+  if (turn.state === 'interrupted' && !turn.cutoff && ctx.prevInterrupted) {
     // No `cost` either, for the opposite reason: the abandoned tokens ARE the whole turn, not a
     // portion of it, so adding them to any other finding's cost double-counts the same spend.
     findings.push({
@@ -469,7 +471,9 @@ function contexts(snap: TreeSnapshot, evidence: Map<number, TurnEvidence>): Map<
   let checkedBefore = false;
   for (let i = 0; i < work.length; i++) {
     out.set(work[i]!.index, {
-      prevInterrupted: work[i - 1]?.state === 'interrupted',
+      // Same rule as the finding it feeds: only a correction the USER made counts as the first of
+      // a pair, so a round the previous session death cut off is not one.
+      prevInterrupted: work[i - 1]?.state === 'interrupted' && !work[i - 1]?.cutoff,
       next: work[i + 1] ?? null,
       checkedBefore,
     });

--- a/apps/server/src/server/aggregate-cache.ts
+++ b/apps/server/src/server/aggregate-cache.ts
@@ -61,7 +61,13 @@ import { subagentStamp } from './subagent-files.ts';
 //        unchanged file must not keep its old summary. 8 of 721 local sessions are affected; the
 //        cost of the bump is one recomputation, since a vanished transcript is dropped from the
 //        aggregate on every refresh anyway.
-const CACHE_VERSION = 13;
+//   v14: a round CUT OFF by a dead session now closes as `interrupted` instead of staying `live`
+//        for ever, so a v13 summary of such a session is missing that turn entirely — the
+//        summarizer keeps closed work turns only. A value change, like v8 and v12, so an unchanged
+//        file must not keep its old summary. It also un-counts those turns from `esc`: an Esc is a
+//        correction the user made, and a crash is not one, so a v13 summary reports a session that
+//        died as tokens its user abandoned.
+const CACHE_VERSION = 14;
 
 const DAY_MS = 24 * 3600 * 1000;
 // The share of a session's billable tokens spent re-entering its context at which Claude Code's
@@ -219,7 +225,10 @@ export function summarizeTree(tree: ReturnType<typeof createSessionTree>): Sessi
           0,
         ),
         apiCalls: t.apiCalls,
-        esc: t.state === 'interrupted',
+        // An Esc is a CORRECTION the user made — which a round cut off by a dead session is not,
+        // however interrupted it was. Reading the state alone reported a crash as tokens the user
+        // had abandoned, in a retrospective whose whole subject is how the user works.
+        esc: t.state === 'interrupted' && !t.cutoff,
         escStreak: has('esc'),
         context: has('context'),
         compaction: has('compaction'),

--- a/apps/server/src/server/parser.ts
+++ b/apps/server/src/server/parser.ts
@@ -297,6 +297,12 @@ export function parseLine(
   if (IGNORED.has(type)) return [];
 
   if (type === 'assistant') {
+    // A line Claude Code produced without calling a model, and that did not fail: `<synthetic>` and
+    // NOT an API error. Told from a failed call by `isApiErrorMessage` alone — both are
+    // `<synthetic>` and both carry an all-zero usage block, so neither the model nor the tokens can
+    // separate them. What follows from the marker alone is only what it MEANS: no model wrote this,
+    // so it is not a call and it is not the model's stated intent.
+    const noAnswer = d.message?.model === '<synthetic>' && d.isApiErrorMessage !== true;
     const usage = d.message?.usage;
     if (usage && typeof usage === 'object') {
       const delta: TokenCounts = {
@@ -336,6 +342,7 @@ export function parseLine(
               : null;
         ev.apiError = { status, message: anon(renderedText(d.message?.content), 300) };
       }
+      if (noAnswer) ev.noCall = true;
       out.push(ev);
     }
 
@@ -394,7 +401,21 @@ export function parseLine(
         .filter((b: any) => b?.type === 'text' && typeof b.text === 'string')
         .map((b: any) => b.text)
         .join('');
-      if (text) {
+      // The round this line closes is over, and THIS text is the whole of the evidence for it:
+      // measured 2026-08-16 over 866 transcripts, every non-error `<synthetic>` line reads exactly
+      // this, and every one is followed by a new user message rather than by any further work.
+      // The claim is read off the text and not off the marker, because the marker cannot carry it:
+      // a future notice Claude Code writes the same way would close a turn that is still working,
+      // reporting a busy session as idle. Same event as an Esc — the same fact by another route —
+      // and emitted after the usage above, so the turn's numbers are folded in before it closes.
+      if (noAnswer && agentId === null && text.trim() === 'No response requested.') {
+        out.push({ type: 'turn-interrupted', ...base, cutoff: true });
+      }
+      // `!noAnswer`: a line no model wrote is not the model saying what it is about to do. As a
+      // narration it became the session's INTENT — the panel that answers "what is this session
+      // doing" reading a sentence no model ever wrote, held for as long as the session stayed
+      // idle. An API-error line is NOT suppressed here: its text is what the user was actually told.
+      if (text && !noAnswer) {
         if (d.message?.stop_reason === 'end_turn') {
           const full = anon(text, 20000);
           if (agentId !== null) {

--- a/apps/server/tests/client-replay.test.ts
+++ b/apps/server/tests/client-replay.test.ts
@@ -24,10 +24,10 @@ class FakeES {
 }
 // A replay connection dies the way a live one does — silently, with no `error` to catch — and
 // this one has more to lose: while a read is in flight every live event goes into `buffer` and
-// nothing comes out, so the tab freezes behind a stream that still looks healthy. `finish()` was
-// reachable only from `replay-end`, `error` and `stop()`, none of which a silently cut path
-// produces. It matters more since the live watchdog started asking for a resync on every recovery.
-test('a replay that goes quiet hands off instead of buffering live events forever', async () => {
+// nothing comes out. `finish()` was reachable only from `replay-end`, `error` and `stop()`, none of
+// which a silently cut path produces, so the read sat `inFlight` for good and nothing could reopen
+// it. The silence deadline is what ends the READ; what ends the WAIT is the reopen below.
+test('a replay that goes quiet is ended and reopened, not left in flight for good', async () => {
   let clock = 0;
   let pushLive: ((e: any) => void) | null = null;
   const got: number[] = [];
@@ -42,13 +42,162 @@ test('a replay that goes quiet hands off instead of buffering live events foreve
     staleMs: 30_000,
     checkMs: 5,
     now: () => clock,
+    retryMs: 5,
   });
+  const quiet = FakeES.last!;
   pushLive!({ type: 'usage', sessionId: 'A', root: 'cli', timestamp: 't', seq: 7, delta: {}, fill: 1 });
   assert.deepEqual(got, [], 'live is held back while the read is in flight');
   clock = 31_000; // the replay connection has delivered nothing at all, and never errored
   await new Promise((res) => setTimeout(res, 40));
-  assert.deepEqual(got, [7], 'the buffered live event is flushed and the tab goes live');
-  assert.equal(FakeES.last!.closed, true, 'and the dead connection is released');
+  assert.equal(quiet.closed, true, 'the dead connection is released');
+  assert.notEqual(FakeES.last, quiet, 'and a fresh read takes its place');
+  // The live event is still HELD: this tab holds no history at all, so a line from the file's tail
+  // cannot be placed in it. Applying it would put the newest turn before every turn that precedes
+  // it, and would then be read as proof the tab holds everything below it.
+  assert.deepEqual(got, [], 'nothing is applied out of order while the history is still missing');
+  FakeES.last!.emit('usage', ev(0, 1));
+  FakeES.last!.emit('replay-end', { sessionId: 'A' });
+  assert.deepEqual(got, [0, 7], 'history first, then the held live line');
+  r.stop();
+});
+
+// The reopen must not become the freeze it replaced. A read that dies at the SAME point every time
+// — a server-side throw on one line, a proxy cutting at a fixed byte count, a child file that will
+// not open — is re-asked from the same marks for ever, and every one of those rounds holds the
+// buffer and the loader. Progress is the test, not the count: a read that advances is never
+// penalised, and only rounds that gain nothing are counted against it.
+test('a reopen that makes no progress gives up instead of looping for ever', async () => {
+  const stream = fakeStream();
+  const got: number[] = [];
+  let live = 0;
+  const r = startReplay('A', (e) => got.push(e.seq), {
+    stream: stream as any,
+    EventSourceImpl: FakeES as any,
+    retryMs: 3,
+    onLive: () => {
+      live++;
+    },
+  });
+  for (let round = 0; round < 8; round++) {
+    FakeES.last!.emit('usage', ev(0, 1));
+    FakeES.last!.emit('usage', ev(1, 2)); // always dies on line 1: `covered` never passes 0
+    stream.push(ev(900 + round, 1)); // and the live feed keeps arriving into the held buffer
+    FakeES.last!.emitError();
+    await new Promise((res) => setTimeout(res, 12));
+    if (live > 0) break;
+  }
+  assert.equal(live, 1, 'it stopped asking and released what it holds');
+  assert.ok(got.includes(900), 'including the live events it was holding');
+  const opened = FakeES.last!;
+  await new Promise((res) => setTimeout(res, 20));
+  assert.equal(FakeES.last, opened, 'and no further reopen is armed');
+  r.stop();
+});
+
+// Giving up is not a verdict on the tab, only on the attempts made so far. An explicit ask — the
+// live stream recovering, or the session being resumed — is new information from outside, so it
+// starts its own budget. Left carrying the spent one, the recovery path `app.ts` provides was dead:
+// the ask opened a read and abandoned it on the first cut without a single retry.
+test('an explicit resync after a give-up starts its own budget', async () => {
+  const stream = fakeStream();
+  const r = startReplay('A', () => {}, {
+    stream: stream as any,
+    EventSourceImpl: FakeES as any,
+    retryMs: 3,
+  });
+  for (let round = 0; round < 8; round++) {
+    FakeES.last!.emit('usage', ev(0, 1));
+    FakeES.last!.emit('usage', ev(1, 2)); // never gets past line 1
+    FakeES.last!.emitError();
+    await new Promise((res) => setTimeout(res, 12));
+  }
+  const abandoned = FakeES.last!;
+  await new Promise((res) => setTimeout(res, 20));
+  assert.equal(FakeES.last, abandoned, 'it has given up on its own attempts');
+
+  r.resync(); // the stream came back, or the session was resumed
+  const asked = FakeES.last!;
+  assert.notEqual(asked, abandoned, 'the explicit ask opens a read');
+  asked.emitError(); // and this one is cut too
+  await new Promise((res) => setTimeout(res, 20));
+  assert.notEqual(FakeES.last, asked, 'which is retried, not abandoned on the spent budget');
+  r.stop();
+});
+
+// A tab that gave up holds a history with a HOLE in it, so the live frontier is no proof of
+// anything — the same reason the buffer is held in the first place. A later resync that trusted it
+// would ask past the missing middle and then reach `replay-end` calling itself complete.
+test('after giving up, a resync still asks from what was actually read', async () => {
+  const stream = fakeStream();
+  const r = startReplay('A', () => {}, {
+    stream: stream as any,
+    EventSourceImpl: FakeES as any,
+    retryMs: 3,
+  });
+  for (let round = 0; round < 8; round++) {
+    FakeES.last!.emit('usage', ev(0, 1));
+    FakeES.last!.emit('usage', ev(1, 2));
+    FakeES.last!.emitError();
+    await new Promise((res) => setTimeout(res, 12));
+  }
+  stream.push(ev(700, 1)); // arrives after the give-up, so it IS applied — at the tail
+  r.resync();
+  const from = decodeURIComponent(new URL(FakeES.last!.url, 'http://x').searchParams.get('from')!);
+  assert.equal(from, ':0', 'from the read, not from the tail line that proves nothing about the middle');
+  r.stop();
+});
+
+// `stop()` is a release, not a discard: the tab is closing and there is no later read to wait for,
+// so whatever is held must be handed over. It ran `finish()`, which returns immediately when no
+// read is in flight — the exact state a pending reopen leaves behind.
+test('stop() with a reopen pending still releases what the tab holds', () => {
+  const stream = fakeStream();
+  const got: number[] = [];
+  let live = 0;
+  const r = startReplay('A', (e) => got.push(e.seq), {
+    stream: stream as any,
+    EventSourceImpl: FakeES as any,
+    retryMs: 500,
+    onLive: () => {
+      live++;
+    },
+  });
+  FakeES.last!.emit('usage', ev(0, 1));
+  stream.push(ev(7, 1));
+  FakeES.last!.emitError(); // a reopen is armed, nothing is in flight
+  r.stop();
+  assert.deepEqual(got, [0, 7], 'the held live line is released, not dropped with the tab');
+  assert.equal(live, 1, 'and the view is told, once');
+});
+
+// The escape hatch for the one case the reopen cannot win: the session is GONE (deleted, moved),
+// so `/api/replay` answers 404 forever and an EventSource cannot tell that from a dropped path.
+// Asked before each reopen; a `false` hands off what the tab has rather than hold the loader on a
+// history that is never coming.
+test('a reopen gives up when the session no longer exists, and hands off what it holds', async () => {
+  const stream = fakeStream();
+  const got: number[] = [];
+  let exists = true;
+  let live = 0;
+  const r = startReplay('A', (e) => got.push(e.seq), {
+    stream: stream as any,
+    EventSourceImpl: FakeES as any,
+    retryMs: 5,
+    stillExists: () => exists,
+    onLive: () => {
+      live++;
+    },
+  });
+  FakeES.last!.emit('usage', ev(0, 1));
+  FakeES.last!.emit('usage', ev(1, 2));
+  stream.push(ev(9, 9));
+  const cut = FakeES.last!;
+  cut.emitError();
+  exists = false; // the file is gone by the time the reopen comes round
+  await new Promise((res) => setTimeout(res, 40));
+  assert.equal(FakeES.last, cut, 'no reopen was attempted');
+  assert.deepEqual(got, [0, 1, 9], 'what it holds is released rather than held behind a loader');
+  assert.equal(live, 1, 'and the view is told it may paint');
   r.stop();
 });
 
@@ -165,16 +314,24 @@ test('onLive fires exactly once at the replay→live handoff (replay-end)', () =
   assert.equal(liveCalls, 1, 'not called again');
 });
 
-test('onLive still fires when the replay connection errors before replay-end', () => {
+// The loader cannot hang, and an error is not the exit: the exit is a read that reaches the end.
+// Handing off on the error itself is what left the tab painting a half-history with nothing saying
+// so — so the handoff waits for the reopen, and the reader keeps the loader in the meantime.
+test('onLive waits for a read that COMPLETES, then fires exactly once', async () => {
   let liveCalls = 0;
-  startReplay('A', () => {}, {
+  const r = startReplay('A', () => {}, {
     EventSourceImpl: FakeES as any,
+    retryMs: 5,
     onLive: () => {
       liveCalls++;
     },
   });
   FakeES.last!.emitError();
-  assert.equal(liveCalls, 1, 'error path also hands off to live');
+  assert.equal(liveCalls, 0, 'a cut read has not finished reading');
+  await new Promise((res) => setTimeout(res, 40));
+  FakeES.last!.emit('replay-end', { sessionId: 'A' });
+  assert.equal(liveCalls, 1, 'the reopened read reached the end — now the view may paint');
+  r.stop();
 });
 
 test('replay forwards EVERY event type — a new type (subagent-output) is not silently dropped', () => {
@@ -251,23 +408,32 @@ test('inactive replay: no stream → events forwarded, stops at replay-end', () 
   r.stop();
 });
 
-test('active handoff: replay connection error before replay-end flushes buffer and goes live', () => {
+test('active handoff: an error before replay-end holds the buffer, then flushes it on the reopen', async () => {
   const stream = fakeStream();
   const got: any[] = [];
-  startReplay('A', (e) => got.push(e), { stream, EventSourceImpl: FakeES as any });
+  const r = startReplay('A', (e) => got.push(e), { stream, EventSourceImpl: FakeES as any, retryMs: 5 });
   FakeES.last!.emit('usage', ev(0, 10)); // partial history
   stream.push(ev(1, 20)); // live buffered during replay
   FakeES.last!.emitError(); // connection dies before replay-end
-  // buffered live is flushed (not stuck), and subsequent live flows straight through
+  // History is delivered as it arrives, as always. The LIVE line is what is held: applied now it
+  // would be taken for proof that everything below it is held (see the ACTIVE-session test below).
   assert.deepEqual(
     got.map((e) => e.seq),
-    [0, 1],
+    [0],
   );
-  stream.push(ev(2, 30));
+  await new Promise((res) => setTimeout(res, 40));
+  FakeES.last!.emit('usage', ev(0, 10)); // the reopen re-reads the line it could not claim…
+  FakeES.last!.emit('replay-end', { sessionId: 'A' }); // …and reaches the end
   assert.deepEqual(
     got.map((e) => e.seq),
-    [0, 1, 2],
+    [0, 0, 1],
   );
+  stream.push(ev(2, 30)); // and subsequent live flows straight through
+  assert.deepEqual(
+    got.map((e) => e.seq),
+    [0, 0, 1, 2],
+  );
+  r.stop();
   assert.equal(FakeES.last!.closed, true); // replay ES closed on error
 });
 
@@ -374,6 +540,164 @@ test('replay delivers tool/subagent-meta event types (not only usage/attribution
 // interruption every couple of minutes it re-read the session and visibly re-drew the
 // dashboard. The client knows how far it got per file, so it asks for the tail instead and
 // folds it into the reducer it already has: no teardown, nothing to look at.
+// A read that ends on `replay-end` is COMPLETE; one that ends any other way is not, and the
+// difference is invisible on screen. It cost a real session every subagent it ran: the server
+// replays the parent transcript whole and only THEN each child, so a connection cut anywhere in
+// the child phase delivers all of the main session and none of the subagents — 14 rows with no
+// duration, no volume, and a session total 30M tokens short, with nothing saying the history was
+// partial. Recovery existed but had to be triggered from outside (a live-stream reconnect, or the
+// session being resumed), and an ENDED tab is offered neither: the gap lasted for the life of the
+// page. The read now finishes its own history.
+test('a replay cut before the end reopens itself, asking only past what it holds whole', async () => {
+  const stream = fakeStream();
+  const got: number[] = [];
+  const r = startReplay('A', (e) => got.push(e.seq), {
+    stream: stream as any,
+    EventSourceImpl: FakeES as any,
+    retryMs: 5,
+  });
+  // The parent streams; the connection dies before the first child ever arrives.
+  FakeES.last!.emit('usage', ev(0, 1));
+  FakeES.last!.emit('usage', ev(1, 2));
+  const cut = FakeES.last!;
+  cut.emitError();
+  assert.equal(FakeES.last, cut, 'not synchronously — a cut path is retried after a wait');
+  await new Promise((res) => setTimeout(res, 40));
+  assert.notEqual(FakeES.last, cut, 'the read reopened by itself');
+  const from = decodeURIComponent(new URL(FakeES.last!.url, 'http://x').searchParams.get('from')!);
+  // ':0', not ':1' — line 1 was the line the read died on, and a line is several events. Only line
+  // 0 is proven whole, so the reopen starts at 1 and the parent's 3791 earlier lines are not re-read.
+  assert.equal(from, ':0', 'from the last parent line it holds WHOLE, not the last one it saw');
+  // The server re-sends line 1 (the tab could not prove it held it), then the children the cut
+  // read never reached.
+  FakeES.last!.emit('usage', ev(1, 2));
+  FakeES.last!.emit('usage', { ...ev(0, 9), agentId: 'child1' });
+  FakeES.last!.emit('replay-end', { sessionId: 'A' });
+  assert.deepEqual(got, [0, 1, 1, 0], 'the subagent history arrives; the unproven line is simply re-read');
+  r.stop();
+});
+
+// The reopen's resume base is only as good as what the tab actually HOLDS, and on an active
+// session the live feed lies about that: `whole()` reads the live frontier as proof that every
+// line below it is in, which is true only for a tab whose history was already complete. A cut read
+// has no such claim — it holds lines 0..2 and a stray live line 500, and asking `from=:499` skips
+// 497 lines for good, then reaches `replay-end` and calls itself whole. Until the history is
+// complete the live feed is therefore HELD, not applied: a line the reducer has not seen cannot be
+// mistaken for one it has.
+test('a replay cut on an ACTIVE session does not resume from the live frontier', async () => {
+  const stream = fakeStream();
+  const got: number[] = [];
+  const r = startReplay('A', (e) => got.push(e.seq), {
+    stream: stream as any,
+    EventSourceImpl: FakeES as any,
+    retryMs: 5,
+  });
+  FakeES.last!.emit('usage', ev(0, 1));
+  FakeES.last!.emit('usage', ev(1, 2));
+  FakeES.last!.emit('usage', ev(2, 3));
+  stream.push(ev(500, 9)); // the session is live and has moved on while we read
+  const cut = FakeES.last!;
+  cut.emitError();
+  assert.deepEqual(got, [0, 1, 2], 'the live line is HELD: the tab must not hold a line it cannot place');
+  await new Promise((res) => setTimeout(res, 40));
+  const from = decodeURIComponent(new URL(FakeES.last!.url, 'http://x').searchParams.get('from')!);
+  assert.equal(from, ':1', 'resumes from what the READ delivered whole, never from the live frontier');
+  for (let seq = 2; seq <= 4; seq++) FakeES.last!.emit('usage', ev(seq, seq));
+  FakeES.last!.emit('replay-end', { sessionId: 'A' });
+  // Line 2 comes back once — it was the line the read died on, so the tab could not claim it.
+  assert.deepEqual(got, [0, 1, 2, 2, 3, 4, 500], 'the middle arrives, then the held live line, in order');
+  r.stop();
+});
+
+// One LINE is several events sharing a seq (usage + attribution + tool-start), and a read can die
+// between two of them. Counting that line as held asks the reopen to start past it, and its
+// remaining events are gone for good — the same hazard `liveMax`/`liveSeen` exist for on the live
+// side, which the replay side had no answer to.
+test('a line cut between two of its own events is re-read whole', async () => {
+  const stream = fakeStream();
+  const got: string[] = [];
+  const r = startReplay('A', (e) => got.push(tag(e)), {
+    stream: stream as any,
+    EventSourceImpl: FakeES as any,
+    retryMs: 5,
+  });
+  for (const [type, e] of line(0)) FakeES.last!.emit(type, e);
+  const [firstType, firstEvent] = line(1)[0]!;
+  FakeES.last!.emit(firstType, firstEvent); // line 1 starts…
+  FakeES.last!.emitError(); // …and dies with two of its three events unsent
+  await new Promise((res) => setTimeout(res, 40));
+  const from = decodeURIComponent(new URL(FakeES.last!.url, 'http://x').searchParams.get('from')!);
+  assert.equal(from, ':0', 'line 1 was never whole, so the reopen asks for it again');
+  for (const [type, e] of line(1)) FakeES.last!.emit(type, e);
+  FakeES.last!.emit('replay-end', { sessionId: 'A' });
+  assert.deepEqual(
+    got,
+    ['usage@0', 'attribution@0', 'tool-start@0', 'usage@1', 'usage@1', 'attribution@1', 'tool-start@1'],
+    'its head is replayed (the reducer is idempotent on it) and its tail is finally delivered',
+  );
+  r.stop();
+});
+
+test('a replay that ended on replay-end is never reopened', async () => {
+  const stream = fakeStream();
+  const r = startReplay('A', () => {}, {
+    stream: stream as any,
+    EventSourceImpl: FakeES as any,
+    retryMs: 5,
+  });
+  FakeES.last!.emit('usage', ev(0, 1));
+  FakeES.last!.emit('replay-end', { sessionId: 'A' });
+  // EventSource fires `error` on the server's normal close too, AFTER the end frame. A retry armed
+  // by that would re-read every session on every open.
+  const done = FakeES.last!;
+  done.emitError();
+  await new Promise((res) => setTimeout(res, 40));
+  assert.equal(FakeES.last, done, 'a complete read has nothing to go back for');
+  r.stop();
+});
+
+// Every `EVENT_TYPES` listener carries `es !== src` because a socket already given up on can still
+// dispatch what was queued before its close. `replay-end` and `error` did not, on the belief that a
+// superseded connection cannot reach them — true only until a reopen makes `inFlight` true again,
+// which is now routine. A stale end frame then closes the NEW read and marks it complete.
+test('a stale frame from a superseded connection cannot end the reopened read', async () => {
+  const stream = fakeStream();
+  const got: number[] = [];
+  const r = startReplay('A', (e) => got.push(e.seq), {
+    stream: stream as any,
+    EventSourceImpl: FakeES as any,
+    retryMs: 5,
+  });
+  const first = FakeES.last!;
+  first.emit('usage', ev(0, 1));
+  first.emitError();
+  await new Promise((res) => setTimeout(res, 40));
+  const second = FakeES.last!;
+  assert.notEqual(second, first, 'the read reopened');
+  first.emit('replay-end', { sessionId: 'A' }); // queued before the first socket closed
+  second.emit('usage', ev(1, 2));
+  assert.equal(second.closed, false, 'the live read was not closed by a dead connection speaking');
+  second.emitError();
+  await new Promise((res) => setTimeout(res, 60));
+  assert.notEqual(FakeES.last, second, 'and the retry is still armed — the read never ended');
+  r.stop();
+});
+
+test('stop() cancels a pending reopen', async () => {
+  const stream = fakeStream();
+  const r = startReplay('A', () => {}, {
+    stream: stream as any,
+    EventSourceImpl: FakeES as any,
+    retryMs: 5,
+  });
+  FakeES.last!.emit('usage', ev(0, 1));
+  const cut = FakeES.last!;
+  cut.emitError();
+  r.stop(); // the tab is gone before the retry fires
+  await new Promise((res) => setTimeout(res, 40));
+  assert.equal(FakeES.last, cut, 'a closed tab must not resurrect its read');
+});
+
 test('resync asks only for what the tab is missing, per file', () => {
   const stream = fakeStream();
   const r = startReplay('A', () => {}, { stream: stream as any, EventSourceImpl: FakeES as any });

--- a/apps/server/tests/golden-transcript.test.ts
+++ b/apps/server/tests/golden-transcript.test.ts
@@ -128,7 +128,12 @@ const typedAfterEsc = (uuid: string, text: string, interrupted: string) =>
 // A synthetic assistant line as Claude Code writes it when a turn produced NO model response
 // (an auto-continue "No response requested.", or an API error): message.model is '<synthetic>'
 // and the usage block is all zeros. It carries no turn_duration and no Esc marker.
-const synthetic = (uuid: string, _text: string) =>
+// Faithful to the real line, `content` INCLUDED: it carries a text block, which is what made it
+// the session's INTENT. The helper used to drop the text it was handed, so every test built on it
+// exercised a line the parser could never take for a narration — the fixture agreed with the code
+// instead of with the file, and no test could discover the panel was quoting Claude Code's own
+// bookkeeping back at the reader.
+const synthetic = (uuid: string, text: string) =>
   JSON.stringify({
     type: 'assistant',
     uuid,
@@ -136,8 +141,34 @@ const synthetic = (uuid: string, _text: string) =>
     isApiErrorMessage: false,
     message: {
       role: 'assistant',
+      id: 'msg-' + uuid,
       model: '<synthetic>',
       stop_reason: 'stop_sequence',
+      stop_sequence: '',
+      content: [{ type: 'text', text }],
+      usage: { input_tokens: 0, output_tokens: 0, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 },
+    },
+  });
+/**
+ * The OTHER `<synthetic>` line: a call that reached the API and FAILED. Same model placeholder and
+ * the same all-zero usage block as the receipt above — `isApiErrorMessage` is the only thing that
+ * separates them, which is why every rule about one has to name that flag and never the model.
+ * Zero because that is what they carry: measured 2026-08-16 over 866 transcripts (528 sessions and
+ * their children), all 21 synthetic lines of either kind reported no tokens.
+ */
+const apiErrorLine = (uuid: string, status: number | null, text: string) =>
+  JSON.stringify({
+    type: 'assistant',
+    uuid,
+    timestamp: '2026-07-14T10:00:05.000Z',
+    isApiErrorMessage: true,
+    ...(status !== null ? { apiErrorStatus: status } : {}),
+    message: {
+      role: 'assistant',
+      id: 'msg_' + uuid,
+      model: '<synthetic>',
+      stop_reason: 'stop_sequence',
+      content: [{ type: 'text', text }],
       usage: { input_tokens: 0, output_tokens: 0, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 },
     },
   });
@@ -191,6 +222,144 @@ test('golden transcript: a turn cut off (synthetic, no turn_duration) is interru
   assert.equal(turns.filter((t) => t.state === 'live').length, 1, 'never two live turns');
   // <synthetic> never enters the model list, so the chip reads the real model, not "<synthetic>".
   assert.deepEqual(snap.main.models, ['claude-opus-4-8']);
+});
+
+test('golden transcript: the auto-continue receipt closes the cut turn, and is neither a call nor a word', () => {
+  // Claude Code was killed mid-round, so no `turn_duration` was ever written and none ever will
+  // be: the transcript only appends. On the next start it injects "Continue from where you left
+  // off." and answers "No response requested." — the only record that the round is over. Read as
+  // an ordinary assistant line it did three wrong things at once: the turn stayed `live` (a clock
+  // ticking on a turn nobody was working on, counted into the session total), its text became the
+  // INTENT panel, and its all-zero usage block was counted as an API call.
+  const snap = timelineOf([
+    typed('u1', 'first request'),
+    assistant('a1', 5000),
+    synthetic('s1', 'No response requested.'),
+  ]);
+  const turn = snap.turnList.at(-1)!;
+  assert.equal(turn.state, 'interrupted', 'the cut round is closed where it was cut');
+  assert.equal(snap.turnList.filter((t) => t.state === 'live').length, 0, 'nothing is left running');
+  assert.equal(snap.apiCalls, 1, 'one real call — the receipt reached no model');
+  assert.equal(turn.apiCalls, 1, 'and the turn counts the same one');
+  assert.equal(turn.lastNarration, null, 'no model said this, so it is not the session intent');
+});
+
+test('golden transcript: the receipt raises no API call on ANY surface, not just the counter', () => {
+  // `newCall` is the one signal that says "a fresh API call happened": the header counts it, the
+  // feed draws a row from it and the Trace opens an `api` span on it. Excluding the receipt from
+  // the counter alone left the three disagreeing — the header saying 1 call over a feed showing
+  // two, the second with a latency measured from the prompt to a line that never called anything.
+  const tree = createSessionTree({ windowFor, mainModel: 'claude-opus-4-8' });
+  const store = createSpanStore();
+  const calls: Array<{ ms: number | null | undefined }> = [];
+  tree.onEvent((e, c) => {
+    store.apply(e, c);
+    if (e.type === 'usage' && c?.newCall) calls.push({ ms: c.callMs });
+  });
+  let seq = 0;
+  for (const l of [typed('u1', 'go'), assistant('a1', 5000), synthetic('s1', 'No response requested.')])
+    for (const ev of parseLine(l, { ...ctx, seq: seq++ }) as NormalizedEvent[]) tree.apply(ev);
+
+  assert.equal(calls.length, 1, 'one call announced to the listeners — the real one');
+  const apiSpans = store
+    .snapshot()
+    .turns.flatMap((t) => t.spans)
+    .filter((s) => s.type === 'api');
+  assert.equal(apiSpans.length, 1, 'and one api span in the Trace, so the surfaces agree');
+  assert.equal(tree.snapshot().apiCalls, 1, 'and the header agrees with both');
+});
+
+test('golden transcript: a cut-off round is interrupted, but it is NOT an Esc', () => {
+  // Both end a round before it finished, so both are `interrupted` — what differs is who ended it.
+  // Everything that reads an interruption as the user's CORRECTION has to ask: the retrospective
+  // says "abandoned to Esc" and the verdict says "second correction in a row", and a session that
+  // died corrected nothing. Read off the state alone, a crash was filed as the user's own doing.
+  const cut = timelineOf([
+    typed('u1', 'first request'),
+    assistant('a1', 5000),
+    synthetic('s1', 'No response requested.'),
+  ]);
+  // An Esc marks the PREVIOUS round, on the user line that follows it — so the one under test is
+  // the first, not the one that Esc opened.
+  const byHand = timelineOf([
+    typed('u1', 'first request'),
+    assistant('a1', 5000),
+    typedAfterEsc('u2', 'no, wait', 'a1'),
+  ]);
+  assert.equal(cut.turnList.at(-1)!.state, 'interrupted', 'a cut-off round did not finish');
+  assert.equal(cut.turnList.at(-1)!.cutoff, true, 'and it was the session dying that ended it');
+  assert.equal(byHand.turnList[0]!.state, 'interrupted', 'an Esc ends a round too');
+  assert.equal(byHand.turnList[0]!.cutoff, false, 'but that one WAS the user');
+});
+
+test('golden transcript: the receipt does not promote a local command to an interrupted work turn', () => {
+  // `kindOf` files a command with no calls as `local` only while its state is not `interrupted` —
+  // so closing a killed session's LAST entry unconditionally turned a `/model` into a work turn
+  // that was interrupted, which is two lies about an entry that never called anything. The
+  // supersede path already had the rule (a turn that made no call is left to the 0-call → done
+  // presentation); the receipt now answers to the same one. An Esc is untouched: the user
+  // interrupted something, whether or not it had billed a token yet.
+  const snap = timelineOf([
+    typed('u1', 'do the thing'),
+    assistant('a1', 5000),
+    turnDuration('d1'),
+    slash('u2', 'model', 'opus'),
+    synthetic('s1', 'No response requested.'),
+  ]);
+  const last = snap.turnList.at(-1)!;
+  assert.equal(last.command, 'model', 'the entry under test is the local command');
+  assert.equal(last.kind, 'local', 'a built-in that called nothing is still a local command');
+  assert.notEqual(last.state, 'interrupted', 'and nothing about it was interrupted');
+});
+
+test('golden transcript: an unknown synthetic notice is not a call, but does not close the turn', () => {
+  // `<synthetic>` means one thing by construction — Claude Code produced this line without calling
+  // a model — so `noCall` and the narration suppression follow from the marker alone. "This round
+  // is over" does NOT: that is read off the ONE text measured to mean it. A future non-error
+  // synthetic notice (a schema that ships a release every ~1.9 days) must not silently close a
+  // live turn, which would report a session as idle while it works.
+  const snap = timelineOf([
+    typed('u1', 'first request'),
+    assistant('a1', 5000),
+    synthetic('s1', 'Some notice Claude Code did not write before.'),
+  ]);
+  const turn = snap.turnList.at(-1)!;
+  assert.equal(turn.state, 'live', 'an unrecognised notice says nothing about whether the round ended');
+  assert.equal(snap.apiCalls, 1, 'it still reached no model, so it is still not a call');
+  assert.equal(turn.lastNarration, null, 'and no model wrote it, so it is still not the intent');
+});
+
+test('golden transcript: an API-error line still counts as a call, and still speaks', () => {
+  // The other `<synthetic>` line, and the reason `isApiErrorMessage` is the discriminator rather
+  // than the model: a failed call DID reach the API, and its text is what the user was shown.
+  const snap = timelineOf([
+    typed('u1', 'first request'),
+    assistant('a1', 5000),
+    apiErrorLine('e1', 529, 'API Error: 529 Overloaded'),
+  ]);
+  assert.equal(snap.apiCalls, 2, 'a call that failed is still a call');
+  assert.equal(snap.turnList.at(-1)!.state, 'live', 'and an error can be retried — the turn is not closed');
+  assert.equal(snap.error?.status, '529', 'it is surfaced as the session error, which is its own state');
+});
+
+test('golden transcript: a synthetic line reports no window, and must not become the window', () => {
+  // The same line as the test above, read for what it does to the CONTEXT card rather than to the
+  // turn. Claude Code stamps `<synthetic>` on a line that reached NO model — an auto-continue after
+  // a resume, an API error — and still gives it a usage block, structurally a call's and all zeros.
+  // `mainFill` is last-write-wins, so that zero became "the window right now": the card read
+  // 0 / 1.0M · 0% for as long as the session went without a real call, which on a session resumed
+  // and left idle is until the user types again. The denominator survived (the model chip is
+  // guarded); only the numerator was lost, which is what made it read as an empty context rather
+  // than as a missing one.
+  const snap = timelineOf([
+    typed('u1', 'first request'),
+    assistant('a1', 5000),
+    synthetic('s1', 'No response requested.'),
+  ]);
+  assert.equal(snap.main.fill, 5000, 'the window stays what the last REAL call reported');
+  assert.equal(snap.main.breakdown.cacheRead, 4990, 'and so does its composition');
+  assert.equal(snap.main.pct, Math.round((5000 / snap.main.window) * 100), 'the dial agrees with the fill');
+  assert.equal(snap.turnList.at(-1)!.fillEnd, 5000, 'the turn ends where its last real call left it');
 });
 
 test('golden transcript: every line the user sent becomes a timeline entry, typed for kind', () => {
@@ -1040,6 +1209,88 @@ test('golden transcript: an API-error call folds into the agent model, no duplic
     [{ model: 'claude-sonnet-4-6', tokens: real + err }],
     'and the session bar shows the one merged model',
   );
+});
+
+test('golden transcript: a synthetic line in a CHILD leaves that subagent context bar alone', () => {
+  // The subagent-side mirror of the main-session rule: `a.fill` is last-write-wins too, so a child
+  // transcript ending on an all-zero synthetic line showed the subagent at 0% — a row claiming a
+  // context bar it never had. Same guard, same reason, and it has to be tested on its own branch:
+  // the two owners are separate code paths in the reducer.
+  const tree = createSessionTree({ windowFor, mainModel: 'claude-opus-4-8' });
+  let seq = 0;
+  const main = [
+    typed('u1', 'go'),
+    toolUse('a2', 'toolu_09', 'Agent', { prompt: 'work', subagent_type: 'general-purpose', model: 'sonnet' }),
+  ];
+  for (const l of main) for (const e of parseLine(l, { ...ctx, seq: seq++ }) as NormalizedEvent[]) tree.apply(e);
+  const childCtx = { sessionId: 's1', root: 'cli' as const, agentId: 'ag9' };
+  const realCall = JSON.stringify({
+    type: 'assistant',
+    uuid: 'c1',
+    timestamp: '2026-07-14T10:00:05.000Z',
+    message: {
+      role: 'assistant',
+      id: 'm1',
+      model: 'claude-sonnet-4-6',
+      usage: { input_tokens: 10, output_tokens: 200, cache_read_input_tokens: 90_000, cache_creation_input_tokens: 0 },
+    },
+  });
+  for (const l of [realCall, synthetic('c2', 'No response requested.')])
+    for (const e of parseLine(l, { ...childCtx, seq: seq++ }) as NormalizedEvent[]) tree.apply(e);
+  // Without it the child is not joined to its spawn and the list holds two rows — the spawn's,
+  // whose fill is 0 for a reason that has nothing to do with this test.
+  tree.apply({
+    type: 'subagent-meta',
+    sessionId: 's1',
+    root: 'cli',
+    timestamp: '',
+    seq: seq++,
+    agentId: 'ag9',
+    toolUseId: 'toolu_09',
+    agentType: 'general-purpose',
+    spawnDepth: 1,
+    model: 'claude-sonnet-4-6',
+  } as NormalizedEvent);
+
+  const snap9 = tree.snapshot();
+  assert.equal(snap9.subagents.length, 1, 'the child is joined to its spawn, so there is one row to read');
+  const sub = snap9.subagents[0]!;
+  assert.equal(sub.fill, 90_010, 'the child window stays what its last REAL call reported');
+  assert.ok(sub.pct > 0, 'so its context bar is not drawn empty');
+});
+
+test('golden transcript: a receipt in a CHILD raises no API call on the child lane either', () => {
+  // The exclusion lives on `newCall`, and `newCall` is computed on BOTH owners — the main branch
+  // and the subagent branch are separate code. Fixing only the main one left a child's receipt
+  // still drawing a Trace span and a feed row on the child lane, with a latency measured to a line
+  // that never called anything: the same three surfaces disagreeing, one lane over.
+  const tree = createSessionTree({ windowFor, mainModel: 'claude-opus-4-8' });
+  const store = createSpanStore();
+  const announced: string[] = [];
+  tree.onEvent((e, c) => {
+    store.apply(e, c);
+    if (e.type === 'usage' && c?.newCall) announced.push(e.agentId ?? 'main');
+  });
+  let seq = 0;
+  for (const l of [typed('u1', 'go'), toolUse('a2', 'toolu_10', 'Agent', { prompt: 'work', subagent_type: 'x' })])
+    for (const e of parseLine(l, { ...ctx, seq: seq++ }) as NormalizedEvent[]) tree.apply(e);
+  const childCtx = { sessionId: 's1', root: 'cli' as const, agentId: 'ag10' };
+  const realCall = JSON.stringify({
+    type: 'assistant',
+    uuid: 'k1',
+    timestamp: '2026-07-14T10:00:05.000Z',
+    message: {
+      role: 'assistant',
+      id: 'm1',
+      model: 'claude-sonnet-4-6',
+      usage: { input_tokens: 10, output_tokens: 5, cache_read_input_tokens: 900, cache_creation_input_tokens: 0 },
+    },
+  });
+  for (const l of [realCall, synthetic('k2', 'No response requested.')])
+    for (const e of parseLine(l, { ...childCtx, seq: seq++ }) as NormalizedEvent[]) tree.apply(e);
+
+  // The spawn line carries no usage of its own, so the child's single real call is the only one.
+  assert.deepEqual(announced, ['ag10'], 'the child made one call; its receipt made none');
 });
 
 test('golden transcript: a subagent with no per-call usage puts its estimated volume on its own model', () => {
@@ -2599,24 +2850,6 @@ const toolResultError = (uuid: string, toolUseId: string, text: string, denialKi
       content: [{ type: 'tool_result', tool_use_id: toolUseId, is_error: true, content: text }],
     },
   });
-/** An API-error line as CC writes it: assistant, isApiErrorMessage, synthetic model, a usage block. */
-const apiErrorLine = (uuid: string, status: number | null, text: string) =>
-  JSON.stringify({
-    type: 'assistant',
-    uuid,
-    timestamp: '2026-07-14T10:00:05.000Z',
-    isApiErrorMessage: true,
-    ...(status !== null ? { apiErrorStatus: status } : {}),
-    message: {
-      role: 'assistant',
-      id: 'msg_' + uuid,
-      model: '<synthetic>',
-      stop_reason: 'stop_sequence',
-      content: [{ type: 'text', text }],
-      usage: { input_tokens: 4, output_tokens: 0, cache_read_input_tokens: 100, cache_creation_input_tokens: 0 },
-    },
-  });
-
 test('golden: a failed tool is flagged, a user refusal is NOT', () => {
   const tree = createSessionTree({ windowFor, mainModel: 'claude-opus-4-8' });
   const store = createSpanStore();
@@ -2874,7 +3107,7 @@ test('golden verdict: an api-error opener does not turn the session BOOT into a 
   // Driven from raw jsonl because the fact lives in the reducer, not in any node the verdict sees.
   const withOpener = timelineOf([
     typed('u1', 'go'),
-    synthetic('a0', 'API error'),
+    apiErrorLine('a0', 529, 'API Error: 529 Overloaded'),
     call('a1', 5_000, 175_000),
     turnDuration('d1'),
   ]);
@@ -2921,6 +3154,36 @@ test('golden verdict: two interruptions in a row → warn esc on the SECOND, fro
   const second = computeVerdict(esc[1]!, snap);
   assert.equal(second.severity, 'warn');
   assert.equal(second.findings[0]!.kind, 'esc');
+});
+
+test('golden verdict: a session that DIED after an Esc is not a second correction', () => {
+  // The pair the finding is about is two corrections in a row, and only a person corrects. This
+  // shape — the user stops a round, then the session is killed mid-round and reopened — read as
+  // two interruptions and told the user off for a crash. It has to hold in both roles: the cut
+  // round is not the second of a pair, and it cannot be the FIRST of one either.
+  const snap = timelineOf([
+    typed('u1', 'do the thing'),
+    assistant('a1', 5000),
+    typedAfterEsc('u2', 'no, like this', 'a1'),
+    assistant('a2', 5100),
+    synthetic('s1', 'No response requested.'), // the session was killed here
+    typed('u3', 'riprendi'),
+    assistant('a3', 5200),
+    turnDuration('d3'),
+  ]);
+  const interrupted = snap.turnList.filter((t) => t.state === 'interrupted');
+  assert.equal(interrupted.length, 2, 'both rounds ended before finishing');
+  assert.deepEqual(
+    interrupted.map((t) => t.cutoff),
+    [false, true],
+    'the first was the user, the second was the session dying',
+  );
+  assert.equal(computeVerdict(interrupted[1]!, snap).severity, 'good', 'a crash is not a correction');
+  assert.equal(
+    computeVerdict(snap.turnList.at(-1)!, snap).findings.filter((f) => f.kind === 'esc').length,
+    0,
+    'and it cannot make the next turn look like the second of a pair either',
+  );
 });
 
 test('golden verdict: an ordinary turn → good (no false positives)', () => {

--- a/apps/server/tests/graph-derive.test.ts
+++ b/apps/server/tests/graph-derive.test.ts
@@ -27,6 +27,7 @@ function turn(over: Partial<TurnNode> = {}): TurnNode {
     kind: 'work',
     startedAt: null,
     state: 'done',
+    cutoff: false,
     durationMs: 1000,
     messageCount: 2,
     apiCalls: 3,

--- a/apps/server/tests/graph-shell.test.ts
+++ b/apps/server/tests/graph-shell.test.ts
@@ -472,6 +472,7 @@ function makeTurn(index: number, opts: Partial<TurnNode> = {}): TurnNode {
     kind: opts.kind ?? 'work',
     command: opts.command ?? null,
     state: opts.state ?? 'done',
+    cutoff: opts.cutoff ?? false,
     durationMs: 60000,
     messageCount: 3,
     apiCalls: 5,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -52,6 +52,55 @@ Everything released before `0.20.0` — including the pre-publication developmen
   and the Windows first-launch warnings in `docs/install.md` describe the way through without
   quoting each dialog verbatim.
 
+### Fixed
+
+- **A round cut off by a killed session now closes where it was cut.** Claude Code writes no
+  `turn_duration` for a round whose process died, and a transcript only appends, so that record
+  will never exist: the turn stayed `live` for good, running a clock nobody was working under and
+  counting it into the session's total — over an hour of "work" on a session that had been idle
+  since the kill. On re-entry Claude Code injects "Continue from where you left off." and answers
+  "No response requested.", and that receipt is the only record the round is over; it now closes
+  the turn, exactly as an Esc does. Its text is no longer taken for the model's stated intent (the
+  INTENT panel quoted it back at the reader for as long as the session stayed idle), and its
+  all-zero usage block raises no API call on any surface — not the header's count, not the feed's
+  row, not the Trace's span, which had been left disagreeing with each other. A round that called
+  nothing is left alone: closing a bare `/model` would have promoted it to an interrupted work turn.
+  A call that FAILED is not the same thing and is still counted, still speaks, and still leaves its
+  turn open to a retry. A cut-off round is `interrupted` like one stopped with Esc — both ended
+  before finishing — but it is no longer counted AS an Esc: the retrospective's "abandoned to Esc"
+  and the verdict's "interrupted again — second correction in a row" are claims about how the user
+  works, and a session that died corrected nothing. The aggregate cache version is bumped with it,
+  since both the turn's presence and its Esc flag are values a cached summary already holds.
+- **A replay that was cut now finishes its own history instead of leaving the tab short in
+  silence.** The server sends the parent transcript whole and only then each subagent child, so a
+  connection cut anywhere in the child phase delivered all of the main session and none of the
+  subagents: rows with no duration and no volume, no subagent activity in the feed, and a session
+  token total short by everything the children spent — with nothing on screen saying the history
+  was partial. Recovery existed but had to come from outside (a live-stream reconnect, or the
+  session being resumed), and a tab whose session had ended was offered neither, so the gap lasted
+  for the life of the page. A read that ends any way other than `replay-end` now reopens itself
+  after a wait that doubles up to 30s, asking only past what each file it holds is complete on —
+  never past the line it died on, since a line is several events and the read can stop between two
+  of them. Until the history is complete the live feed is held rather than applied: applied, it
+  would put the newest turn ahead of every turn preceding it, and its frontier would be read as
+  proof the tab holds everything below it — so a tab holding three lines and a stray tail line
+  resumed past the whole middle and then called itself complete. The reopen gives up only when the
+  roster says the session no longer exists (a deleted session answers 404 forever, and an
+  `EventSource` cannot read a status) or when three consecutive attempts gain no ground — futility,
+  never a count, so a slow or flaky path is never penalised however many rounds it takes. Either
+  way it releases what it holds rather than keeping the loader up for a history that is never
+  coming, and a tab that gave up keeps its live frontier untrusted so a later resync cannot ask
+  past the middle it never read. An ask from outside — the live stream recovering, the session
+  being resumed — starts its own budget rather than inheriting the spent one.
+- **The Context card no longer empties itself on a line that never called a model.** Claude Code
+  stamps `<synthetic>` on lines that reached none — the "No response requested." it writes when a
+  killed session is resumed, and API-error lines — and gives them a `usage` block all the same,
+  structurally a call's and all zeros. The reducer took it as the window's newest state, so the
+  card read `0 / 1.0M · 0%` with the model chip and the denominator intact, until the next real
+  call arrived; on a session resumed and then left idle, that is until the user types again. A
+  subagent's own context bar had the same hole on its own branch. Both now refuse a usage line
+  that names no model AND reports no tokens.
+
 ## 0.28.1 (2026-08-16)
 
 ### Fixed

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -498,9 +498,9 @@ The parser flattens the raw log into a small set of events consumers care about:
 | `compaction`      | `compactMetadata` / `isCompactSummary`                     | a compaction (context deflate)   |
 | `user-turn`       | a user line that is `origin.kind: 'human'`, **or** carries `<command-name>`, **or** is the plain text of a command (see below) | the user sent something — opens a timeline entry; `prompt` is the text (a command's `<command-args>`, or its arguments), `command` the slash command that carried it, `promptId` the invocation the line belongs to |
 | `command`         | the same three shapes as `user-turn`                       | a slash command was used         |
-| `turn-narration`  | an assistant `text` block on a line whose `stop_reason` is anything but `end_turn`; main session only | mid-turn narration — the model saying what it is about to do: `text` (anonymized, capped at 2000) and `callId` (`message.id`), which is also the call whose tools form the Trace's round. A subagent's narration has no consumer and is dropped |
+| `turn-narration`  | an assistant `text` block on a line whose `stop_reason` is anything but `end_turn`; main session only; never the auto-continue receipt (see `turn-interrupted`), whose text no model wrote | mid-turn narration — the model saying what it is about to do: `text` (anonymized, capped at 2000) and `callId` (`message.id`), which is also the call whose tools form the Trace's round. A subagent's narration has no consumer and is dropped |
 | `turn-result`     | an assistant `text` block on a line whose `stop_reason` is `end_turn` | the turn's final answer — `outputFull` (anonymized, capped at 20k) and `outLen`. The same shape on a CHILD line becomes `subagent-output` instead |
-| `turn-interrupted` | `interruptedMessageId` on the next user line after an Esc | the previous turn was interrupted. Emitted BEFORE that line's `user-turn`, so the reducer closes the old turn before opening the new one |
+| `turn-interrupted` | `interruptedMessageId` on the next user line after an Esc, **or** Claude Code's auto-continue receipt — a `<synthetic>` assistant line that is not an API error, which it writes when it re-enters a session whose last round never finished | the previous turn was interrupted. After an Esc it is emitted BEFORE that line's `user-turn`, so the reducer closes the old turn before opening the new one. The receipt is recognised by its TEXT, not by the `<synthetic>` marker: the marker says only that no model wrote the line, while "this round is over" is read off the one wording measured to mean it — a future notice Claude Code writes the same way would otherwise close a turn that is still working. It is the ONLY record that a killed round is over — the `turn_duration` that would have closed it was owed by a process that died, and a transcript only appends — so without it the turn stays `live` for good, running a clock nobody is working under and counting it into the session's total. It carries `cutoff`, and a cutoff closes only a round that made a call: an Esc says the user stopped something, while a killed session says only that nothing more is coming, so a bare `/model` is left to the 0-call → done presentation rather than promoted to an interrupted work turn. `cutoff` rides on to `TurnNode`, because the distinction outlives the event: a cut round IS interrupted, but it is not an **Esc**, and every surface that reads an interruption as the user's CORRECTION — the retrospective's "abandoned to Esc", the verdict's "second correction in a row" — must exclude it. A crash is not a correction |
 | `turn-end`        | a `system` line with `subtype: 'turn_duration'`; main session only | the turn finished — `durationMs` and `messageCount`, both nullable. Claude Code's own measure, not one seedeep derives |
 | `agent-launch`    | `<forked-skill-launch>` on a `system`/`local_command` line  | a forked skill (`/code-review`) started a background agent — `launchedAgentId`, `skillName`, `description`. It is NOT a `tool_use`: this line is the only record that the agent exists, when it started and which turn asked for it |
 | `file-change`     | a `file-history-delta` line (`trackingPath`)               | Claude Code backed up one file it changed — its own /rewind ledger. It records ONLY what CC's own file-writing tools wrote: a file written by `python3`, by `cat >>` or by the build produces no delta at all, and WHICH session made a shell write is recorded nowhere on disk. So the Changed files card does not count this event — its number comes from the session's own commits via `GET /api/files` (`docs/session-output.md`), reproducible with `git show --stat`. The ledger's one remaining job is the session scratchpad, which lives outside the repo where git cannot see it: `isScratchPath` (`apps/server/src/core/text.ts`) classifies on the `~scratch` token `anon` produces, so a path is anonymized BEFORE it is tested. `trackingPath` has TWO shapes — absolute, or relative to the session's cwd, in which case `backup.realParentDir` names the directory — and `ledgerPath` resolves both. The reducer still attributes each delta to the open turn; the baseline `file-history-snapshot` stays ignored |
@@ -592,6 +592,14 @@ prompt of ONE API call, so the reducer keeps its tokens in two shapes:
 
 - `main.breakdown` / `turn.breakdown` — the **last call**, absolute. It answers
   "what is the window made of right now", so it (and only it) drives the Context bar.
+  The last call that reached a MODEL, which is not every `usage` line: Claude Code
+  stamps `<synthetic>` on lines that called none — the "No response requested." it
+  writes when a killed session is resumed, and API-error lines — and gives them a
+  `usage` block all the same, structurally a call's and all zeros. Taken as last-call
+  state it reports an empty window, so the reducer refuses a line that names no model
+  AND reports no tokens (`reportsWindow`). Both conditions: a real call can arrive
+  without a model on the line, and can never read zero, having at least its system
+  prompt. The SUMS below are outside that guard — an all-zero line adds nothing to them.
 - `main.cacheTotals` + `main.inputTotal` + `main.outputTotal` (and the per-turn
   equivalents) — **summed over every call in the scope**. They answer "how many tokens
   did this billing category cost", and they drive the **Session** card's ledger.
@@ -650,6 +658,14 @@ event as `callId`, with the `seq` as fallback for `<synthetic>` lines that have 
 each call by its block count. The same guard also absorbs the stream's high-water re-send after a reconnect
 (`stream.ts` guards with `seq <`), which a SUM — unlike everything set-shaped in the
 reducer — would otherwise double-count.
+**And not every `usage` line is a call at all.** Claude Code's auto-continue receipt carries a full
+usage block, all zeros, having reached no model. The parser marks it `noCall`, and the reducer
+withholds `newCall` from it — not merely the counter, because `newCall` is the ONE signal that says
+a fresh call happened and three surfaces read it: the header's count, the feed's row and the Trace's
+`api` span (with `callMs`, a latency that would be measured to a line that never called anything).
+Excluding it from the counter alone left the three disagreeing on screen. A FAILED call is not the
+same thing and raises all three — it reached the API. The two are told apart by `isApiErrorMessage`,
+never by the model: both are `<synthetic>`, and both report zero tokens.
 
 Every file-tailed event also carries a **`seq`**: a per-file line number assigned
 by whoever reads the lines (the watcher for the live tail, the replay reader for
@@ -1150,6 +1166,35 @@ And the connection rules:
   session's history is thousands of events and painting through that flood rebuilds the whole bento
   per coalesced tick. The loader cannot hang — `startReplay` fires the handoff exactly once, on
   `replay-end`, on a dead connection, or on `stop()`.
+- **A read that was CUT reopens itself**, after a wait that doubles up to 30s, until one reaches
+  `replay-end` — the only frame that says the history is all here. The loss a cut causes is not
+  spread evenly: the server sends the parent transcript whole and only then each child, so a cut in
+  the child phase costs every subagent and no main-session line. The reopen asks only past what each
+  file holds **whole** — a line is several events sharing one `seq`, so the line a read died on is
+  never claimed — and requests whole any file the tab has never seen, which is what makes the
+  children arrive complete. A tab whose session has ENDED needs this most: nothing else would ever
+  ask again.
+- **Until the history is complete, the live feed is HELD, not applied.** Two reasons, and the second
+  is the one that bites: a line from the file's tail applied before the middle would put the newest
+  turn ahead of every turn that precedes it, and the resume mark reads the live frontier as proof
+  that everything below it is held — so a tab holding lines 0–2 and a stray line 500 would resume
+  from 499 and lose the middle for good, then reach `replay-end` and call itself complete. The
+  reader keeps the loader a while longer, which is the truth. The handoff (`onLive`) waits for a read
+  that COMPLETES; `stop()` releases it too — including between two attempts, when no read is in
+  flight at all — since a closing tab has no later read to wait for.
+- **The reopen gives up on futility, never on a count.** A read that advances resets the counter, so
+  a slow or flaky path is never penalised however many rounds it takes; three consecutive reopens
+  that gain no ground end it, because that read is not coming back — a server-side throw on one
+  line, a proxy cutting at a fixed byte count, a child file that will not open. It also gives up
+  when the roster says the session is GONE: a deleted session answers 404 forever, and an
+  `EventSource` cannot read a status, so it fires the same contentless `error` a dropped path does.
+  Either way it hands off what the tab holds — keeping the loader up for a history that is never
+  coming is the same freeze this replaced, reached from the other side. A tab that gave up keeps a
+  history with a hole in it, so the live frontier stays untrusted for good (see the previous rule):
+  a later resync asks from what was actually read. Giving up is a verdict on the attempts, never on
+  the tab: an ask from OUTSIDE — the live stream recovering, the session being resumed — is new
+  information and starts its own budget, backoff and futility count both. Carrying the spent one
+  made that recovery path a dead letter, abandoning the ask on its first cut with no retry at all.
 - **A live roster.** The roster is re-fetched on a light timer: a newly-born session appears in
   the dropdown (never stealing focus by auto-opening a tab), and a session that ends re-labels its
   tab, closes its live subscription and freezes the view on the last state.


### PR DESCRIPTION
The repository went public with two ways in, and both of them demand a reproduction. `config.yml` disables the blank issue, and — verified against GitHub's documentation — that removal is real for everyone arriving from outside: write access still sees the *Blank issue* option, Read and Triage see only the templates. So a visitor who simply did not understand what seedeep was showing them had a bug form asking for their OS and their install method, a feature form asking what should change, and nothing else.

This adds a third template: one required free-text field, one optional line of context, the same privacy notice as the bug form, and the no-SLA expectation linked from `CONTRIBUTING.md` before anyone starts typing. It is deliberately wide where the bug form is narrow — a narrow door for a question is the same as no door. The `question` label it applies already exists in the repository.

**Discussions stay off, deliberately.** Enabling them creates a tab with six default categories and no posts, and a second notification queue to police on a project with no community yet — and GitHub does not document what becomes of the content if they are later switched off, so it is a one-way door. Questions live in the Issues, one inbox, the one that is already read.

## Checks

`Bun.YAML.parse` accepts all four templates · the `#how-we-work-together` anchor resolves · `bun test apps/server/tests/docs.test.ts` 4 pass · one new file, nothing else touched.

Still unproven, and it needs a non-owner view: no issue has ever been opened through these templates, so the chooser has never been seen as a visitor sees it. Opening a test issue as the owner would not reproduce it.