### PR TITLE
The landing copy states what is missing, instead of complaining about it

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,12 @@
 [![license](https://img.shields.io/badge/license-MIT-blue)](LICENSE)
 ![for Claude Code](https://img.shields.io/badge/for-Claude%20Code-d97757)
 
-**A Claude Code turn tells you nothing while it runs, and no more when it ends.**
+**A Claude Code turn shows you its output, not its work.**
 
 You send a prompt and the terminal shows a spinner. Behind it the window fills,
 subagents spawn and spend it on models of their own, the same context is read
-again on every call, and a compaction quietly deflates the lot. Minutes later an
-answer arrives, with no account of what it cost or which part of it was waste.
+again on every call, and a compaction deflates the lot. Minutes later an answer
+arrives, and what it took to get there is not on screen.
 
 `seedeep` records the whole chain **while it is still running** — your prompt,
 every call to the model with its latency and its own input and output, every tool

--- a/apps/server/npm/README.md
+++ b/apps/server/npm/README.md
@@ -2,8 +2,9 @@
 
 ### *See deep into what Claude Code is doing.*
 
-`seedeep` makes visible what a Claude Code session hides: **how the context window
-fills, live, during a turn** — and what the subagents are doing while it happens.
+`seedeep` makes visible what a Claude Code session does not show you: **how the
+context window fills, live, during a turn** — and what the subagents are doing
+while it happens.
 It reads the session logs Claude Code already writes on your machine. No session
 content is sent anywhere and nothing is written back — the only outbound request it
 makes on its own is the update check against npm, which `seedeep update --offline`

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,17 @@ Everything released before `0.20.0` — including the pre-publication developmen
 
 ## Unreleased
 
+### Changed
+
+- The landing copy states what is missing rather than complaining about it. The README opened on
+  *"A Claude Code turn tells you nothing while it runs"*, which is refutable in one reply — the
+  terminal does show the tools it runs and the text it writes. What it does not show is the work:
+  how many calls, how much of the context is being read again, what each subagent is spending. The
+  opening is now **"A Claude Code turn shows you its output, not its work."**, and the paragraph
+  under it no longer claims there is "no account of what it cost", since `/cost` gives one.
+- The npm page said seedeep makes visible what a session **hides**, which reads as an accusation of
+  intent. It says `does not show you` — the same fact, with nothing attributed to anyone.
+
 ## 0.30.0 (2026-08-17)
 
 ### Added


### PR DESCRIPTION
The README opened on **"A Claude Code turn tells you nothing while it runs, and no more when it
ends."** It is the first line a visitor reads, and it is refutable in one reply: the terminal does
show the tools it runs, the text it writes, the thinking.

What it does not show is the **work** — how many calls a turn really made, how much of the context
was read again on each of them, what each subagent is spending in a window of its own. So the
opening now claims the thing that is true and cannot be answered with a screenshot of a terminal:

> **A Claude Code turn shows you its output, not its work.**

## The three edits

- **README, the opening line** — as above.
- **README, the paragraph under it** — drops *"with no account of what it cost or which part of it
  was waste"*. `/cost` gives an account, just not a per-turn one, and a sentence a reader can
  falsify costs more than it buys on a landing page that has never met a stranger. It now ends on
  *"what it took to get there is not on screen"*.
- **The npm page** — said seedeep makes visible what a Claude Code session **hides**. Nothing hides
  anything: the logs are on disk, complete, and seedeep only draws them. Attributing intent to a
  tool the reader likes is the one register that turns a curious visitor into an argument. It now
  reads `does not show you` — same fact, nobody accused.

## What is deliberately unchanged

seedeep existing implies Claude Code does not show enough. That implication cannot be removed
without removing the reason for the product, and it is the premise of every observability tool ever
written. The rule this change follows is to state it as an observation, never as a grievance.

One line was also left alone on purpose — *"Every line below is something your session does not
tell you"* — because it introduces a list of specific, checkable facts. It is an index, not
rhetoric.

The npm page only updates on a publish, so this reaches npmjs.com with the next tag.