### PR TITLE
0.31.0

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,8 @@ Everything released before `0.20.0` — including the pre-publication developmen
 
 ## Unreleased
 
+## 0.31.0 (2026-08-19)
+
 ### Added
 
 - Sessions hosted outside the terminal — the desktop app's **Code** tab, and headless runs — now

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "seedeep",
-  "version": "0.30.1",
+  "version": "0.31.0",
   "private": true,
   "type": "module",
   "description": "Live context & subagent visualizer for Claude Code",


### PR DESCRIPTION
Version bump and the changelog cut, in one diff: `## Unreleased` becomes `## 0.31.0 (2026-08-19)`
with a fresh empty heading above it, so a reader on this build can tell what is in it.

What it releases: a live state for sessions hosted outside the terminal — the desktop app's **Code**
tab and headless runs — and turns that close for them, both from the transcript, plus the review's
three follow-ups (the Trace's own turn state, a user line nobody answers, a tail line too big for
the first window).