### PR TITLE
0.30.1

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,8 @@ Everything released before `0.20.0` — including the pre-publication developmen
 
 ## Unreleased
 
+## 0.30.1 (2026-08-17)
+
 ### Changed
 
 - The landing copy states what is missing rather than complaining about it. The README opened on

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "seedeep",
-  "version": "0.30.0",
+  "version": "0.30.1",
   "private": true,
   "type": "module",
   "description": "Live context & subagent visualizer for Claude Code",


### PR DESCRIPTION
The landing copy, published.

`docs/CHANGELOG.md` cuts `Unreleased` into `0.30.1 (2026-08-17)` in this same diff.

A patch rather than a minor: nothing under `apps/server/src`, `apps/server/public` or `apps/tray`
changed. What changed is the README's opening claim and the npm page's first paragraph — the two
surfaces a stranger meets before anything else.

The npm page is the reason this is a release at all rather than a commit: it only updates on a
publish, so 0.30.0 is currently serving the sentence this corrects — the one saying a Claude Code
session *hides* what seedeep shows.