### PR TITLE
0.30.0

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,8 @@ Everything released before `0.20.0` — including the pre-publication developmen
 
 ## Unreleased
 
+## 0.30.0 (2026-08-17)
+
 ### Added
 
 - `capture-demo.ts social` — the launch clip: one continuous shot of a session's last turn running,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "seedeep",
-  "version": "0.29.0",
+  "version": "0.30.0",
   "private": true,
   "type": "module",
   "description": "Live context & subagent visualizer for Claude Code",


### PR DESCRIPTION
The launch text, and the release that publishes it.

`docs/CHANGELOG.md` cuts `Unreleased` into `0.30.0 (2026-08-17)` in this same diff, so a reader on
0.30.0 can tell which entries are in their build.

## What is in it

- **The tagline names Claude Code** and stops naming the context window — in the README, on the npm
  page and in `seedeep --help`. The window is one surface of the tool, not its perimeter, and
  "your agent" promised a tool that runs against any agent when seedeep reads Claude Code's session
  files and nothing else.
- **The privacy claim, made exact** on the three surfaces a newcomer meets first. seedeep does make
  one outbound request on its own — the update check against `registry.npmjs.org` — and each surface
  now names it, and the `seedeep update --offline` that skips it, beside the thing that is actually
  true: session content never leaves the machine.
- **The launch clip** and the capture tooling that cuts it, plus the fixes that made each surface in
  it true rather than merely drawn.

## Why the version matters here

The npm page is the only surface that corrects itself solely on a publish — a commit on `main` does
not change what npmjs.com serves. Until this tag, npm publishes the previous release's tagline and
the wider privacy claim, on the channel with the easiest install. That is the reason this release
exists now rather than after the launch.