### PR TITLE
The tagline names Claude Code, and stops naming the context window

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # seedeep
 
-### *See deep into your agent's context.*
+### *See deep into what Claude Code is doing.*
 
 [![npm](https://img.shields.io/badge/npm-seedeep-cb3837)](https://www.npmjs.com/package/seedeep)
 [![license](https://img.shields.io/badge/license-MIT-blue)](LICENSE)

--- a/apps/server/npm/README.md
+++ b/apps/server/npm/README.md
@@ -1,6 +1,6 @@
 # seedeep
 
-### *See deep into your agent's context.*
+### *See deep into what Claude Code is doing.*
 
 `seedeep` makes visible what a Claude Code session hides: **how the context window
 fills, live, during a turn** — and what the subagents are doing while it happens.

--- a/apps/server/src/server/help.ts
+++ b/apps/server/src/server/help.ts
@@ -42,7 +42,7 @@ const pad = (rows: [string, string][]): string[] => {
 /** The whole `--help` text. */
 export function usage(version = VERSION): string {
   return [
-    `seedeep ${version} — see deep into your agent's context.`,
+    `seedeep ${version} — see deep into what Claude Code is doing.`,
     '',
     'Commands',
     ...pad(COMMANDS),

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -24,6 +24,15 @@ Everything released before `0.20.0` — including the pre-publication developmen
   user scope in the capture's throwaway profile: Claude Code asks for approval before using a
   project-scoped `.mcp.json`, and an unattended recording has nobody to answer.
 
+### Changed
+
+- The tagline is now **"See deep into what Claude Code is doing."**, in the README, on the npm page
+  and in `seedeep --help`. It replaces *"See deep into your agent's context"*, and both halves of
+  that are deliberate. *Context* went because the context window is one surface of the tool rather
+  than its perimeter — what the tool shows is what Claude Code is doing at each moment, and the
+  window filling is a consequence of that. *Your agent* went because seedeep reads Claude Code's own
+  session files and works with nothing else, so the wider word promised more than it does.
+
 ### Fixed
 
 - The privacy claim is now exact on the three surfaces a newcomer meets first. The README, the npm


### PR DESCRIPTION
Two words changed in one sentence, and each was promising something slightly off.

## `context` → what it is doing

The context window is one surface of the tool, not its perimeter. What seedeep shows is what
Claude Code is doing at each moment — the calls, the tools, the subagent tree, what the session
produced — and the window filling is a consequence of that rather than the subject. A tagline
naming only the window shrinks the tool to a meter, which is also the category it has the most
reason to stay out of.

## `your agent` → Claude Code

seedeep reads Claude Code's own session files and works with nothing else. "Your agent" promises a
tool that runs against any agent, which is the same defect as the privacy claim corrected in the
commit before this one: a sentence slightly wider than the truth, sitting on the surface a reader
meets first. Naming Claude Code is also what makes the project findable by the people it is for.

## Where it lives

`README.md`, `apps/server/npm/README.md`, and **`seedeep --help`** — the last of which no list of
the tagline's homes had ever counted. The changelog entry records both halves of the reasoning, so
the next person to reach for a wider word finds out why it was narrowed.

The npm page corrects itself only on a publish, so this reaches npmjs.com with the next tag and not
before.