### PR TITLE
0.31.1

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,15 @@ Everything released before `0.20.0` — including the pre-publication developmen
 
 ## Unreleased
 
+## 0.31.1 (2026-08-21)
+
+### Changed
+
+- Dependency maintenance only — nothing here reaches a running seedeep. `@biomejs/biome` moves
+  2.5.7 → 2.5.9; it is a development dependency, so the distributed binary never carried it. The
+  `Swatinem/rust-cache` action that caches the tray's Rust build in CI and in the release workflow
+  is re-pinned to a newer commit, which changes how those two jobs cache and nothing that ships.
+
 ## 0.31.0 (2026-08-19)
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "seedeep",
-  "version": "0.31.0",
+  "version": "0.31.1",
   "private": true,
   "type": "module",
   "description": "Live context & subagent visualizer for Claude Code",


### PR DESCRIPTION
Maintenance release. Nothing in it reaches a running seedeep.

- `@biomejs/biome` 2.5.7 → 2.5.9 — a development dependency, absent from the distributed binary.
- `Swatinem/rust-cache` re-pinned to a newer commit — it caches the tray's Rust build in CI and in
  the release workflow, so it changes how those two jobs cache and nothing that ships.

Version bumped in `package.json` and the changelog section cut in the same diff, per the release
procedure.