### PR TITLE
0.29.0

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,8 @@ Everything released before `0.20.0` — including the pre-publication developmen
 
 ## Unreleased
 
+## 0.29.0 (2026-08-17)
+
 ### Added
 
 - `docs/api.md` — the HTTP reference: every route with its parameters, response type, status

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "seedeep",
-  "version": "0.28.1",
+  "version": "0.29.0",
   "private": true,
   "type": "module",
   "description": "Live context & subagent visualizer for Claude Code",


### PR DESCRIPTION
The version bump and the changelog cut, in one diff — `## Unreleased` becomes `## 0.29.0 (2026-08-17)` with a fresh empty heading above it, so a reader on 0.29.0 can tell what is in their build.

What the section holds, in short: a session killed mid-round no longer reads as an empty context window, a turn ticking for nobody and an intent panel quoting Claude Code's own bookkeeping; a replay cut by a dropped connection finishes its own history instead of leaving the tab silently short of every subagent; and a crash is told apart from an Esc wherever the difference is a claim about how the user works. The aggregate cache version moves with it, so summaries taken before this are recomputed on the first refresh.

## Checks

`bun run test` 1740 pass / 0 fail · `typecheck` and `lint` clean. The two pull requests this releases were merged green (10 checks each, including the Rust tray on macOS and Windows).