### PR TITLE
The privacy claim, made exact on the three surfaces met first

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ every call to the model with its latency and its own input and output, every too
 it fired and what came back, each subagent's work folded under the spawn that
 launched it, down to the answer you read. One continuous flow, live during the
 turn and still there to walk through afterwards. All of it from the logs Claude
-Code already writes on your machine: **read-only, no proxy, no daemon, nothing
-sent anywhere.**
+Code already writes on your machine: **read-only, no proxy, no daemon, no session
+content sent anywhere.**
 
 ![The context window filling live while six subagents run on three models](docs/assets/hero.gif)
 
@@ -202,8 +202,10 @@ honest estimate of what an untouched square still holds.
   APIs alone — no runtime builtins — so they run and are tested anywhere. The server
   around them is Bun, and ships with it embedded: you never install a runtime to run
   `seedeep`.
-- **Local by default.** Nothing leaves the machine unless you ask for it, and asking
-  for it turns on TLS and a token in the same move.
+- **Local by default.** Your session content never leaves the machine unless you ask for
+  it, and asking for it turns on TLS and a token in the same move. The only outbound
+  request seedeep makes on its own is the update check against `registry.npmjs.org`, and
+  `seedeep update --offline` skips it.
 - **Visual is the point.** The number is the message; the picture is what makes it
   click.
 

--- a/apps/server/npm/README.md
+++ b/apps/server/npm/README.md
@@ -4,8 +4,10 @@
 
 `seedeep` makes visible what a Claude Code session hides: **how the context window
 fills, live, during a turn** — and what the subagents are doing while it happens.
-It reads the session logs Claude Code already writes on your machine. Nothing is
-sent anywhere, nothing is written back.
+It reads the session logs Claude Code already writes on your machine. No session
+content is sent anywhere and nothing is written back — the only outbound request it
+makes on its own is the update check against npm, which `seedeep update --offline`
+skips.
 
 ![The context window filling live while six subagents run on three models](https://raw.githubusercontent.com/duqaXxX/seedeep/v{{VERSION}}/docs/assets/hero.gif)
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -26,6 +26,12 @@ Everything released before `0.20.0` — including the pre-publication developmen
 
 ### Fixed
 
+- The privacy claim is now exact on the three surfaces a newcomer meets first. The README, the npm
+  page and the repository description each said that nothing is sent anywhere, while seedeep does
+  make one outbound request on its own — the update check against `registry.npmjs.org`. What never
+  leaves the machine is the session content, which is what the claim was about; the check, and the
+  `seedeep update --offline` that skips it, are now named beside it. `SECURITY.md` and
+  `docs/install.md` already stated it precisely, and their wording is what the three borrow.
 - A recorded scene now waits for the marker of its OWN prompt. A background task finishing injects a
   `<task-notification>` user line, which is a turn carrying its own `turn_duration`, and a wait
   keyed on the next marker was satisfied by it — so a scene was declared finished while it was still


### PR DESCRIPTION
The README, the npm page and the repository description each said that nothing is sent
anywhere. seedeep does make one outbound request on its own — the update check against
`registry.npmjs.org` — so a reader who greps for the call finds it before they find it
documented, on the three surfaces a launch points at first.

## What was actually wrong

Nothing about the behaviour: `SECURITY.md` and `docs/install.md` have always stated it
precisely. The two accurate documents are the ones nobody reads first, and the loose ones
were the landing page, the npm page and the link preview.

## What each one says now

What never leaves the machine is the **session content**, which is what the claim was
always about. Each surface now says that, and names the check and the
`seedeep update --offline` that skips it beside it.

- `README.md`, opening paragraph — `no session content sent anywhere`, in place of
  `nothing sent anywhere`.
- `README.md`, the *Local by default* principle — carries the update check and the flag
  that skips it, which is where the detail belongs.
- `apps/server/npm/README.md` — the same, in the register of that page. It is the surface
  that only a publish can correct, so it could not wait for the next docs pass.
- The repository description, already applied on the repository itself.

The wording is borrowed from `SECURITY.md` rather than written again, so there is one
account of the outbound call instead of four.

The lines about writing are untouched — `no network interception`, `nothing written back`,
`nothing seedeep reads is ever written` — because they were never the claim in question,
and they are true.