### PR TITLE
A door for a question, not only for a bug

### DIFF
--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,27 @@
+name: Question
+description: Ask how something in seedeep works, or why it behaves the way it does.
+title: "[Question] "
+labels: ["question"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **Privacy notice:** seedeep reads your Claude Code session logs, which contain real file paths, project names, and prompt content. Redact any such information from screenshots and pasted output. Replace real paths with placeholders like `/home/dev/myproject` and real project names with generic ones.
+
+        seedeep is maintained by one person outside working hours, so an answer may take a while — see [CONTRIBUTING.md](https://github.com/duqaXxX/seedeep/blob/main/CONTRIBUTING.md#how-we-work-together).
+
+  - type: textarea
+    id: question
+    attributes:
+      label: Your question
+      description: What are you trying to understand? If seedeep showed you something you did not expect, say what it showed and what you thought it meant.
+      placeholder: "The context bar keeps growing after a compaction. Is that the same window being re-counted, or does compaction not shrink it?"
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Anything that helps answer it
+      description: Optional. The seedeep version (`seedeep --version`), your OS, or what you were doing at the time — only if it is relevant to the question.
+      placeholder: "seedeep 0.28.0 on macOS, watching a live session."


### PR DESCRIPTION
The repository went public with two ways in, and both of them demand a reproduction. `config.yml` disables the blank issue, and — verified against GitHub's documentation — that removal is real for everyone arriving from outside: write access still sees the *Blank issue* option, Read and Triage see only the templates. So a visitor who simply did not understand what seedeep was showing them had a bug form asking for their OS and their install method, a feature form asking what should change, and nothing else.

This adds a third template: one required free-text field, one optional line of context, the same privacy notice as the bug form, and the no-SLA expectation linked from `CONTRIBUTING.md` before anyone starts typing. It is deliberately wide where the bug form is narrow — a narrow door for a question is the same as no door. The `question` label it applies already exists in the repository.

**Discussions stay off, deliberately.** Enabling them creates a tab with six default categories and no posts, and a second notification queue to police on a project with no community yet — and GitHub does not document what becomes of the content if they are later switched off, so it is a one-way door. Questions live in the Issues, one inbox, the one that is already read.

## Checks

`Bun.YAML.parse` accepts all four templates · the `#how-we-work-together` anchor resolves · `bun test apps/server/tests/docs.test.ts` 4 pass · one new file, nothing else touched.

Still unproven, and it needs a non-owner view: no issue has ever been opened through these templates, so the chooser has never been seen as a visitor sees it. Opening a test issue as the owner would not reproduce it.