### PR TITLE
docs: rewrite the public docs to read as a reference, not a pitch

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,8 +9,8 @@
 - [ ] `bun run test` and `bun run typecheck` pass (plus `bun run test:tray` if this touches `apps/tray/`, which CI does not run).
 - [ ] Client code changed? `bun run build:client` was run and `apps/server/public/lib/app.js` is committed with it.
 - [ ] Docs under `docs/` are updated in this same change, and a structural change has a dated entry at the top of `docs/CHANGELOG.md`.
-- [ ] **Nothing here comes from a real session.** Fixtures, screenshots and GIFs are from a synthetic session — fake project, fake paths — and no real home path, personal address, private URL or internal identifier appears anywhere in the diff.
+- [ ] Nothing here comes from a real session. Fixtures, screenshots and GIFs are from a synthetic session (fake project, fake paths) and no real home path, personal address, private URL or internal identifier appears anywhere in the diff.
 
 <!-- The last box is the one that cannot be undone: this repo is public, and anything committed
      once stays in its history. CI scans the added lines for the obvious shapes, but it only
-     catches what it can recognise — the reading is yours. -->
+     catches what it can recognise; the reading is yours. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,12 +1,12 @@
 # Contributing to seedeep
 
-Thanks for your interest in `seedeep`. The three things you are most likely to want are first —
+Thanks for your interest in `seedeep`. The three things you are most likely to want are first:
 how to report something, how to send a change, and what to expect from the people here. Everything
 after them is setup and convention, to read when you need it.
 
 ## Reporting a bug, or asking for a feature
 
-Open an issue — the forms ask for what a report needs to be actionable: the seedeep version
+Open an issue. The forms ask for what a report needs to be actionable: the seedeep version
 (`seedeep --version`), how it was installed, your operating system, the Claude Code version, and
 whether the session was live or being replayed.
 
@@ -24,18 +24,18 @@ private route.
    change under `apps/tray/src-tauri/`).
 4. Open a pull request describing **what** changed and **why**.
 
-Three CI jobs then run on the pull request, and **all of them must be green before it can be
-merged** — `main` takes no direct pushes, from anyone, and cannot be force-pushed or
+Three CI jobs then run on the pull request, and all of them must be green before it can be
+merged. `main` takes no direct pushes, from anyone, and cannot be force-pushed or
 deleted. The maintainer goes through a pull request on the same terms:
 
-- **Tests, types, lint, client bundle** — the suite, the type-checker, `bun run lint`
+- **Tests, types, lint, client bundle:** the suite, the type-checker, `bun run lint`
   (Biome: a formatting violation blocks the change here, before review), and a rebuild of
   `apps/server/public/lib/app.js` that fails if the committed bundle no longer
   matches its source. Rebuild and commit it whenever you change client code.
-- **Tray (Rust)** — `cargo test` on a macOS and Windows matrix. `bun run test` does not
+- **Tray (Rust):** `cargo test` on a macOS and Windows matrix. `bun run test` does not
   reach it, so this job is the whole of CI's coverage for a change under
-  `apps/tray/src-tauri/` — run `bun run test:tray` before you push one.
-- **Sensitive-data scan** — the added lines are checked for real home paths,
+  `apps/tray/src-tauri/`, so run `bun run test:tray` before you push one.
+- **Sensitive-data scan:** the added lines are checked for real home paths,
   personal email addresses, secret markers and private tracker references. This
   repo is public and a leak committed once stays in the history forever, so this
   job blocks the change rather than warning about it. The check is
@@ -49,7 +49,7 @@ an unacceptable interaction uses the same private route as a vulnerability.
 
 Two expectations beyond it, both about this project's shape rather than about conduct:
 
-- **It is maintained by one person, outside working hours.** There is no SLA. A pull request may
+- It is maintained by one person, outside working hours. There is no SLA. A pull request may
   sit; a question may take a week. Saying so is more honest than an unstated promise.
 - **Say what you measured, not what you assume.** seedeep reads a log format Anthropic owns and
   changes often, so "this is wrong" is hard to act on and "on version X, this line said Y and the
@@ -60,7 +60,7 @@ Two expectations beyond it, both about this project's shape rather than about co
 - [Bun](https://bun.sh) (the project is developed against Bun; a Node path
   exists via `tsx` but is not the primary target).
 
-That is everything the server and the browser GUI need — no other runtime, no
+That is everything the server and the browser GUI need: no other runtime, no
 global CLIs, no services.
 
 The **tray app** (`apps/tray/`) additionally needs a [Rust
@@ -68,7 +68,7 @@ toolchain](https://rustup.rs) and the platform SDK (Xcode Command Line Tools on
 macOS, MSVC Build Tools on Windows). You only need it if you are changing the
 tray; nothing else in the repo does. See [`docs/tray.md`](docs/tray.md).
 
-**`cargo` has to be on your `PATH`, and rustup does not always put it there** — it
+`cargo` has to be on your `PATH`, and rustup does not always put it there. It
 writes `~/.cargo/env` but only edits your shell profile if you let it, so a shell
 that never loads that file has a working Rust install it cannot see. Fix it for
 this shell with `source $HOME/.cargo/env`, or for good by adding that line to your
@@ -103,7 +103,7 @@ bun run tray:dev          # build the tray's panel, compile the Rust shell, run 
 bun run test:tray         # the tray's Rust tests (needs the Rust toolchain)
 ```
 
-`build:server` rebuilds the browser GUI and embeds it — never call `bun build
+`build:server` rebuilds the browser GUI and embeds it. Never call `bun build
 --compile` by hand, or the binary ships whatever bundle your checkout happened to
 contain.
 
@@ -113,7 +113,7 @@ contain.
 
 ```sh
 bun run dev        # the server you are working on, on :44843
-bun run tray:dev   # the tray you are working on — it finds that server by itself
+bun run tray:dev   # the tray you are working on; it finds that server by itself
 ```
 
 An installed pair can stay running the whole time. This section is the only place the arrangement is
@@ -121,8 +121,8 @@ written down; `docs/tray.md` and `docs/architecture.md` state the rules of their
 
 #### Why it needs saying at all
 
-Each app resolves the SAME path a release does — `~/.seedeep/` for the server, the app's config
-directory for the tray — so a checkout writing there reconfigures the installed copy: the port you
+Each app resolves the SAME path a release does (`~/.seedeep/` for the server, the app's config
+directory for the tray), so a checkout writing there reconfigures the installed copy: the port you
 changed from a settings panel, or the server a dev tray was pointed at, is what the installed one
 reads on its next start. It does not take two processes at once; alternating is enough, and the
 symptom (a tray that says **Offline** for no visible reason) names nothing.
@@ -138,9 +138,9 @@ to `.seedeep-dev` inside the checkout, which is gitignored.
 | Tray: `connection.json` | `.seedeep-dev/tray/` | the app's own config directory |
 | Port | 44843 | 44842 |
 
-Nothing is shared: token, certificate, port, caches — all doubled. Notification preferences are NOT in that list: they live in the server's `config.json`, so a dev server and an installed one each have their own, and the tray reads whichever it is connected to. The
-installed apps never carry the variable, and the tray *cannot*: a GUI app inherits no shell
-environment at all, which is what makes it the installed world without anyone choosing that.
+Nothing is shared: token, certificate, port and caches are all doubled. Notification preferences are NOT in that list: they live in the server's `config.json`, so a dev server and an installed one each have their own, and the tray reads whichever it is connected to. The
+installed apps never carry the variable, and the tray cannot
+([`configuration.md`](docs/configuration.md#moving-it-seedeep_home) says why).
 
 It also works on its own, without the scripts:
 
@@ -159,20 +159,20 @@ port. That is also why `seedeep --port 9000` is found for an ordinary user.
 #### What the two worlds DO share
 
 The sessions. They come from `~/.claude/projects/`, which belongs to Claude Code and which seedeep
-only reads — so a dev portal and an installed one list exactly the same work, and everything that
+only reads, so a dev portal and an installed one list exactly the same work, and everything that
 differs between them is off screen. Each half therefore marks itself, and only when it is the
 development one:
 
 - the **tray** draws a small dot in the icon's upper left, in every state;
 - the **portal** renames its tab to *seedeep dev* and puts a chip beside the brand.
 
-Neither reads `SEEDEEP_HOME` to decide that — moving your state is not declaring yourself a
+Neither reads `SEEDEEP_HOME` to decide that: moving your state is not declaring yourself a
 developer. The tray asks `tauri::is_dev()`, the server asks `Bun.embeddedFiles.length`; both are
 facts about how the binary was produced.
 
 #### One thing that will surprise you
 
-**A dev tray's Start button does not launch your working copy.** It resolves `seedeep` on your login
+A dev tray's Start button does not launch your working copy. It resolves `seedeep` on your login
 shell's `PATH`, so it starts whatever is installed there. To make it start what you just built:
 
 ```sh
@@ -188,24 +188,24 @@ it looks for test files, so `bun test` on its own misses the checks that live in
 
 `bun run test` does **not** run the type-checker, so run `bun run typecheck`
 separately before opening a PR. It runs the tray's TypeScript tests with
-everything else, but nothing of its **Rust** side — a change under
+everything else, but nothing of its **Rust** side, and a change under
 `apps/tray/src-tauri/` needs `bun run test:tray` as well. That command compiles the blocks
 your platform selects and no others, so a change inside `#[cfg(windows)]` on a Mac is
 checked by CI and by nothing you can run; the reverse holds on Windows.
 
 ### Where the code lives
 
-Each deliverable is an app under `apps/`: the server — watcher, HTTP/SSE API and browser
-client — is `apps/server/`, and the menu-bar tray is `apps/tray/`, a pure HTTP client of
+Each deliverable is an app under `apps/`. The server (watcher, HTTP/SSE API and browser
+client) is `apps/server/`, and the menu-bar tray is `apps/tray/`, a pure HTTP client of
 the server's API that links none of its code. **Run every command from the repo root**: there is one
 `package.json` and one version for the whole repo, and its scripts know where each app
 lives. Inside `apps/server/src/` there are three layers, one folder each: **`core/`** is pure
 derivation (no `node:` builtin, nothing from the other two), **`server/`** is everything
 that touches the machine, **`client/`** is the browser bundle. A test enforces it through
-the import graph, so put a new module in the layer it belongs to by nature — not by who
+the import graph, so put a new module in the layer it belongs to by nature, not by who
 calls it today. `bun run build:client` is the only command that writes into the tree
-(`apps/server/public/lib/app.js`, a build artifact — rebuild it before verifying a client
-change, or you will be verifying the previous bundle). The layout is described in
+(`apps/server/public/lib/app.js`, a build artifact, so rebuild it before verifying a client
+change or you will be verifying the previous bundle). The layout is described in
 [`docs/architecture.md`](docs/architecture.md#repository-layout).
 
 ### Checking against a real session (optional)
@@ -217,17 +217,17 @@ Claude Code sessions and prints a few live events:
 bun run apps/server/scripts/live-check.ts
 ```
 
-It only reads the session store — like `seedeep` itself, it never writes.
+It only reads the session store: like `seedeep` itself, it never writes.
 
 ## How seedeep is architected
 
 `seedeep` reads the JSONL session logs Claude Code already writes and reconstructs
-a live view — **read-only, no proxy, no daemon.** Before making a non-trivial
+a live view: **read-only, no proxy, no daemon.** Before making a non-trivial
 change, read [`docs/architecture.md`](docs/architecture.md); it explains the data
 sources, the event model, and the invariants the code relies on.
 
-The one invariant worth stating up front: **`seedeep` never writes to, proxies, or
-intercepts a session.** Any change that would break the read-only guarantee will
+The one invariant worth stating up front: `seedeep` never writes to, proxies, or
+intercepts a session. Any change that would break the read-only guarantee will
 not be accepted.
 
 ## Coding conventions
@@ -235,46 +235,46 @@ not be accepted.
 - **Language:** English for all code, comments, docs, and commit messages.
 - **TypeScript, strict.** The project builds under `strict` and
   `noUncheckedIndexedAccess`; keep it warning-free (`bun run typecheck`).
-- **Formatting is not a discussion.** `bun run lint:fix` before you push, and CI
+- Formatting is not a discussion. `bun run lint:fix` before you push, and CI
   checks it. The rules are in `biome.jsonc`, and every disabled rule carries the
-  reason it is off — if one gets in your way, argue with the reason rather than
+  reason it is off; if one gets in your way, argue with the reason rather than
   adding a suppression. One commit in this repo is pure reformatting: run
   `git config blame.ignoreRevsFile .git-blame-ignore-revs` once and `git blame`
   will skip it.
-- **Comment the *why*, not the *what*.** Explain a non-obvious decision or
+- **Comment the *why*, not the *what*. Explain a non-obvious decision or
   invariant; never narrate what the code plainly does. Match the density already
   in the codebase.
-- **JSDoc on exported functions.** Public exported functions carry a one-line
-  JSDoc stating the contract — what it returns, key invariants, and side effects.
+- JSDoc on exported functions. Public exported functions carry a one-line
+  JSDoc stating the contract: what it returns, key invariants, and side effects.
   Trivial exports whose signature is already the contract don't need one.
-- **Dependency injection for I/O.** Inject filesystem, time, and env so units
+- Dependency injection for I/O. Inject filesystem, time, and env so units
   stay testable without touching the real machine (see `DiscoverOptions`,
   `ServerDeps`). New I/O-bound code should follow the same shape.
 
 ## Tests
 
 - A test earns its place only if a plausible bug could make it fail usefully.
-  There is **no coverage quota** — delete a test that can't fail meaningfully.
-- **Fix-on-touch:** when you change a source file that has tests, update those
+  There is no coverage quota, so delete a test that can't fail meaningfully.
+- Fix-on-touch: when you change a source file that has tests, update those
   tests in the same commit.
-- **Run before you push:** `bun run test` and `bun run typecheck` must pass — plus
+- Run before you push: `bun run test` and `bun run typecheck` must pass, plus
   `bun run test:tray` if you touched `apps/tray/src-tauri/`, since `bun run test`
   does not reach the Rust side. CI runs all three on every push and pull request, so a
-  failure here is a failure there. It runs the Rust ones on **macOS and Windows both**,
+  failure here is a failure there. It runs the Rust ones on macOS and Windows both,
   which your machine cannot: `#[cfg(windows)]` is not merely untested off Windows, it is
   never handed to the compiler there, and `local.rs` carries five such blocks. So write a
-  Rust test that can pass on either — build paths from `std::env::temp_dir()` rather than
+  Rust test that can pass on either: build paths from `std::env::temp_dir()` rather than
   writing `/tmp/...` (which is not even absolute on Windows), create the files you assert
   on instead of borrowing `/usr/bin/true`, and encode JSON rather than formatting a path
   into a string literal, where a backslash is not an escape.
-- Fixtures (`apps/server/tests/fixtures/*.jsonl`) must be **synthetic and anonymized** — no
+- Fixtures (`apps/server/tests/fixtures/*.jsonl`) must be synthetic and anonymized, with no
   real paths, project names, or session content. The repo is public; never
   commit a real session log, real user data, or a screenshot of a real session.
 
 ### The tray's live probes
 
-Certificate pinning is a claim about a real TLS handshake, and nothing hermetic can make it. **Seven
-Cargo tests are `#[ignore]`d**, each gated on a variable of its own: four need a server started by
+Certificate pinning is a claim about a real TLS handshake, and nothing hermetic can make it. Seven
+Cargo tests are `#[ignore]`d, each gated on a variable of its own: four need a server started by
 hand, one starts and stops a real server itself, and the last two are a hostname check and an icon
 dump. The four:
 
@@ -287,13 +287,13 @@ SEEDEEP_TRAY_PROBE_LOCAL_REMOTE=1 cargo test -- --ignored --nocapture a_local_se
 # a seedeep in REMOTE mode on THIS machine, which the tray adopts without asking for a paste
 SEEDEEP_TRAY_PROBE_LOCAL_ADOPT=1 cargo test -- --ignored --nocapture a_co_located_server_in_remote_mode
 # the whole remote flow against any server: learn, refuse to store, trust, restart, read the digest,
-# re-paste without being asked again, then refuse a pin that does not match — and re-pin it
+# re-paste without being asked again, then refuse a pin that does not match, and re-pin it
 SEEDEEP_TRAY_PROBE_URL='https://127.0.0.1:44842/?token=…' cargo test -- --ignored --nocapture a_real_server_is_reached
 ```
 
-Each is named on purpose: they want different servers and more than one wants the same port, so
+Each is named apart: they want different servers and more than one wants the same port, so
 `--ignored` with no filter runs all seven and fails the ones whose server is not up. That noise is
-deliberate — a probe that passes without having run is worse than one that says it could not. The
+deliberate: a probe that passes without having run is worse than one that says it could not. The
 last one prints the fingerprint it learned, so it can be compared against the line the server
 printed: the same out-of-band check a user is asked to perform.
 
@@ -305,7 +305,7 @@ tray was installed and used, and six defects were found and fixed: the installer
 Administrator rights, the tray icon reads in the notification area, the popover opens at full
 height, notifications are delivered on both switches, and trust-on-first-use works against a
 server reached over HTTPS on another machine. What that leaves is ordinary use rather than a list
-of open questions — report what you see in an issue, since an "it all worked" is still worth
+of open questions. Report what you see in an issue, since an "it all worked" is still worth
 sending on a platform nobody here uses daily.
 
 Where an observation goes: [`docs/tray.md`](docs/tray.md#what-an-unsigned-build-can-actually-deliver)
@@ -314,74 +314,74 @@ not a footnote to that one.
 
 ## Documentation
 
-- Permanent docs live in `docs/`. Keep them in sync with the code in the **same**
-  change — a behavior change and its doc update belong together.
+- Permanent docs live in `docs/`. Keep them in sync with the code in the same
+  change: a behavior change and its doc update belong together.
 - Structural changes get a dated entry at the top of `docs/CHANGELOG.md`.
 
 Four rules keep those references usable. They are not style preferences: an audit read every
 public document against the code and found about forty claims that contradicted it, and roughly a
 fifth of the prose describing designs that no longer existed. None of it arrived in one bad
-change — it accumulated a sentence at a time.
+change; it accumulated a sentence at a time.
 
-- **A reference states CURRENT behaviour.** Not "it used to", not "this was tried and rejected",
+- A reference states CURRENT behaviour. Not "it used to", not "this was tried and rejected",
   not a dated internal decision. That belongs in `docs/CHANGELOG.md` and in git, where it stays
   findable without making a reference lie.
-- **Point at a symbol, never at a line number.** A pointer naming a line in a source file is a
+- Point at a symbol, never at a line number. A pointer naming a line in a source file is a
   comment three weeks later, and nothing can tell a stale line number from a good one.
-  `bun run test` fails on one in a doc — including on the example this bullet is tempted to give.
-- **Do not publish a measurement a reader cannot reproduce.** State the rule instead; if the
+  `bun run test` fails on one in a doc, including on the example this bullet is tempted to give.
+- Do not publish a measurement a reader cannot reproduce. State the rule instead; if the
   number is what justifies the rule, keep it in a comment beside the code it constrains, where a
   change has to read it.
-- **One subject, one home.** If you find yourself writing "unlike in `other-doc.md`", the two
+- One subject, one home. If you find yourself writing "unlike in `other-doc.md`", the two
   belong together.
 
 `apps/server/tests/docs.test.ts` checks what a machine can: every link and anchor resolves, every
 `apps/…` path a doc names exists, no doc points at a line number, and no doc under `docs/` is
 unreachable. It runs over the whole doc set, not over your diff, because a claim usually goes
 false when the code grows around it rather than when someone edits the sentence.
-- **Never add a screenshot by hand.** The figures in `docs/features.md` are cut by
-  `bun run doc-shots` — from a recorded session, or from a written transcript in
+- Never add a screenshot by hand. The figures in `docs/features.md` are cut by
+  `bun run doc-shots`, from a recorded session or from a written transcript in
   `apps/server/scripts/doc-scenes.ts` for the states no recording can provoke (a
   failed API call, a compaction, a corpus). A scene is synthetic in content and
   faithful in SHAPE, and `apps/server/tests/doc-scenes.test.ts` runs each one through
-  the real parser and reducer to assert the state its figure claims — add a scene and
+  the real parser and reducer to assert the state its figure claims. Add a scene and
   you add its assertions, or the figure can go empty with nothing to catch it. Each
   figure is declared in `apps/server/data/doc-shots.json` alongside the source files
-  that invalidate it — plus, for the one figure that needs it, the `server` posture to
+  that invalidate it, plus, for the one figure that needs it, the `server` posture to
   photograph it in: naming a host binds the capture's own throwaway server beyond
   loopback, which is the only way to picture the TLS block and a fingerprint that come
   from the running process rather than from the form. The common name there is
-  synthetic, and is what the panel then prints in its access URL —
+  synthetic, and is what the panel then prints in its access URL,
   so `bun run doc-shots:check` can name the figures a change touched. Nothing else
-  can: no test looks at a PNG. What it names are **candidates, not verdicts** — the
+  can: no test looks at a PNG. What it names are candidates, not verdicts**: the
   map is per-file and `client/graph.ts` draws every widget, so a three-line change to
   one panel named 15 figures of 20, and re-cutting them produced 18 byte-identical
   files. The pre-push hook prints that list and stops there, WARN-only: deciding
-  whether a figure went false is a judgement — did what it *shows* change? —
+  whether a figure went false is a judgement (did what it *shows* change?),
   not something a file-level map can make for you. `--verify` settles it by
   **re-cutting the suspects into a temp directory it then deletes, and comparing the
-  pixels** — so it publishes nothing, and it costs minutes. Reach for it when what a
+  pixels**, so it publishes nothing, and it costs minutes. Reach for it when what a
   figure SHOWS is genuinely in doubt, not on a schedule: a release in particular is not
   a reason to re-cut, nor to verify. The Settings figures print the server's version, but a
   figure documents the surface it photographs, not the version that was running, and a
   stale number there makes nothing it claims false. If you change a widget that a figure
-  shows, say so in the PR — re-cutting needs the recorded bundle, which is not in the
+  shows, say so in the PR: re-cutting needs the recorded bundle, which is not in the
   repo, so a maintainer does it.
-- **The notification figure is cut too, by a different command.** `docs/assets/notifications.png`
-  is three REAL macOS banners, so no headless browser can produce it — but it is not a
+- The notification figure is cut too, by a different command. `docs/assets/notifications.png`
+  is three REAL macOS banners, so no headless browser can produce it, and it is not a
   screenshot somebody took either: `capture-demo.ts notif` drives the installed tray
   against a synthetic session, provokes the approval, the failure and the finish in
   turn, films the screen, and finds each banner by subtracting a frame of the screen
   from a frame with a banner on it. Two things it learned the hard way are worth
   knowing before touching it. The backdrop must be an ordinary window and never a
-  fullscreen one — **macOS delivers a notification while a fullscreen app is frontmost
-  and draws no banner at all**, which is a fact about the product as much as about the
+  fullscreen one, because macOS delivers a notification while a fullscreen app is frontmost
+  and draws no banner at all, which is a fact about the product as much as about the
   capture. And the banner's edges are read at a much lower threshold than its text: the
   body of a banner differs from what is behind it by a step of three or four, so a
   threshold tuned on the lettering cuts the figure through the middle of the second
   line. It needs the tray of the SAME version installed, notification permission
   granted, and the screen for about a minute.
-- **A shot must declare `waitFor`** — a selector for something its own subject
+- A shot must declare `waitFor`: a selector for something its own subject
   renders, and the run FAILS when it never appears. It is the only place a figure
   states what it must contain in a form the capture can check: while an unmet wait
   was merely ignored, four of twenty figures were photographing a state that never
@@ -389,56 +389,56 @@ false when the code grows around it rather than when someone edits the sentence.
   child data, a list with nothing indented) and nothing in the suite could see it.
   A test enforces that every shot has one.
 - A shot may declare `viewportHeight` when the widget takes its size from the
-  window rather than from its content — a drawer is `height: 100%`, so at the run's
+  window rather than from its content. A drawer is `height: 100%`, so at the run's
   shared height the settings panel was cropped with 45% of the figure empty under
   its last row. Everything that grows with its content leaves it out.
-- **The launch clip is a fifth verb, `capture-demo.ts social`**, and it shares the recorded bundle
-  with `shoot` while keeping its own camera moves — the take `shoot` records is what the README
+- The launch clip is a fifth verb, `capture-demo.ts social`, and it shares the recorded bundle
+  with `shoot` while keeping its own camera moves. The take `shoot` records is what the README
   figures are cut from, and a change made for a clip must not silently re-frame five published
   figures. It films the session's LAST turn, so the page it opens onto already has a history behind
   it, then scrolls through what the earlier turns produced, clicks into the background-commands tab
   and closes on the Trace, in one continuous shot with no cut. The same run also writes
-  `docs/assets/launch-poster.png`, the still a reader may be shown instead of the clip — taken
+  `docs/assets/launch-poster.png`, the still a reader may be shown instead of the clip, taken
   during the dwell rather than anywhere in the tour, because that is the one moment every live
   surface is on screen at once, and a real screenshot rather than a frame pulled out of the video,
   which would carry the recording's compression. Three things it does are not cosmetic, and each
   exists because the surface refuses to be faked:
-  - **The commits are re-dated onto the replay's clock.** seedeep only reads commits authored inside
-    the session's own span, and a replay rewrites every transcript timestamp to now — so a commit
+  - The commits are re-dated onto the replay's clock. seedeep only reads commits authored inside
+    the session's own span, and a replay rewrites every transcript timestamp to now, so a commit
     still carrying the recording's date is never even fetched. `--amend` reaches only the last one,
     which is why a session that committed twice once showed one; the stage rebases from the seed
     commit so every commit the session made moves.
-  - **The background command's output file is held open for real.** Nothing ever writes that a
-    background command stopped, so the server asks the machine — `lsof` — and a file nobody holds
+  - The background command's output file is held open for real. Nothing ever writes that a
+    background command stopped, so the server asks the machine with `lsof`, and a file nobody holds
     open marks the command vanished rather than running. A `tail -f` started by the capture makes
     the frame true rather than staged.
-  - **The tracker is the capture's own.** A card is recognised only from an MCP tool whose name
+  - The tracker is the capture's own. A card is recognised only from an MCP tool whose name
     carries `issue`, so `apps/server/scripts/demo-tracker-mcp.ts` serves three invented issues over
-    stdio, registered at USER scope in the throwaway profile — a project `.mcp.json` would be the
+    stdio, registered at USER scope in the throwaway profile. A project `.mcp.json` would be the
     obvious home and is the wrong one, because Claude Code asks for approval before using one and an
     unattended recording has nobody to answer.
 
 ## How a release is built
 
-`.github/workflows/release.yml` builds everything a user downloads, across nine jobs, and **a tag is
-the only thing that publishes.** Pushing `v*` creates a draft release, the build jobs upload into
+`.github/workflows/release.yml` builds everything a user downloads, across nine jobs, and a tag is
+the only thing that publishes. Pushing `v*` creates a draft release, the build jobs upload into
 it, and a final job flips the draft to published.
 
-- **Publishing is its own job, gated on all the others** — `needs: [tray, server, smoke, windows]`
+- Publishing is its own job, gated on all the others: `needs: [tray, server, smoke, windows]`
   and `if: github.ref_type == 'tag'`. A Windows failure, or a server that will not compile, leaves a
   draft rather than putting half a download page in front of people. Publishing from a build job
   would put a release on the download page as soon as the first runner finished.
-- **A manual run (`workflow_dispatch`) publishes nothing.** It builds the same artifacts and leaves
+- A manual run (`workflow_dispatch`) publishes nothing. It builds the same artifacts and leaves
   them on the workflow run; every step that writes to a repository or a registry is gated on the tag.
-- **The pipeline rehearses on a pull request.** The same jobs run on the version-bump pull request,
-  publishing nothing, and one `Release rehearsal` check reports the result — so the release path is
+- The pipeline rehearses on a pull request. The same jobs run on the version-bump pull request,
+  publishing nothing, and one `Release rehearsal` check reports the result, so the release path is
   exercised before the tag exists rather than after. The tray job is skipped there: what it would add
   is the Tauri bundler, and the gates being rehearsed are elsewhere.
-- **Every asset carries a build-provenance attestation** (`actions/attest-build-provenance`),
+- Every asset carries a build-provenance attestation (`actions/attest-build-provenance`),
   generated on a tag before the upload, so what is attested is what ships. Anyone can check a
   download with `gh attestation verify <file> -R duqaXxX/seedeep`. Nothing is code-signed.
-- **The npm job runs in the `npm-publish` environment**, which the trusted publishers on npmjs.com
-  are configured to demand — one setting written in two places, so renaming it here makes the
+- The npm job runs in the `npm-publish` environment, which the trusted publishers on npmjs.com
+  are configured to demand: one setting written in two places, so renaming it here makes the
   registry reject every publish until the other side matches. It is also gated on the repository
   variable `SEEDEEP_NPM_PUBLISH`, and it is not a dependency of `publish`: a failed npm publish
   leaves a perfectly green release page, so check both channels after a tag.
@@ -451,7 +451,7 @@ running against the asset itself on a runner of its own OS (`ubuntu-latest`, `ub
 `macos-latest`, `macos-15-intel`, `windows-latest`, `windows-11-arm`):
 
 - **`.github/scripts/smoke-server.sh`** asserts that `--version` prints the version being released,
-  that `GET /api/config` answers, and that `/`, `/lib/app.js` and `/css/chrome.css` answer too — the
+  that `GET /api/config` answers, and that `/`, `/lib/app.js` and `/css/chrome.css` answer too. The
   last three because the measured failure mode of a first compile was an API that answered while
   every static path returned 404.
 - **`.github/scripts/idle-survival.sh`** starts the binary repeatedly and leaves it completely alone
@@ -460,23 +460,23 @@ running against the asset itself on a runner of its own OS (`ubuntu-latest`, `ub
 - **`.github/scripts/server-lifecycle.sh`** drives `start` → `status` → `restart` → `stop` and
   asserts that the restart changed the pid and that something answers afterwards. The detached path
   earns its own coverage because it branches by OS, and its only other test injects its
-  dependencies — proving the logic while never running the process.
+  dependencies, proving the logic while never running the process.
 
 On a tag the binary is downloaded **from the release**, which also proves the upload happened; on a
 manual run it comes from the run's own artifact, so the whole matrix is provable without cutting a
 release. Both exits from the pipeline wait for these: `publish`, so a broken build stays a draft, and
 `npm`, which cannot be taken back at all.
 
-The Windows x64 binary additionally gets its own job, running one binary on two runners — native x64
-silicon and the same binary under Prism, Windows-on-ARM's x64 emulator — at the full protocol, so a
-crash can be attributed rather than assumed. **The Prism leg is `continue-on-error`**: failing a
+The Windows x64 binary additionally gets its own job, running one binary on two runners, native x64
+silicon and the same binary under Prism (Windows-on-ARM's x64 emulator), at the full protocol, so a
+crash can be attributed rather than assumed. The Prism leg is `continue-on-error`: failing a
 release over Microsoft's emulator would be failing it over something seedeep does not ship. The
 native leg gates `publish` and `npm` exactly as the smoke job does.
 
 ### Why the rehearsal's filter is a job and not a `paths:` trigger
 
 A workflow a path filter keeps from starting reports nothing at all, and a required check that is
-never reported sits at *Pending* and blocks the pull request forever — while a job skipped by its own
+never reported sits at *Pending* and blocks the pull request forever, while a job skipped by its own
 `if:` reports success. So a first job (`changes`) reads the diff and decides whether the rest is
 needed, and one summary job with a fixed name, `Release rehearsal`, is what the `main` ruleset
 requires. The matrix legs cannot be required directly: their names carry the matrix, so the ruleset
@@ -484,7 +484,7 @@ would break the day a target is added or renamed.
 
 ### Every action is pinned to a commit SHA
 
-Trusted publishing removes the stored token but not the credential — it mints one inside the job, so
+Trusted publishing removes the stored token but not the credential: it mints one inside the job, so
 anything running there is already in a position to publish. A tag like `@v2` is a pointer its owner
 can move at any time, and a SHA is the content, so what runs is what was reviewed. The tag is kept
 in a comment on the same line.

--- a/README.md
+++ b/README.md
@@ -10,26 +10,22 @@
 [![license](https://img.shields.io/badge/license-MIT-blue)](LICENSE)
 ![for Claude Code](https://img.shields.io/badge/for-Claude%20Code-d97757)
 
-**A Claude Code turn shows you its output, not its work.**
+Claude Code writes a session log to disk as it runs. `seedeep` tails that log and
+rebuilds the turn while it is still happening: the context window filling, every API
+call with its latency and token split, every tool call and its result, and each
+subagent folded under the spawn that launched it. The same view is there afterwards
+to walk through.
 
-You send a prompt and the terminal shows a spinner. Behind it the window fills,
-subagents spawn and spend it on models of their own, the same context is read
-again on every call, and a compaction deflates the lot. Minutes later an answer
-arrives, and what it took to get there is not on screen.
+Read-only. No proxy, no daemon, no session content leaves the machine.
 
-`seedeep` records the whole chain **while it is still running** — your prompt,
-every call to the model with its latency and its own input and output, every tool
-it fired and what came back, each subagent's work folded under the spawn that
-launched it, down to the answer you read. One continuous flow, live during the
-turn and still there to walk through afterwards. All of it from the logs Claude
-Code already writes on your machine: **read-only, no proxy, no daemon, no session
-content sent anywhere.**
+```sh
+npm i -g seedeep && seedeep     # Node or Bun; binaries below for neither
+```
 
 ![The context window filling live while six subagents run on three models](docs/assets/hero.gif)
 
-*Your last turn looked like a spinner. This is what it was doing: 3% → 26% of the
-window, six subagents on three different models, 2.9M tokens billed — 2.5M of them
-the same context read again.*
+*One turn, from 3% to 26% of the window: six subagents on three different models,
+2.9M tokens billed, 2.5M of them the same context read again.*
 
 </div>
 
@@ -37,109 +33,107 @@ the same context read again.*
 
 ## Why you'd run it
 
-Every line below is something your session does not tell you, and what `seedeep`
-does about it instead.
+Eight things a Claude Code session does not report, and what `seedeep` shows instead.
 
-- **A session died and never said so.** A failed API call — an expired login, a
-  session limit, an overloaded server — ends the turn and leaves it sitting there:
-  measured over 1830 real transcripts, **39 of 47 failed calls were the last thing
-  their session ever wrote.** seedeep turns the tab red, files the session under
-  *Broken*, and the menu-bar icon goes red above every other signal.
-- **A session has been waiting on you for ten minutes.** An approval dialog reaches
-  no log at all, so a stopped session looks exactly like a thinking one. seedeep
-  reads Claude Code's own live state and turns the tab amber the moment it stops,
-  saying what it is waiting to approve.
-- **A subagent is spending the window you needed.** The live tree shows each one as
-  it launches — its own context filling, the model it actually runs on, and the
+- A failed API call ends the turn silently. An expired login, a session limit, an
+  overloaded server: the turn stops and the terminal keeps looking normal. Across
+  1830 real transcripts, 39 of 47 failed calls were the last line their session ever
+  wrote. seedeep turns the tab red, files the session under *Broken*, and turns the
+  menu-bar icon red above every other signal.
+- An approval dialog reaches no log at all, so a session stopped on a permission
+  prompt looks identical to one that is thinking. seedeep reads Claude Code's own
+  live state, turns the tab amber the moment it stops, and names what is waiting to
+  be approved.
+- Subagent spend is invisible from the terminal. The live tree shows each subagent as
+  it launches: its own context filling, the model it actually runs on, and the
   verbatim output it handed back to the main session.
-- **The window is not the size you assume.** The bar follows the model your calls
-  really run on, so `/model` mid-session moves it, and a Haiku subagent is measured
-  against 200k while the session around it runs on 1M.
-- **The turn that paid to come back.** A turn resumed after the cache went cold
-  re-creates its whole prompt before doing any work — on a real corpus that is **a
-  quarter of every token spent**, and it looks exactly like work.
-- **Waste you would otherwise reconstruct by hand.** Seven deterministic checks
-  (no LLM) score every turn as it closes, each quoting the Claude Code
-  documentation that justifies it — and they name what the turn did right too.
-- **What the call actually cost.** Every API call in the feed with its latency, its
-  input and output on demand, and the split between cached context and what was new.
-- **What the session shipped.** The commits and the tracker cards it produced, read
-  from the calls that made them, never from a key typed in a prompt.
+- The window size depends on the model. The bar follows the model your calls really
+  run on, so `/model` mid-session moves it, and a Haiku subagent is measured against
+  200k inside a session running on 1M.
+- A resumed turn re-pays for its context. After the cache goes cold, the turn
+  re-creates its whole prompt before doing any work. On a real corpus that accounts
+  for a quarter of every token spent, and on screen it looks like work.
+- Waste is scored per turn. Seven deterministic checks (no LLM) run as each turn
+  closes, each quoting the Claude Code documentation that justifies it. They report
+  what the turn did right as well.
+- Cost is shown per call. Every API call in the feed carries its latency, its input
+  and output on demand, and the split between cached context and new tokens.
+- Output is attributed to the session that produced it. Commits and tracker cards are
+  read from the calls that made them, not from anything typed in a prompt.
 
-`seedeep` is under active development. **[The complete tour of every
-surface →](docs/features.md)**
+`seedeep` is under active development.
+**[The complete tour of every surface →](docs/features.md)**
 
 ## What it looks like
 
-Every capture below is a **synthetic session** on a fictional project — no real
-path, prompt or project name appears in any frame.
+Every capture below is a synthetic session on a fictional project. No real path,
+prompt or project name appears in any frame.
 
-### The Trace — the turn's shape, while it is still happening
+### The Trace
 
 ![The Trace filling in as the session runs](docs/assets/trace.gif)
 
-Each turn as a row: how many steps it took, how long it ran, whether a step failed,
-and the subagent rounds it spawned. It fills in as the session works — this is not a
-report produced afterwards. ([rules](docs/trace.md))
+One row per turn: how many steps it took, how long it ran, whether a step failed, and
+the subagent rounds it spawned. It fills in as the session works, rather than being
+assembled once the turn is over. ([rules](docs/trace.md))
 
-### The tray — the same session, from the menu bar
+### The tray
 
 ![The tray panel tracking a running session](docs/assets/tray.gif)
 
-A native menu-bar client, polling the same local server. It says what the session is
-doing right now, which subagents are running and on which model, and how full the
-window is — without a browser tab open. ([rules](docs/tray.md))
+A native menu-bar client polling the same local server. It reports what the session
+is doing right now, which subagents are running and on which model, and how full the
+window is, with no browser tab open. ([rules](docs/tray.md))
 
-### The notifications — the reason to have a tray at all
+### Notifications
 
 <img src="docs/assets/notifications.png" width="420" alt="Three tray notifications: waiting for approval on Bash, a failed API call, and a finished turn">
 
-Three things about a session are worth interrupting you for, and each has its own
-switch. Nothing else notifies: not a subagent finishing, not a tool error. A tray
-that notifies about everything is a tray you mute.
+Three events are worth interrupting you for, and each has its own switch. Nothing else
+notifies: not a subagent finishing, not a tool error.
 
 | Banner | Ships | Why |
 | -- | -- | -- |
-| **Waiting for your approval** | on | the session cannot go on until you answer |
-| **The last API call failed** | on | it has stopped, and nothing on screen says so — 39 of 47 real failures were the last line their session ever wrote |
-| **Turn finished** | **off** | news you can read whenever you like should not be able to force you to silence the two that cannot wait |
+| **Waiting for your approval** | on | the session cannot continue until you answer |
+| **The last API call failed** | on | it has stopped and nothing on screen says so (39 of 47 real failures were the last line their session wrote) |
+| **Turn finished** | **off** | routine news, off by default so the two above stay unmuted |
 
-Each is one title and one line — which session, and what happened. The command
-awaiting approval and the error text stay in the panel: you cannot act on a banner,
-and the webhook channel sends its payload off your machine.
+Each banner is one title and one line: which session, and what happened. The command
+awaiting approval and the error text stay in the panel, because a banner is not
+actionable and the webhook channel sends its payload off your machine.
 
-seedeep ships unsigned, so macOS asks for the notification permission again on every
-update — a tray that goes quiet after an upgrade is
-[that, not a bug](docs/install.md#installing-the-tray).
+seedeep ships unsigned, so macOS asks for the notification permission again after
+every update. If the tray goes quiet following an upgrade, see
+[installing the tray](docs/install.md#installing-the-tray).
 
-### Home — what your sessions have actually cost
+### Home
 
 ![The Home retrospective](docs/assets/home.gif)
 
 Across every session on the machine: turn-size distribution, where the waste came
-from, and tokens split by the model that spent them — **subagents counted under their
-own model**, so a Haiku explorer inside an Opus session shows up as Haiku.
+from, and tokens split by the model that spent them. Subagents count under their own
+model, so a Haiku explorer inside an Opus session shows up as Haiku.
 
-### Search — finding the session that solved it
+### Search
 
 ![Searching across sessions](docs/assets/search.gif)
 
-Every word narrows. Your prompts and Claude's answers, matches highlighted in place,
-ranked by density rather than recency. Paste a commit hash or a tracker id and it
-also asks git and its own index — the session that did the work is exactly the one
-text search misses. ([rules](docs/search.md))
+Every word narrows the results. Your prompts and Claude's answers, matches highlighted
+in place, ranked by density instead of recency. Paste a commit hash or a tracker id
+and it queries git and its own index too, which is where plain text search comes up
+empty. ([rules](docs/search.md))
 
 ## How it works
 
-Claude Code appends one line to a local session file per content block — a single
-response becomes several — each stamped with its call's token usage. `seedeep` tails
-those files and reconstructs the picture — no network interception, no
-`ANTHROPIC_BASE_URL` hack, nothing written back. It watches every active Claude Code
-session at once, and identifies its own launching session so it never counts itself.
+Claude Code appends one line to a local session file per content block, so a single
+response becomes several lines, each stamped with its call's token usage. `seedeep`
+tails those files and reconstructs the picture. No network interception, no
+`ANTHROPIC_BASE_URL` override, nothing written back. It watches every active Claude
+Code session at once, and identifies its own launching session so it never counts
+itself.
 
-Session data flows one way: the server pushes to the browser over Server-Sent Events,
-and nothing seedeep reads is ever written. See
-[`docs/architecture.md`](docs/architecture.md) for the full design.
+Session data flows one way: the server pushes to the browser over Server-Sent Events.
+See [`docs/architecture.md`](docs/architecture.md) for the full design.
 
 ## Install
 
@@ -150,77 +144,73 @@ npm i -g seedeep          # or: bun install -g seedeep --trust
 seedeep                   # watch, serve, and open the browser
 ```
 
-**With neither**, take the file for your platform from
-[the latest release](../../releases/latest) — macOS arm64/x64, Linux x64/arm64,
-Windows x64/arm64 — and run it. **That file is not an installer, it is the program**: it
-carries its own runtime and the whole browser GUI inside, installs nothing, and
-leaves behind only `~/.seedeep/`. The Linux builds require **glibc** (Debian,
-Ubuntu, Fedora and derivatives) — Alpine and other musl-based distributions are
-not supported.
+With neither, take the file for your platform from [the latest
+release](../../releases/latest) (macOS arm64/x64, Linux x64/arm64, Windows x64/arm64)
+and run it. It is a standalone program, not an installer: it carries its own runtime
+and the whole browser GUI inside, installs nothing, and leaves behind only
+`~/.seedeep/`. The Linux builds require glibc (Debian, Ubuntu, Fedora and
+derivatives); Alpine and other musl-based distributions are not supported.
 
-The **menu-bar tray** is a separate, optional download from the same release: a
-universal `.dmg` for macOS, a `-setup.exe` for Windows. It is a pure client — the
-server is what has to run where Claude Code runs. **Both are unsigned**, so macOS and
-Windows each show a first-launch warning.
+The menu-bar tray is a separate, optional download from the same release: a universal
+`.dmg` for macOS, a `-setup.exe` for Windows. It is a pure client, so the server still
+has to run where Claude Code runs. Both are unsigned, and macOS and Windows each show
+a first-launch warning.
 
-Inside Claude Code, `seedeep install-command` adds a `/seedeep` command that opens
-the GUI, stops the server, or reports what the current session cost.
+Inside Claude Code, `seedeep install-command` adds a `/seedeep` command that opens the
+GUI, stops the server, or reports what the current session cost.
 
 **[Installing, running, updating, remote access and removal in full →](docs/install.md)**
 
 ## Which platforms have actually been run
 
-Everything above was checked by hand on **macOS**, on the machine `seedeep` is
-developed on. **Linux has been used once**, in a VM, on arm64; **Windows in a VM**,
-several times. Building for three systems is not the same as having used three, and
-this section is that difference written down rather than left for you to find.
+Everything above was checked by hand on macOS, the machine `seedeep` is developed on.
+Linux has been used once, in a VM, on arm64. Windows in a VM, several times. Building
+for three systems is not the same as having used three, so here is that difference
+written down.
 
-There is a middle ground worth naming: **started is not used**. Every release runs
-each server binary on a runner of its own operating system before anything is
-published — it must report its version, answer on its API and serve the browser GUI,
-or the release stays a draft. That rules out the download that dies at startup. It
-says nothing about whether the thing is pleasant, or correct, in front of a person on
-that machine.
+Every release also runs each server binary on a runner of its own operating system
+before anything is published: it must report its version, answer on its API and serve
+the browser GUI, or the release stays a draft. That rules out a download that dies at
+startup. It says nothing about whether the tool is correct or pleasant in front of a
+person on that machine.
 
 | | macOS | Windows | Linux |
 | -- | -- | -- | -- |
-| **Server** — download or npm | Used daily; every claim above was checked here | **Used on Windows 11 in a VM** — installed from npm, server started and served its API against a real Claude Code session, `status`, `stop`, `restart` and `install-command` confirmed, and consecutive cold starts measured without a failure. `/seedeep` there needs one line of configuration ([`install.md`](docs/install.md#seedeep-inside-claude-code)) | **arm64: used on Ubuntu 24 in a VM** — GUI opened against a real Claude Code session, lifecycle and `install-command` confirmed. **x64: exercised on every release, never used by a person** — started, left idle and driven through the full lifecycle in CI, and version-checked on Docker; never run in front of a person. Both builds require glibc; Alpine/musl is not supported. |
-| **Tray** | Used daily on a real menu bar | **Installed and used on Windows 11 in a VM** — the installer runs, the icon reads in the notification area, the popover opens at full height, trust-on-first-use and the connection screen work, the panel's buttons respond, notifications are delivered, and no console window appears | **Not a target**, deliberately: Tauri emits no tray click event on Linux, so the panel could not open — see [`docs/tray.md`](docs/tray.md) |
+| **Server** | Used daily; every claim above was checked here | Used on Windows 11 in a VM: installed from npm, server started and served its API against a real Claude Code session, `status`, `stop`, `restart` and `install-command` confirmed, consecutive cold starts measured without a failure. `/seedeep` there needs one line of configuration ([`install.md`](docs/install.md#seedeep-inside-claude-code)) | arm64: used on Ubuntu 24 in a VM, GUI opened against a real Claude Code session, lifecycle and `install-command` confirmed. x64: exercised on every release but never used by a person, only started, left idle and driven through the full lifecycle in CI, plus a version check on Docker. Both builds require glibc; Alpine/musl is not supported |
+| **Tray** | Used daily on a real menu bar | Installed and used on Windows 11 in a VM: the installer runs, the icon reads in the notification area, the popover opens at full height, trust-on-first-use and the connection screen work, the panel's buttons respond, notifications are delivered, and no console window appears | Not a target, deliberately: Tauri emits no tray click event on Linux, so the panel could not open ([`docs/tray.md`](docs/tray.md)) |
 
-Concretely: on **Linux x64** you are the first to use it. A defect there is expected
-rather than surprising, and [an issue](../../issues) saying what you saw is the most
-useful thing you can send — every Windows session so far found several, which is the
-honest estimate of what an untouched square still holds.
+Concretely: on Linux x64 you are the first to use it. A defect there is expected, and
+[an issue](../../issues) saying what you saw is the most useful thing you can send.
+Every Windows session so far turned up several.
 
-**And which Claude Code hosts.** Terminal sessions and the desktop app's **Code** tab
-are both watched live. One signal is missing on the desktop app: a session stopped at a
-**tool approval** reads as working rather than amber, because only a terminal session
-publishes that state and a transcript cannot tell a call awaiting your yes from one that
-is running. A question the model asks you does light amber there
+Terminal sessions and the desktop app's Code tab are both watched live. One signal is
+missing on the desktop app: a session stopped at a tool approval reads as working
+rather than amber, because only a terminal session publishes that state and a
+transcript cannot tell a call awaiting your yes from one that is running. A question
+the model asks you does light amber there
 ([what each surface shows](docs/features.md#when-a-session-is-waiting-for-you)).
 
 ## Design principles
 
-- **Read-only.** `seedeep` only reads what Claude Code already writes. It never
+- **Read-only.** seedeep only reads what Claude Code already writes. It never
   modifies, proxies, or intercepts your session.
-- **Live, not post-hoc.** The point is watching a turn *as it happens*, not analyzing
-  spend after the fact.
-- **Runtime-agnostic core.** The reducer and every rule it applies are built on standard
-  APIs alone — no runtime builtins — so they run and are tested anywhere. The server
-  around them is Bun, and ships with it embedded: you never install a runtime to run
+- **Live.** The target is watching a turn as it happens, not analyzing spend after
+  the fact.
+- **Runtime-agnostic core.** The reducer and every rule it applies use standard APIs
+  only, no runtime builtins, so they run and are tested anywhere. The server around
+  them is Bun, shipped with it embedded, so you never install a runtime to run
   `seedeep`.
-- **Local by default.** Your session content never leaves the machine unless you ask for
-  it, and asking for it turns on TLS and a token in the same move. The only outbound
-  request seedeep makes on its own is the update check against `registry.npmjs.org`, and
-  `seedeep update --offline` skips it.
-- **Visual is the point.** The number is the message; the picture is what makes it
-  click.
+- **Local by default.** Your session content stays on the machine unless you ask
+  otherwise, and asking turns on TLS and a token in the same move. The only outbound
+  request seedeep makes on its own is the update check against `registry.npmjs.org`,
+  and `seedeep update --offline` skips it.
+- **Visual.** Every number is shown as something you can read at a glance.
 
 ## Development
 
-The server and the browser GUI are developed against [Bun](https://bun.sh) — no
-other runtime required. The menu-bar tray is a Tauri app, so building *it*
-additionally needs a Rust toolchain and the platform SDK.
+The server and the browser GUI are developed against [Bun](https://bun.sh), with no
+other runtime required. The menu-bar tray is a Tauri app, so building it additionally
+needs a Rust toolchain and the platform SDK.
 
 ```sh
 bun install
@@ -248,7 +238,7 @@ send a change.
 | [`session-output.md`](docs/session-output.md) | what a session shipped, worked on, and touched |
 | [`claude-code-upgrades.md`](docs/claude-code-upgrades.md) | how seedeep survives a Claude Code release |
 | [`CHANGELOG.md`](docs/CHANGELOG.md) | what changed, newest first |
-| [`CONTRIBUTING.md`](CONTRIBUTING.md) | hit a bug or want a change? start here — and what to redact before you attach anything |
+| [`CONTRIBUTING.md`](CONTRIBUTING.md) | hit a bug or want a change? start here, and what to redact before you attach anything |
 | [`SECURITY.md`](SECURITY.md) | found a vulnerability? report it privately, never as an issue |
 | [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md) | community standards and how violations are handled |
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,27 +7,26 @@ also reachable from the Security tab of this repository. It opens a draft adviso
 only you and the maintainer can read, and it is where a fix and a CVE would be
 coordinated from.
 
-**Please don't open a public issue or a pull request for it.** An issue is readable by
-everyone the moment it is filed — including for however long the fix takes. The
-advisory form is the only private channel this project has; there is no security
+Please don't open a public issue or a pull request for it. An issue is readable by
+everyone the moment it is filed, including for however long the fix takes. The
+advisory form is the only private channel this project has, and there is no security
 mailing address.
 
 Useful in a report: what an attacker gets, and the shortest way you got there. seedeep
-runs on a developer's own machine, so *who* the attacker is matters — say whether they
+runs on a developer's own machine, so *who* the attacker is matters. Say whether they
 are on the same network, holding a link the user clicks, or sending a pull request.
 
 ## What you can expect
 
 seedeep is a personal project maintained by one person outside working hours. There is
-**no SLA and no bounty**, and saying so is more honest than an unstated promise.
-Realistically: an acknowledgement once I see the advisory, a fix when I understand it,
-and credit in the published advisory unless you would rather not be named. If a report
-sits untouched for a couple of weeks, a comment on the same advisory is welcome — it
-means I missed it, not that I decided against it.
+no SLA and no bounty. Realistically: an acknowledgement once I see the advisory, a fix
+when I understand it, and credit in the published advisory unless you would rather not
+be named. If a report sits untouched for a couple of weeks, a comment on the same
+advisory is welcome; it means I missed it.
 
-**Only the latest release is supported.** Everything — the server binaries, the seven npm
-packages, the tray installers — ships from one version tag, so a fix goes out as a new
-release and there are no backports.
+Only the latest release is supported. The server binaries, the seven npm packages and
+the tray installers all ship from one version tag, so a fix goes out as a new release
+and there are no backports.
 
 ## In scope
 
@@ -40,8 +39,8 @@ The interesting surface is small, and specific:
   bypasses the TLS requirement, or that makes the server listen beyond loopback without
   the operator having asked for it.
 - **The certificate and the tray's pinning.** The server issues its own self-signed
-  certificate and prints its SHA-256 fingerprint on every start; the tray pins one leaf
-  certificate in Rust (`apps/tray/src-tauri/src/pin.rs`) because the alternative on that
+  certificate and prints its SHA-256 fingerprint on every start. The tray pins one leaf
+  certificate in Rust (`apps/tray/src-tauri/src/pin.rs`), because the alternative on that
   stack is disabling verification entirely. Anything that makes a different certificate
   acceptable to a pinned client, or that makes the printed fingerprint disagree with
   what is actually served.
@@ -50,26 +49,26 @@ The interesting surface is small, and specific:
   which is not in the tagged commit end up inside a published artifact, or that lets a
   workflow be triggered into publishing by someone who cannot push a tag.
 - **Your session files leaving the machine.** seedeep reads Claude Code's local session
-  logs — your prompts, your file paths, your project names — and never writes them back.
-  The only outbound request it makes **on its own** is the update check against
-  `registry.npmjs.org`. The one exception is the notification webhook, which is off
-  until you configure it and then POSTs to an address you chose yourself
-  ([what it sends](docs/install.md#data-flow)) — so a report about it is about seedeep
-  sending more than the banner says, or sending it somewhere you did not name. Anything
-  that serves a path outside what an endpoint should reach, or that sends session
-  content anywhere at all, is exactly the bug worth reporting.
+  logs, which contain your prompts, your file paths and your project names, and never
+  writes them back. The only outbound request it makes on its own is the update check
+  against `registry.npmjs.org`. The one exception is the notification webhook, which is
+  off until you configure it and then POSTs to an address you chose yourself
+  ([what it sends](docs/install.md#data-flow)), so a report about it is about seedeep
+  sending more than the banner says, or sending it somewhere you did not name. Also in
+  scope: anything that serves a path outside what an endpoint should reach, or that
+  sends session content anywhere at all.
 
 ## Not a vulnerability
 
 - **A crash or a wrong number on an unexpected session line.** seedeep parses a log
-  format Anthropic owns and changes often; a line it mishandles is a bug, and
+  format Anthropic owns and changes often. A line it mishandles is a bug, and
   [an issue](../../issues) is the right place for it.
 - **The unsigned first-launch warning** on macOS and Windows. The binaries and the tray
   installers are deliberately unsigned for now, and the README says so.
 - **The browser's warning on the self-signed certificate.** That is what a self-signed
-  certificate is; the fingerprint is printed on every start and shown in the settings
+  certificate does. The fingerprint is printed on every start and shown in the settings
   panel so it can be checked rather than clicked through.
-- **An attacker who is already the local user.** seedeep's state lives in `~/.seedeep/`
+- An attacker who is already the local user. seedeep's state lives in `~/.seedeep/`
   and the session logs live in `~/.claude/`, both protected by nothing more than the
   account they belong to. Someone who is already that user can read the sessions
   directly, without seedeep.

--- a/apps/server/npm/README.md
+++ b/apps/server/npm/README.md
@@ -2,18 +2,17 @@
 
 ### *See deep into what Claude Code is doing.*
 
-`seedeep` makes visible what a Claude Code session does not show you: **how the
-context window fills, live, during a turn** — and what the subagents are doing
-while it happens.
+`seedeep` shows what a Claude Code session keeps to itself: how the context window
+fills, live, during a turn, and what the subagents are doing while it happens.
 It reads the session logs Claude Code already writes on your machine. No session
-content is sent anywhere and nothing is written back — the only outbound request it
+content is sent anywhere and nothing is written back. The only outbound request it
 makes on its own is the update check against npm, which `seedeep update --offline`
 skips.
 
 ![The context window filling live while six subagents run on three models](https://raw.githubusercontent.com/duqaXxX/seedeep/v{{VERSION}}/docs/assets/hero.gif)
 
-*3% → 26% of the window, six subagents on three different models, 2.9M tokens
-billed — 2.5M of them the same context read again.*
+*One turn, from 3% to 26% of the window: six subagents on three different models,
+2.9M tokens billed, 2.5M of them the same context read again.*
 
 ```sh
 npm i -g seedeep                       # or: bun install -g seedeep --trust
@@ -31,9 +30,8 @@ seedeep --port 9000   # a different port (default 44842)
 seedeep --no-open     # do not open the browser
 ```
 
-**Node is needed to install this, never to run it.** The package carries a compiled
-executable with its own runtime inside — `npm` places it on your PATH and steps
-out of the way.
+Node is needed to install this, never to run it. The package carries a compiled
+executable with its own runtime inside, and `npm` places it on your PATH.
 
 Full documentation, the optional menu-bar tray, and the plain downloads for a
 machine without Node: **https://github.com/duqaXxX/seedeep**

--- a/apps/server/tests/docs.test.ts
+++ b/apps/server/tests/docs.test.ts
@@ -130,3 +130,39 @@ test('every doc under docs/ is linked from somewhere', () => {
     .filter((f) => !corpus.includes(f.slice('docs/'.length)) || corpus.split(f.slice('docs/'.length)).length < 3);
   assert.deepEqual(orphans, [], 'these docs are reachable from nothing but themselves');
 });
+
+/**
+ * Prose outside a heading, a fenced block or a backtick span, with every inline code span removed.
+ * The three exemptions are not stylistic: a heading's em dash is part of an anchor other docs link
+ * to, and a backtick span quotes a literal seedeep prints (`Waiting for your approval — Bash`),
+ * which the doc would be lying about if it rewrote it.
+ */
+function proseLines(markdown: string): string[] {
+  const out: string[] = [];
+  let fenced = false;
+  for (const raw of markdown.split('\n')) {
+    const line = raw.trimStart();
+    if (line.startsWith('```')) {
+      fenced = !fenced;
+      out.push('');
+      continue;
+    }
+    out.push(fenced || line.startsWith('#') ? '' : raw.replace(/`[^`]*`/g, ''));
+  }
+  return out;
+}
+
+// The one tell of AI-written prose a regex can settle. A stranger's only public comment on seedeep
+// was that its README read as generated, and the corpus held 1094 em dashes at the time. The rest
+// of the register — paragraphs closing on an aphorism, "not X but Y", bold lead-ins — needs
+// judgement and lives in the project's writing rules; this catches the one that can be counted.
+test('no em dash in a public doc’s prose', () => {
+  const hits: string[] = [];
+  for (const f of trackedMarkdown()) {
+    if (isChangelog(f)) continue; // a released entry is a historical record, never rewritten
+    proseLines(readFileSync(join(ROOT, f), 'utf8')).forEach((line, i) => {
+      if (line.includes('—')) hits.push(`${f}:${i + 1} → ${line.trim().slice(0, 90)}`);
+    });
+  }
+  assert.deepEqual(hits, [], 'use : , . ; or parentheses — a literal seedeep prints goes in backticks');
+});

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,27 @@ Everything released before `0.20.0` — including the pre-publication developmen
 
 ## Unreleased
 
+### Changed
+
+- Every public document rewritten to read as a reference rather than as a pitch. The prose carried
+  the register readers associate with generated text, and the count that made it measurable was
+  1094 em dashes across 16 files. Removed, along with 20 paragraphs closing on an aphorism, 436
+  bold spans wrapping a whole sentence, and 29 of the 54 "deliberately / on purpose" that defended
+  a choice the following clause already explained. No figure, table or admission was touched: the
+  pass took out voice, not evidence, and the corpus lost 11% of its words.
+- `README.md` leads with the install command, which sat at line 149 of 257 and is now in the first
+  screen.
+- The explanation of why the installed tray cannot read `SEEDEEP_HOME` lived in both
+  `CONTRIBUTING.md` and `configuration.md`. It now lives in `configuration.md`, which owns the
+  variable, and `CONTRIBUTING.md` links to it.
+
+### Added
+
+- `apps/server/tests/docs.test.ts` gains `no em dash in a public doc's prose`, blocking, over every
+  tracked markdown but the changelogs. It reads the file rather than the diff, which is what lets it
+  exempt headings, fenced blocks and backtick spans: an em dash inside backticks is a literal
+  seedeep prints (`Waiting for your approval — Bash`) and rewriting it would make the doc false.
+
 ## 0.31.1 (2026-08-21)
 
 ### Changed

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,8 +1,8 @@
 # HTTP API
 
-The local server exposes 21 routes: the static page and 20 under `/api/`, across 19 paths — only
-`/api/config` answers to two methods. This document is the
-reference — every route, its parameters, its response and its failure modes. The reasoning behind
+The local server exposes 21 routes: the static page and 20 under `/api/`, across 19 paths, since
+only `/api/config` answers to two methods. This document is the
+reference for every route, its parameters, its response and its failure modes. The reasoning behind
 the design (why the roster is split, why the digest exists, how the watcher feeds any of it) is in
 [architecture.md](architecture.md).
 
@@ -21,19 +21,19 @@ seedeep code and reads only these.
 The other sixteen are consumed by the browser GUI shipped in the same executable. They are
 documented here because they are reachable and useful, **not** because they are frozen: treat them
 as internal to the GUI and expect them to change with it. There is no `/v1` prefix, no version
-negotiation and no deprecation window — the server's version is in `GET /api/config`, and every
+negotiation and no deprecation window. The server's version is in `GET /api/config`, and every
 deliverable ships from one tag.
 
 ## Base URL
 
 `http://127.0.0.1:44842` by default. Naming any other host makes HTTPS mandatory and a token
-required — see [install.md → remote access](install.md#remote-access).
+required, as described in [install.md → remote access](install.md#remote-access).
 
 ## Authentication
 
 On loopback there is no authentication: there is no network to authenticate against.
 
-Beyond loopback, **every `/api/*` route except `GET /api/config` requires the token**, either as a
+Beyond loopback, every `/api/*` route except `GET /api/config` requires the token, either as a
 header or as a query parameter:
 
 ```http
@@ -67,21 +67,21 @@ The API answers with **two different error shapes**, and which one you get depen
 
 | Status | Body | When |
 |---|---|---|
-| `400` | JSON — `{"error":"invalid JSON"}`, `{"error":"port must be a number"}`, `{"error":"host must be a string"}`, and the host/TLS validation messages | a malformed `POST /api/config` body |
-| `401` | JSON — `{"error":"unauthorized"}` | no valid token, beyond loopback |
-| `404` | **plain text** — `unknown session`, `unknown or ended session`, `no output for that tool`, `no such API call`, `no prompt found`, `not found` | the named session, call or asset does not exist |
-| `405` | **plain text** — `method not allowed` | any method other than `GET`, outside the two documented `POST`s |
-| `415` | JSON — `{"error":"Content-Type must be application/json"}` | `POST /api/config` without the JSON content type |
+| `400` | JSON: `{"error":"invalid JSON"}`, `{"error":"port must be a number"}`, `{"error":"host must be a string"}`, and the host/TLS validation messages | a malformed `POST /api/config` body |
+| `401` | JSON: `{"error":"unauthorized"}` | no valid token, beyond loopback |
+| `404` | **plain text**: `unknown session`, `unknown or ended session`, `no output for that tool`, `no such API call`, `no prompt found`, `not found` | the named session, call or asset does not exist |
+| `405` | **plain text**: `method not allowed` | any method other than `GET`, outside the two documented `POST`s |
+| `415` | JSON: `{"error":"Content-Type must be application/json"}` | `POST /api/config` without the JSON content type |
 
 A missing required query parameter is not a `400`: the route looks up the empty string, finds
-nothing and answers `404`. `GET /api/search` is the exception — an absent `q` is an empty query,
-not a bad request, and it answers `200` with no rows.
+nothing and answers `404`. `GET /api/search` is the exception, where an absent `q` is an empty
+query rather than a bad request, and it answers `200` with no rows.
 
 ## Caching
 
 Every JSON response and every static asset goes through one path:
 
-- `cache-control: no-cache` — revalidate every time; it does **not** mean "do not store".
+- `cache-control: no-cache`, which means revalidate every time and does **not** mean "do not store".
 - A strong `etag`. A matching `if-none-match` gets `304` with no body.
 - Bodies of **1400 bytes or more** are gzipped when the request accepts it. A compressed body's
   ETag carries a `-gz` suffix, so a strong validator is never shared between two different sets of
@@ -96,20 +96,20 @@ session. A browser-based client has to be served by seedeep itself.
 
 | Method | Path | Required parameters | Answers |
 |---|---|---|---|
-| `GET` | `/` | — | the GUI page (any other path serves its asset, else `404`) |
-| `GET` | `/api/config` | — | redacted config + server state; **the only route needing no token** |
+| `GET` | `/` | none | the GUI page (any other path serves its asset, else `404`) |
+| `GET` | `/api/config` | none | redacted config + server state; **the only route needing no token** |
 | `POST` | `/api/config` | JSON body | writes the config file, answers as `GET` does |
-| `POST` | `/api/restart` | — | `{"ok":true}`, then hands the port to a successor |
-| `GET` | `/api/update` | — | which version is current, and how this install updates |
-| `GET` | `/api/sessions` | — | `CatalogueRecord[]` — the roster's stable half |
-| `GET` | `/api/live` | — | `LivePayload` — the running sessions |
-| `GET` | `/api/digest` | — (`sessionId` optional) | `DigestEntry[]`, or one `DigestEntry` |
-| `GET` | `/api/session-stats` | — | turns and tokens per session |
-| `GET` | `/api/baseline` | — | `Baseline` — the user's per-turn token baseline |
-| `GET` | `/api/retro` | — | `Retrospective` — the corpus retrospective |
-| `GET` | `/api/compare` | — | `Comparison` — session weight by time window |
-| `GET` | `/api/search` | — (`q` carries the query) | `SearchResponse` |
-| `GET` | `/api/stream` | — | SSE, every session, live |
+| `POST` | `/api/restart` | none | `{"ok":true}`, then hands the port to a successor |
+| `GET` | `/api/update` | none | which version is current, and how this install updates |
+| `GET` | `/api/sessions` | none | `CatalogueRecord[]`, the roster's stable half |
+| `GET` | `/api/live` | none | `LivePayload`, the running sessions |
+| `GET` | `/api/digest` | none (`sessionId` optional) | `DigestEntry[]`, or one `DigestEntry` |
+| `GET` | `/api/session-stats` | none | turns and tokens per session |
+| `GET` | `/api/baseline` | none | `Baseline`, the user's per-turn token baseline |
+| `GET` | `/api/retro` | none | `Retrospective`, the corpus retrospective |
+| `GET` | `/api/compare` | none | `Comparison`, session weight by time window |
+| `GET` | `/api/search` | none (`q` carries the query) | `SearchResponse` |
+| `GET` | `/api/stream` | none | SSE, every session, live |
 | `GET` | `/api/replay` | `sessionId` | SSE, one session's history |
 | `GET` | `/api/tool-output` | `sessionId`, `toolUseId` | `ToolOutput` |
 | `GET` | `/api/call-io` | `sessionId`, `callId` | `CallIO` |
@@ -133,7 +133,7 @@ Returns `CatalogueRecord[]` (`core/roster.ts`).
 
 ### `GET /api/live`
 
-The handful of sessions actually running, in full. This is the only thing a client polls — about
+The handful of sessions actually running, in full. This is the only thing a client polls, about
 1 KB against the catalogue's hundreds.
 
 Returns `LivePayload` (`core/roster.ts`): `{ total, sessions, pidVisible }`.
@@ -146,7 +146,7 @@ would have produced whole.
 Turn count and token total per session, from the aggregate cache.
 
 Returns `Record<sessionId, { turns: number; totalTokens: number }>`. A session the cache has not
-folded yet is simply absent — the object is not padded with zeroes.
+folded yet is simply absent, and the object is not padded with zeroes.
 
 ---
 
@@ -154,7 +154,7 @@ folded yet is simply absent — the object is not padded with zeroes.
 
 ### `GET /api/digest`
 
-**The endpoint for a client that does not own the reducer.** The server has already reduced: an
+The endpoint for a client that does not own the reducer. The server has already reduced: an
 entry is derived state, not events to fold.
 
 | Parameter | Required | Meaning |
@@ -163,7 +163,7 @@ entry is derived state, not events to fold.
 
 - Without it: `DigestEntry[]`, one per live session.
 - With it: a single `DigestEntry`, or **`404 unknown or ended session`**. A session that ends leaves
-  immediately — there is no tombstone entry.
+  immediately, and there is no tombstone entry.
 
 Returns `DigestEntry` (`server/digest.ts`): the project and subject, the context block, the model
 and effort, the turn's state (`done` | `interrupted` | `live`) and what it is doing now, the
@@ -184,26 +184,26 @@ One session's history as SSE, then `replay-end`.
 | Parameter | Required | Meaning |
 |---|---|---|
 | `sessionId` | yes | `404 unknown session` if not in the roster |
-| `from` | no | resume marks — deliver only what a client has not already seen |
+| `from` | no | resume marks, so as to deliver only what a client has not already seen |
 
 ---
 
 ## Reading back one thing
 
-These four take a session id and one more identifier. **The file path always comes from the roster,
-never from the query**: a caller can only name a session seedeep already discovered, so no path
+These four take a session id and one more identifier. The file path always comes from the roster,
+never from the query: a caller can only name a session seedeep already discovered, so no path
 outside the corpus is reachable.
 
 ### `GET /api/tool-output`
 
-`sessionId`, `toolUseId` — both required.
+`sessionId` and `toolUseId`, both required.
 
 Returns `ToolOutput` (`server/tool-output.ts`): `{ toolUseId, text, len, truncated }`, the text
 capped at 20 000 characters. `404 no output for that tool` when the id names nothing.
 
 ### `GET /api/call-io`
 
-`sessionId`, `callId` — both required.
+`sessionId` and `callId`, both required.
 
 Returns `CallIO` (`server/call-io.ts`): the call's input and output, whether the output carried
 tools, its narration, its length, and the model, usage and effort that call ran on. Same 20 000
@@ -211,11 +211,11 @@ cap. `404 no such API call`.
 
 ### `GET /api/agent-prompt`
 
-`sessionId`, `agentId` — both required.
+`sessionId` and `agentId`, both required.
 
 Returns `{ text, truncated }`, capped at **1000** characters.
 
-**It serves workflow members only.** The prompt is read from
+It serves workflow members only. The prompt is read from
 `<sessionDir>/subagents/workflows/<runId>/agent-<agentId>.jsonl`; an ordinary subagent has no such
 file and gets `404 no prompt found`.
 
@@ -238,13 +238,13 @@ Each takes `sessionId`, each answers `404 unknown session`.
 ### `GET /api/retro`, `GET /api/baseline`
 
 `Retrospective` and `Baseline` (`core/types.ts`), both folded from the aggregate cache. `/api/baseline`
-is exactly the `baseline` that rides along inside `/api/retro` — the small route exists so a client
+is exactly the `baseline` that rides along inside `/api/retro`; the small route exists so a client
 needing only the baseline does not fetch the retrospective.
 
 ### `GET /api/compare`
 
 `Comparison` (`core/types.ts`): session weight per time window, where weight is a token count
-weighted by the kind of token and the model that spent it — never a cost in currency.
+weighted by the kind of token and the model that spent it, never a cost in currency.
 
 ### `GET /api/search`
 
@@ -253,7 +253,7 @@ weighted by the kind of token and the model that spent it — never a cost in cu
 | `q` | no, in effect | the words; every word narrows. Absent or empty answers `200` with no rows rather than an error |
 
 Returns `SearchResponse` (`core/types.ts`): `{ terms, rows, ms }`. An empty or absent `q` is not an
-error — it answers `{"terms":[],"rows":[],"ms":0}`.
+error, and answers `{"terms":[],"rows":[],"ms":0}`.
 
 What is indexed and how rows are ordered: [search.md](search.md).
 
@@ -274,7 +274,7 @@ Returns the configuration with every credential redacted, plus:
 | `dev` | present only when authorised: this server runs from source |
 | `auth.token` | always `***` |
 | `tls.fingerprint` | the SHA-256 of the served leaf certificate; `cert` and `key` paths are not returned |
-| `notifications.webhook.url` | `""` when unset, otherwise redacted — the URL is a credential, not an address |
+| `notifications.webhook.url` | `""` when unset, otherwise redacted, since the URL is a credential rather than an address |
 | `notifications.webhook.headers` | keys only; every value redacted |
 | `restart_pending` | a bound-at-startup setting was changed and needs a restart to take effect |
 | `save_pending` | the file on disk differs from what this process is running |
@@ -296,15 +296,15 @@ restart; the bound-at-startup settings are the ones `restart_pending` names.
 
 ### `GET /api/update`
 
-What npm says is current, from a cache that refreshes once an hour. It is how a REMOTE client — the
-tray, or the portal in a browser — learns the version of the server it is pointed at. The local CLI
+What npm says is current, from a cache that refreshes once an hour. It is how a REMOTE client, the
+tray or the portal in a browser, learns the version of the server it is pointed at. The local CLI
 does not use it: `seedeep update` reads the same cache directly, and forces a fetch.
 
 Returns `UpdateStatus` (`server/update-check.ts`) plus:
 
 | Field | Meaning |
 |---|---|
-| `current` | **this server's** version — a client on another machine compares `latest` against its own |
+| `current` | **this server's** version; a client on another machine compares `latest` against its own |
 | `channel` | how this server was installed (`npm`, `download`, `checkout`, …) |
 | `command` | what to tell the user to run, or `null` when replacing a file by hand is the answer |
 
@@ -337,7 +337,7 @@ There is no `Last-Event-ID` handling and no backlog: a client that reconnects re
 ### Deduplicating live against replay
 
 Every file-tailed event carries a **`seq`**: a per-file line number, a POSITION rather than a
-counter. One `seq` per source line — a line yielding several events (`usage` + `attribution` +
+counter. One `seq` per source line, so a line yielding several events (`usage` + `attribution` +
 `tool-start`) shares one.
 
 A client that opens a replay while the live stream is running dedups **per `(sessionId, agentId)`**,
@@ -347,14 +347,14 @@ that position is three numbers, not one:
 | Mark | Meaning | Test |
 |---|---|---|
 | `covered` | the last line a replay delivered ENTIRE | a live event at or below it is a re-delivery (`seq <=`) |
-| `liveMax` | the live frontier — a line possibly delivered only in PART | live drops only what is strictly earlier (`seq <`), so every event of the newest line passes |
-| `liveSeen` | how many events of that frontier line arrived | — |
+| `liveMax` | the live frontier, a line possibly delivered only in PART | live drops only what is strictly earlier (`seq <`), so every event of the newest line passes |
+| `liveSeen` | how many events of that frontier line arrived | |
 
 A replay in flight is measured against a **snapshot** of that position taken when it opened.
 Measuring against a mark the same replay is advancing drops every event of a line after its first.
 
-Events with `seq < 0` are out of band — a `subagent-meta` read from a sidecar has no line position —
-and are exempt from the dedup; the reducer folds them idempotently.
+Events with `seq < 0` are out of band, since a `subagent-meta` read from a sidecar has no line
+position, and are exempt from the dedup; the reducer folds them idempotently.
 
 When the tailer re-reads a file from offset 0 (it shrank), `seq` restarts with it. That is a
 re-delivery from 0, which the rules above already absorb.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,7 +2,7 @@
 
 seedeep makes the invisible inside a Claude Code session visible: in real time
 during a turn, how the **context window** fills and what the **subagents** are
-doing — assembled live from the local session logs.
+doing, assembled live from the local session logs.
 
 The design principle is **read-only**: seedeep only reads the session files Claude
 Code already writes. It never writes, proxies, or intercepts anything Claude Code owns.
@@ -15,7 +15,7 @@ retrospective and the personal baseline fast.
 
 ## Repository layout
 
-**Every deliverable is an app under `apps/`, and none of them sits at the root** — so a
+Every deliverable is an app under `apps/`, and none of them sits at the root, so a
 second one arrives as a peer of the first instead of as an appendage to it:
 
 ```text
@@ -25,29 +25,29 @@ seedeep/
 │   │   ├── src/         three layers, one folder each: core/ server/ client/
 │   │   ├── public/      the GUI's files, embedded in the binary; `lib/app.js` is BUILT
 │   │   ├── tests/       the suite (`bun run test`)
-│   │   ├── probe/       the schema probe — never shipped, runs out of `bun test`
+│   │   ├── probe/       the schema probe: never shipped, runs out of `bun test`
 │   │   ├── data/        checked-in reference data (known fields, context windows)
 │   │   ├── npm/         the npm wrapper's own files: postinstall, placeholder, its README
 │   │   └── scripts/     one-off maintenance scripts
-│   └── tray/            the menu-bar client — see `docs/tray.md`
+│   └── tray/            the menu-bar client, see `docs/tray.md`
 │       ├── ui/          the popover's HTML/CSS/TS, bundled by Bun
 │       └── src-tauri/   the Rust shell: tray icon, window, notifications
-├── docs/                this reference — it documents the PRODUCT, not one app
+├── docs/                this reference: it documents the PRODUCT, not one app
 ├── .github/
 │   ├── workflows/       ci.yml on every push and PR; release.yml on a tag (`docs/tray.md`)
-│   └── scripts/         checks CI runs — the sensitive-data scan, and its tests
+│   └── scripts/         checks CI runs: the sensitive-data scan, and its tests
 └── package.json         one manifest, one version, scripts for every app
 ```
 
-**`src/` is three layers and each one is a folder**, so the rule between them can be
+`src/` is three layers and each one is a folder, so the rule between them can be
 stated about directories rather than recited as a list of filenames:
 
-- **`core/`** — pure derivation: no `node:` builtin, nothing from `server/` or `client/`.
+- **`core/`:** pure derivation, with no `node:` builtin and nothing from `server/` or `client/`.
   It is the half of seedeep that does not care where it runs, which is why both other
   layers may import it and why it is the easiest part to test.
-- **`server/`** — everything that touches the machine: the watcher, discovery, the tailer,
+- **`server/`:** everything that touches the machine: the watcher, discovery, the tailer,
   the HTTP/SSE server, TLS and config, the schema guard's command-line entry points.
-- **`client/`** — the browser bundle's own modules, the only ones allowed to touch the DOM.
+- **`client/`:** the browser bundle's own modules, the only ones allowed to touch the DOM.
 
 The split is by what a module *is*, not by who happens to call it: `core/span-store.ts` is
 reached only from the client today and stays in `core/` because it is pure, while
@@ -55,27 +55,27 @@ reached only from the client today and stays in `core/` because it is pure, whil
 hold the line (`apps/server/tests/layering.test.ts`), both walking the import graph rather
 than the directory listing.
 
-`docs/` stays at the root deliberately: `architecture.md`, `api.md`, `configuration.md`,
+`docs/` stays at the root: `architecture.md`, `api.md`, `configuration.md`,
 `features.md`, `trace.md`, `search.md`, `session-output.md`, `claude-code-upgrades.md`,
 `install.md` and `tray.md` describe the product, and a second app would otherwise bury half the
 reference inside its own directory.
 
-**The tray shares no code with the server** — it reaches it over HTTP only, through four
+**The tray shares no code with the server**: it reaches it over HTTP only, through four
 endpoints: `/api/digest`, `/api/stream`, `/api/config` and `/api/update` (`docs/tray.md`).
 That is why it lives beside `apps/server/` rather than
 inside it, and why a change to `core/` can never break it without changing an endpoint.
 
 There is **one version for the whole repo**, so a tag ships every deliverable together
-and two of them built from the same tag are compatible by construction — no
+and two of them built from the same tag are compatible by construction, with no
 compatibility matrix. It is not a convention anybody has to remember: the root
 `package.json` holds the only version number, and `apps/tray/src-tauri/tauri.conf.json`
 names that file as its `version` instead of carrying one of its own. Pushing a `v*` tag
 is what turns that number into downloads: the tray's three installers and the server's six
-executables, out of the same workflow and the same commit — see
+executables, out of the same workflow and the same commit; see
 [Shipping the server](#shipping-the-server).
 
-**CI runs on every pull request and on every push to `main`** — three jobs, `scan`,
-`check` and `tray` (`.github/workflows/ci.yml`) — because a rule nothing enforces is a
+CI runs on every pull request and on every push to `main`: three jobs, `scan`,
+`check` and `tray` (`.github/workflows/ci.yml`), because a rule nothing enforces is a
 rule that quietly stops being true, and a local run that never invokes the type-checker is
 not evidence it is green. Between them they enforce:
 
@@ -83,11 +83,11 @@ not evidence it is green. Between them they enforce:
 - **Biome** (`bun run lint`): format and lint check across all TypeScript sources. A PR
   that passes tests but has formatting violations is blocked here before review;
 - a rebuild of `apps/server/public/lib/app.js`, which fails if the committed bundle no
-  longer matches its source. That artifact is committed on purpose — a clone runs the GUI
-  without a build step — and this is what keeps the two in step;
+  longer matches its source. That artifact is committed so a clone runs the GUI
+  without a build step, and this is what keeps the two in step;
 - the **layering** (`apps/server/tests/layering.test.ts`): nothing reachable from
   `apps/server/src/client/app.ts` may import a `node:` builtin, and nothing in `core/` may
-  import one either — nor anything from `server/` or `client/`. Nothing else stops a
+  import one either, nor anything from `server/` or `client/`. Nothing else stops a
   client file from importing the watcher: `bun build --target browser` does not fail on a
   node builtin, it substitutes a polyfill that throws, so the mistake reaches the browser
   as a blank page. Both checks follow the import graph, so an indirect import three hops
@@ -96,9 +96,9 @@ not evidence it is green. Between them they enforce:
   `bun run build:tray-ui`). `bun run test` does not reach it, so this job is the whole of
   CI's coverage for a change under `apps/tray/src-tauri/`;
 - the **sensitive-data scan** (`.github/scripts/scan-sensitive-diff.sh`) over the added
-  lines — real home paths, personal addresses, secret markers, private tracker
+  lines: real home paths, personal addresses, secret markers, private tracker
   references. It blocks rather than warns: this repo is public, and a leak committed once
-  stays in the history forever. A fork inherits it, which is the whole point — a local
+  stays in the history forever. A fork inherits it, which is the whole point: a local
   git hook cannot be inherited, since `.git/` is not tracked.
 
 Every command runs from the repo root (`bun run test`, `bun run start`,
@@ -110,24 +110,24 @@ reach it as imports (`assets.ts`), not as a path it resolves.
 
 ### Shipping the server
 
-The server is a **standalone executable, one per platform**, with the Bun runtime inside it —
+The server is a **standalone executable, one per platform**, with the Bun runtime inside it,
 `bun run build:server:all` (`apps/server/scripts/build-binaries.ts`) writes all six into `dist/`,
 cross-compiled from whichever machine runs it. Nothing has to be installed to run one, which is why
 the GUI is embedded in the binary rather than served from a folder beside it.
 
-**Every asset is named after the app it is** — `seedeep-server_<version>_<platform>` beside the
+Every asset is named after the app it is: `seedeep-server_<version>_<platform>` beside the
 tray's `seedeep-tray_<version>_…`. A release page carries both, and two macOS files sharing a prefix
 would say nothing about which one reads your sessions.
 
 Three properties of the build are decisions, not detail:
 
-- **The compile rebuilds the client bundle itself.** `assets.ts` embeds `public/lib/app.js` by path,
-  so a compile that skipped the rebuild would ship a GUI from an older commit — and nothing
+- The compile rebuilds the client bundle itself. `assets.ts` embeds `public/lib/app.js` by path,
+  so a compile that skipped the rebuild would ship a GUI from an older commit, and nothing
   downstream could tell.
 - **Nothing is left external.** A dependency doing a COMPUTED `require` cannot be bundled, and Bun
   leaves it to runtime with the build machine's path frozen into it: a binary that works everywhere
   it was built and nowhere else.
-- **A binary may not contain the path of the machine that built it.** `assertNoBuildPath` fails the
+- A binary may not contain the path of the machine that built it. `assertNoBuildPath` fails the
   build on any occurrence, because that is the one class of defect a test on the build machine
   cannot see.
 
@@ -135,14 +135,14 @@ The Linux binaries are dynamically linked against glibc, so a musl distribution 
 target.
 
 Every executable is started, run and driven through its whole lifecycle on a machine that did not
-build it before anything publishes — how that is arranged is in
+build it before anything publishes; how that is arranged is in
 [`CONTRIBUTING.md`](../CONTRIBUTING.md#how-a-release-is-built).
 
 #### The npm channel
 
 The same six executables also ship as npm packages, which is what `npm i -g seedeep` installs.
-**Node is needed to install them, never to run one**: the package carries the compiled binary, and
-`bun run build:npm` (`apps/server/scripts/build-npm.ts`) only arranges files — it never compiles, so
+Node is needed to install them, never to run one: the package carries the compiled binary, and
+`bun run build:npm` (`apps/server/scripts/build-npm.ts`) only arranges files and never compiles, so
 `bun run build:server:all` has to have run first, and in that order, since the compiler wipes
 `dist/`.
 
@@ -150,55 +150,55 @@ The shape is a wrapper package whose `bin` points at a file inside itself, plus 
 `optionalDependency` per platform carrying the real executable. npm resolves those against each
 package's `os`/`cpu`, so a machine downloads one binary rather than six, and the wrapper's
 postinstall (`apps/server/npm/install.cjs`) puts that binary over the placeholder the `bin` field
-already names. Nothing is fetched by the script itself, and no Node process survives the install —
+already names. Nothing is fetched by the script itself, and no Node process survives the install,
 `seedeep` on PATH *is* the server.
 
 Four decisions hold it up:
 
-- **The channel exists because of the quarantine flag.** macOS sets `com.apple.quarantine` in the
+- The channel exists because of the quarantine flag. macOS sets `com.apple.quarantine` in the
   program that downloads a file, not in the file; installed through npm the binary never acquires
   it, so the first-launch refusal a plain download has to explain never happens here.
-- **The placeholder is named `seedeep.exe` on every platform and carries no shebang.** npm generates
+- The placeholder is named `seedeep.exe` on every platform and carries no shebang. npm generates
   the Windows `.cmd` shim from that file *before* the postinstall replaces it, and `cmd-shim` only
-  emits a direct exec of the target when it finds no shebang to honour — a `#!` line would make
+  emits a direct exec of the target when it finds no shebang to honour, and a `#!` line would make
   every Windows install hand a native executable to an interpreter.
-- **An unsupported platform is refused by npm itself.** The wrapper declares the `os` and `cpu` it
+- An unsupported platform is refused by npm itself. The wrapper declares the `os` and `cpu` it
   was built for, and npm reads them as a cross product: anything outside fails with `EBADPLATFORM`,
   naming both what was wanted and what the machine is. Every combination that cross product admits
   is a package that exists, which a test asserts; the postinstall still refuses a pair it finds no
   package for, because the two lists are independent and adding to one alone reopens the hole.
-- **The wrapper pins its binaries to its own exact version.** One tag publishes both halves; a range
+- The wrapper pins its binaries to its own exact version. One tag publishes both halves; a range
   would let npm pair a wrapper with an older executable.
 
 The bare downloads stay on the release page, and are not a fallback: they are the channel for a
-machine with no Node at all — a headless box reached over SSH — and requiring a runtime before
+machine with no Node at all (a headless box reached over SSH), and requiring a runtime before
 seedeep is the exact failure the distribution invariant exists to prevent. Which command installs
 which, and the gesture each platform asks for, is in [`install.md`](install.md).
 
 ## Data source
 
 Claude Code writes one JSON-lines file per session, appended once per **content
-block** — not once per turn, and not once per API call either: one response
+block**, not once per turn and not once per API call either: one response
 becomes several lines (`thinking`, then `text`, then each `tool_use`), all
 sharing a `requestId`. Each line carries an ISO-timestamped `message.usage`
 block with `input_tokens`, `output_tokens`, `cache_creation_input_tokens`, and
 `cache_read_input_tokens`; the usage is the CALL's, so it is repeated verbatim on
-every line of that call (measured: identical on 53 of 53 multi-line requests) —
+every line of that call (measured: identical on 53 of 53 multi-line requests),
 summing it per line would multiply the cost, which is what `newCall` guards
 against.
 
-A line is appended when its block CLOSES, so the console — which draws a block as
-it streams — always leads the file. Measured on a live session (267 lines): the
+A line is appended when its block CLOSES, so the console, which draws a block as
+it streams, always leads the file. Measured on a live session (267 lines): the
 gap between a line's own timestamp and the instant it becomes readable is p50
 0.16s, p90 1.29s, p99 11.46s; the tail is `thinking`, whose whole streaming time
 elapses before the line exists. For the blocks the live surfaces actually read it
-is much tighter — `tool_use` is p50 0.23s / p90 0.29s. Tailing is therefore a
+is much tighter: `tool_use` is p50 0.23s / p90 0.29s. Tailing is therefore a
 sub-second event stream for tool activity, and no faster than a block's own
 duration for anything else.
 
 Sessions live under one local root:
 
-- **Claude Code (CLI):** `~/.claude/projects/<slug>/<sessionId>.jsonl` — or under `CLAUDE_CONFIG_DIR`
+- **Claude Code (CLI):** `~/.claude/projects/<slug>/<sessionId>.jsonl`, or under `CLAUDE_CONFIG_DIR`
   when it is set, which moves Claude Code's whole directory and therefore the transcripts too
   (`claudeDir` in `roots.ts`). `<slug>` is the session's working directory with its separators
   turned into dashes: verified against all 16 project directories on this machine, each compared
@@ -208,7 +208,7 @@ Claude Chat and Cowork are deliberately NOT observed: the chat writes no
 per-API-call log to disk (only editor drafts and UI state), and the current
 Cowork runs the session remotely, leaving nothing local to read.
 Subagents write their own separate files under a `subagents/` directory beside
-the parent session. A **Workflow run** nests its own fleet one level deeper —
+the parent session. A **Workflow run** nests its own fleet one level deeper,
 `subagents/workflows/wf_<runId>/`, same file names, plus a `journal.jsonl` recording each
 of its subagents starting and returning. A run is shown as ONE aggregate row (a real
 `deep-research` run spawns ~100 subagents), never expanded.
@@ -216,7 +216,7 @@ of its subagents starting and returning. A run is shown as ONE aggregate row (a 
 ## The core engine
 
 The core is an in-process, runtime-agnostic TypeScript library (standard
-`node:*` and Web APIs only — no runtime lock-in). It is organized as a layered
+`node:*` and Web APIs only, so no runtime lock-in). It is organized as a layered
 pipeline where each unit has a single responsibility and a defined interface:
 
 ```text
@@ -229,10 +229,10 @@ discovery ──▶ watcher ──▶ (EventEmitter: normalized events, tagged b
    └── roots    (root paths, exclusions, active-window)
 ```
 
-The pipeline has two pure halves and the split matters: **the left half turns bytes
-into events, the right half turns events into meaning.** Both are runtime-agnostic,
-and neither knows who is asking. `apps/server/src/core/` holds the second half — the reducer and
-everything derived from its snapshot — so it can run wherever the events arrive: in
+The pipeline has two pure halves and the split matters: the left half turns bytes
+into events, the right half turns events into meaning. Both are runtime-agnostic,
+and neither knows who is asking. `apps/server/src/core/` holds the second half, the reducer and
+everything derived from its snapshot, so it can run wherever the events arrive: in
 the browser, which folds a live stream, and in the server process, which folds a file
 per corpus entry to build `/api/retro` and `/api/baseline`. Two callers, one
 derivation, no second source of truth.
@@ -252,7 +252,7 @@ interface SessionRecord {
   status: 'busy' | 'idle' | 'waiting' | 'shell' | null;  // from that file; see below
   waitingFor: string | null; // while 'waiting': what it is blocked on, verbatim from CC
   waitingSince: number | null; // and when it stopped there (CC's statusUpdatedAt)
-  subject: string | null;    // first real prompt, anonymized — the readable picker/tab label
+  subject: string | null;    // first real prompt, anonymized: the readable picker/tab label
   entrypoint: string | null; // 'cli' (interactive) vs 'sdk-cli'/'sdk-py' (headless)
   root: 'cli';
   path: string;
@@ -263,51 +263,51 @@ Files under `subagents/` and bookkeeping files are excluded from the top-level
 session list.
 
 **One definition of "live".** `isLive(record)` (in `types.ts`, beside the record) answers it
-for every consumer: `isOpen ?? isActive` — the running process decides, and the mtime window
+for every consumer: `isOpen ?? isActive`, so the running process decides and the mtime window
 only gets a vote when there is no process signal to read (`isOpen: null`, i.e.
 `~/.claude/sessions/` does not exist; it is an undocumented Claude Code internal that a
 release may drop). The watcher tails a session while it is live, and the picker files it
-under **Live**, from that same call — split in two, they disagree exactly where it hurts: a
+under **Live**, from that same call. Split in two, they disagree exactly where it hurts: a
 session waiting on a **background subagent** writes nothing to its own jsonl, so `isActive`
-lapses while the process is alive and the child files are still growing — gating on `isActive`
+lapses while the process is alive and the child files are still growing, so gating on `isActive`
 alone drops such a session, children included, until the main agent speaks again, freezing the
 live feed for the whole subagent run. The other side of the same rule: a session whose process
 has exited is NOT live, however recently its file was written.
 
-**One definition of "working", and it is not `status === 'busy'`.** `isWorking(record)` (beside
-`isLive`, same reason) reads `busy` OR **`shell`** — Claude Code's own word for a turn that is over
+One definition of "working", and it is not `status === 'busy'`. `isWorking(record)` (beside
+`isLive`, same reason) reads `busy` OR **`shell`**, Claude Code's own word for a turn that is over
 while a command it launched in the background is still running. A session with no status makes no
 claim, so dropping an unrecognised word to `null` reads as idle on every surface and jumps back to
-working when the command ends. The value is therefore carried raw and interpreted at the edges — the
+working when the command ends. The value is therefore carried raw and interpreted at the edges: the
 browser's tab badge, the tray's band, and the tray's Rust icon, each pinned to this function by a
 test. Everything still unknown becomes `null`: the vocabulary is Claude Code's, and it has
 already grown once.
 
-**One reading of `isOpen` is not proof it closed.** Claude Code REWRITES the PID file on every
-status change, and `listOpenSessions` skips a file it catches mid-rewrite — so a running
+One reading of `isOpen` is not proof it closed. Claude Code REWRITES the PID file on every
+status change, and `listOpenSessions` skips a file it catches mid-rewrite, so a running
 session can be missing from exactly one poll. Anything COSTLY must therefore wait for a
 second reading: `known` in `sessions.ts` is never pruned on a blink, and ending a tab (it
 freezes the graph into its ended presentation) goes through
 `end-guard.ts`, which re-reads the roster a full poll later and commits only if it still
-agrees. Counting notifications cannot do this job — `onChange` fires on identity CHANGE, so a
+agrees. Counting notifications cannot do this job: `onChange` fires on identity CHANGE, so a
 session that really closed notifies once and then never again; the confirmation reads
 `roster.current()`, which every poll refreshes whether or not it notified.
 
 What makes it a SECOND reading is `roster.readings()`, not the wait. A poll whose fetch failed
-keeps the last good rows on purpose, so `current()` can serve back the very snapshot that
-opened the window — one blink of the PID file plus one failed poll and a healthy session would
+keeps the last good rows, so `current()` can serve back the very snapshot that
+opened the window, since one blink of the PID file plus one failed poll and a healthy session would
 be ended on a single reading. The guard therefore requires that counter to have MOVED, and
 when it has not it re-arms instead of giving up: dropping the question would leave a session
 that really ended live for the life of the page, since `gone` is driven by an identity change
 that has already happened.
 
 Ending a tab is **reversible**, and has to be: `claude --resume` continues the SAME session id,
-so a resumed session can never be handed a new tab — nothing auto-opens it
+so a resumed session can never be handed a new tab, and nothing auto-opens it
 (`sessionsToAutoOpen` excludes both `known` and the ids on screen) and picking it from the
 dropdown only switches to it. So the poll that reports it live again calls `revive` (`app.ts`),
 which undoes the freeze and asks the replay endpoint for the tail the tab missed. What makes
-that possible is that the tab's READER outlives the session: `end` does not stop it —
-`stop()` means the tab is gone — and a tab subscribes to the live stream even when it opens
+that possible is that the tab's READER outlives the session, since `end` does not stop it
+(`stop()` means the tab is gone) and a tab subscribes to the live stream even when it opens
 onto a session that is already dead, since a subscription cannot be added later without a
 second reader double-counting the file. Reversibility does not soften the confirmation above:
 the repair arrives seconds late, drops the live chrome in between, and spends a request on a
@@ -315,23 +315,23 @@ tail the tab never lost.
 
 **A session blocked on the user.** Claude Code writes `status: "waiting"` into the PID
 file the moment it raises a dialog, with a `waitingFor` label saying which one, and
-clears it when the dialog is answered — so the state is self-healing and needs no
+clears it when the dialog is answered, so the state is self-healing and needs no
 event. seedeep keeps the label raw here and decides with `pendingInput`
 (`core/types.ts`, shared by the browser, the digest and the notification watcher so they
 cannot disagree) which ones mean *the agent is stopped on you*:
 `"permission prompt"` (a tool or plan approval) and `"input needed"`
-(AskUserQuestion, MCP elicitation). Everything else — `"dialog open"` (a picker the
+(AskUserQuestion, MCP elicitation). Everything else, such as `"dialog open"` (a picker the
 user opened), `"sandbox request"`, `"worker request"`, or an unknown label from a
-newer release — is deliberately NOT claimed as a pending approval. Nothing about a
+newer release, is deliberately NOT claimed as a pending approval. Nothing about a
 pending prompt reaches the transcript, which is why this is read from the PID file
 and not from an event; the contract claim that guards it is C24 (`claude-code-upgrades.md`).
 
-Each record also carries a **readable subject** — the session's first task-bearing
+Each record also carries a **readable subject**: the session's first task-bearing
 prompt (typed, a non-control slash command, or a headless SDK prompt), skipping
 session-control commands like `/clear` and `/effort`. The head scan reads the first
 64KB in one shot and only reads further (up to 1MB) when an anchor is still missing,
 so a session whose head is one huge line still gets labelled. The picker is a custom
-combobox (glass popover, searchable) split into **Human / Automated** tabs — at real
+combobox (glass popover, searchable) split into **Human / Automated** tabs, at real
 scale the ~1000 headless (`sdk-*`) docs-gate runs would otherwise bury the human
 sessions, so they get their own tab and the picker opens on Human. Each row shows the
 subject over a `model · date · id · N turns` meta line (turn count fetched from
@@ -350,7 +350,7 @@ truncated or rewritten.
 
 A **pure function**: one raw JSON line in, zero or more normalized events out.
 It never performs I/O and never throws on malformed input (a half-written line
-just yields no events). It uses an explicit whitelist — six line types produce
+just yields no events). It uses an explicit whitelist: six line types produce
 events (`assistant`, `user`, `system`, `attachment`, `queue-operation` and
 `file-history-delta`); every other line type is ignored.
 
@@ -360,8 +360,8 @@ verbatim output a subagent returned) passes through `anon()`, which strips real
 home paths (`/Users|/home/<name>` → `~`, and the slug-encoded `-Users-<name>`
 form), the scratchpad root (`/private/tmp/claude-<uid>` → `~scratch`), uuids
 (→ `<id>`), and control characters, then caps the length. Because anonymization
-happens at the source, nothing downstream — the reducer, the SSE frames, a
-screenshot — can leak the host or user.
+happens at the source, so nothing downstream (the reducer, the SSE frames, a
+screenshot) can leak the host or user.
 
 **One exemption, and only one**: the uuid inside a published artifact's URL
 (`https://claude.ai/code/artifact/<uuid>`) is kept. The rule exists for session and
@@ -371,7 +371,7 @@ that goes nowhere and cannot even be copied by hand. The same uuid one character
 outside that path is still masked. Nothing `anon()` touches is ever committed, so
 this changes nothing about the repository; the exposure it does carry is a live demo
 or screen-share of a real session, and public screenshots are covered by their own
-rule — they are taken on a synthetic session, which has published nothing.
+rule: they are taken on a synthetic session, which has published nothing.
 
 ### watcher
 
@@ -383,28 +383,28 @@ without re-deriving it.
 
 #### How it finds the live set without scanning the corpus
 
-The gate is `isLive` — `isOpen ?? isActive`. What is not obvious is how the set is REACHED:
+The gate is `isLive`, meaning `isOpen ?? isActive`. What is not obvious is how the set is REACHED:
 a tick must never run the complete discovery and filter afterwards, or a machine with a
 thousand cold sessions pays a full corpus scan several times a second whether or not
 anything is running.
 
 Since `isLive()` is `isOpen ?? isActive`, whenever the open-session mechanism answers at all
-the live set is EXACTLY the sessions holding a live process file — `isActive` is unreachable
+the live set is EXACTLY the sessions holding a live process file, and `isActive` is unreachable
 and the mtime window decides nothing. So a tick reads `~/.claude/sessions/` (one small file
 per running process) and looks each id up in a `sessionId → path` index. A full discovery
 still runs, but only to PLACE an id never seen before, which is what a new session is.
 
 Two states would otherwise bring that whole-corpus cost straight back, and both are handled:
 
-- **An open window nobody has typed into.** Claude Code writes the process file when the
+- An open window nobody has typed into. Claude Code writes the process file when the
   window opens but the transcript only when the conversation does, so the id is on no disk
-  any scan can reach — and this is precisely the idle case. A failed placement is remembered
+  any scan can reach, and this is precisely the idle case. A failed placement is remembered
   and not retried for `RESCAN_MS` (1 s), which caps that state at one scan per second and
   delays a brand-new session's first line by at most the same.
 - **No mechanism at all.** `~/.claude/sessions/` is an undocumented Claude Code internal a
   release may drop; `listOpenSessions` returns `null` rather than `[]` for exactly this. Then
   the mtime window is the only answer there is and the watcher degrades to a full scan per
-  tick — degraded, not blind.
+  tick: degraded, not blind.
 
 ### What a subagent's state SAYS vs what the reducer SAW
 
@@ -418,7 +418,7 @@ arrived". Turning that into what a surface shows is `displayState`
 | A Workflow run silent past `WF_SILENT_MS` (5 min) | `unknown` | A killed run gets no terminal signal anywhere, so silence is the only evidence left |
 | A subagent with no trace of itself (`!hasStarted`) | `unknown` | Nothing on record says an agent is at work |
 
-A background COMMAND has the same problem and cannot be answered the same way — see
+A background COMMAND has the same problem and cannot be answered the same way; see
 [Is a background command still alive?](#is-a-background-command-still-alive) below.
 
 `hasStarted(a)` is true when the agent has **any one** sign: an `agentType` from its sidecar,
@@ -426,15 +426,15 @@ tokens billed to it, a tool it ran, or text it returned. A subagent that reaches
 session still `running` has none of the four: it is a launch with nothing behind it, not an
 agent whose ending was lost.
 
-**It is a fact, not a timeout.** Nothing in it measures duration: a legitimate `Explore` can run
+It is a fact, not a timeout. Nothing in it measures duration: a legitimate `Explore` can run
 for minutes and a threshold would delete true state to hide missing state. It does not claim the
-agent finished — it declines to claim it ever started. Like the workflow rule it is DERIVED and
+agent finished: it declines to claim it ever started. Like the workflow rule it is DERIVED and
 never latched: one line from the agent and it is `running` again, so a false unknown heals
 itself within a watcher tick.
 
-**Counting and showing are different questions**, and `hasStarted` answers only the first. The
-Graph LISTS the launch with an `unknown` badge — seedeep sees a line in the transcript and must
-not hide it, and a launch that never started is an anomaly worth noticing — while `/api/digest`,
+Counting and showing are different questions, and `hasStarted` answers only the first. The
+Graph LISTS the launch with an `unknown` badge, because seedeep sees a line in the transcript and must
+not hide it, and a launch that never started is an anomaly worth noticing, while `/api/digest`,
 whose `subagents.running` a status row prints as a number, does not count it. The Graph's own
 active count uses `displayState` too, so the two never disagree about how many are working; only
 the list differs, which is the point. A Workflow row is exempt from `hasStarted`: its node
@@ -448,15 +448,15 @@ however long ago the command really stopped. A subagent's `unknown` cannot be bo
 here: it is reached by the view knowing the session has CLOSED, and this is a session still open.
 
 So seedeep asks the machine. `apps/server/src/server/command-liveness.ts` runs on its own 15 s
-clock (never the watcher's 300 ms tick — it spends a subprocess), for the commands of sessions a
-tree is already held for, and it asks ONE question: **does any process still hold this command's
-output file open?**
+clock (never the watcher's 300 ms tick, since it spends a subprocess), for the commands of sessions a
+tree is already held for, and it asks ONE question: does any process still hold this command's
+output file open?
 
-**A `Monitor` is never asked.** Its output file is named the same way, so the probe *would* answer
-— with the wrong answer. A background shell command keeps that file open through the whole chain
+A `Monitor` is never asked. Its output file is named the same way, so the probe *would* answer
+with the wrong answer. A background shell command keeps that file open through the whole chain
 (the harness's `zsh`, the command's shell, the leaf), which is what this mechanism rests on; a
 monitor's stream does not, so a monitor that is demonstrably alive answers exactly like one that
-has gone. What ends a monitor instead is its `TaskStop` — see the `agent-end` row in the event
+has gone. What ends a monitor instead is its `TaskStop`; see the `agent-end` row in the event
 table.
 
 - The file is found from the launch's task id, not from the path the transcript prints:
@@ -466,24 +466,24 @@ table.
   leaf), `claude` itself does not, and a command that ends or is killed releases it while the file
   stays on disk. One `lsof -F pn` answers every command at once, which is why the probe spends one
   subprocess per tick and not one per command.
-- **Three other sources cannot answer this** and must not be reached for: Claude Code keeps no
+- Three other sources cannot answer this and must not be reached for: Claude Code keeps no
   registry of its background shells on disk (the task id appears nowhere in `~/.claude` outside
   the transcript); the output file's mtime or size says nothing, since a healthy waiter can sit
   ALIVE for tens of minutes having written 0 bytes; and matching `ps` on the command TEXT fails
   because the harness re-quotes what it runs, so the string seedeep holds is not the string `ps`
   prints.
 
-**The verdict is `unknown` and can never be anything else.** The probe learns that something
-stopped, never what it stopped WITH, so it emits a `command-vanished` event — out of band,
-`seq: -1`, applied like `subagent-meta` — and the reducer refuses it outright if the command has
+The verdict is `unknown` and can never be anything else. The probe learns that something
+stopped, never what it stopped WITH, so it emits a `command-vanished` event, out of band,
+`seq: -1`, applied like `subagent-meta`, and the reducer refuses it outright if the command has
 an `outcome`: Claude Code's own word is the authority and can still arrive afterwards. The row's
 duration becomes the last instant it was SEEN, printed as a bound (`≥ 4m 20s`), never as a
 measurement.
 
-**It fails towards saying nothing.** Two consecutive empty probes before a row tips; no verdict at
+It fails towards saying nothing. Two consecutive empty probes before a row tips; no verdict at
 all when the file cannot be found, has been deleted (the scratch root lives under `/tmp`, which
 the OS cleans), or when `lsof` is absent or times out. A missing prober leaves every row exactly
-as it is today. LIMIT: `lsof` only — a Linux box without it gets no verdict rather than a
+as it is today. LIMIT: `lsof` only, so a Linux box without it gets no verdict rather than a
 `/proc/<pid>/fd` sweep, which is thousands of `readlink`s per probe where this is one process, and
 Windows is out of scope.
 
@@ -493,46 +493,46 @@ The parser flattens the raw log into a small set of events consumers care about:
 
 | Event             | Source field(s)                                              | Meaning                          |
 |-------------------|-------------------------------------------------------------|----------------------------------|
-| `usage`           | `message.usage` + `message.model` + root `effort`           | context fill + per-call delta, and the model/effort THAT CALL ran on; for a line flagged `isApiErrorMessage` also `apiError` (status + the message shown to the user) — the call FAILED |
+| `usage`           | `message.usage` + `message.model` + root `effort`           | context fill + per-call delta, and the model/effort THAT CALL ran on; for a line flagged `isApiErrorMessage` also `apiError` (status + the message shown to the user), meaning the call FAILED |
 | `attribution`     | `attributionSkill` / `attributionMcpServer` / `attributionMcpTool` | what is filling the context (skill turns are counted from this) |
 | `compaction`      | `compactMetadata` / `isCompactSummary`                     | a compaction (context deflate)   |
-| `user-turn`       | a user line that is `origin.kind: 'human'`, **or** carries `<command-name>`, **or** is the plain text of a command (see below) | the user sent something — opens a timeline entry; `prompt` is the text (a command's `<command-args>`, or its arguments), `command` the slash command that carried it, `promptId` the invocation the line belongs to |
+| `user-turn`       | a user line that is `origin.kind: 'human'`, **or** carries `<command-name>`, **or** is the plain text of a command (see below) | the user sent something, which opens a timeline entry; `prompt` is the text (a command's `<command-args>`, or its arguments), `command` the slash command that carried it, `promptId` the invocation the line belongs to |
 | `command`         | the same three shapes as `user-turn`                       | a slash command was used         |
-| `turn-narration`  | an assistant `text` block on a line whose `stop_reason` is anything but `end_turn`; main session only; never the auto-continue receipt (see `turn-interrupted`), whose text no model wrote | mid-turn narration — the model saying what it is about to do: `text` (anonymized, capped at 2000) and `callId` (`message.id`), which is also the call whose tools form the Trace's round. A subagent's narration has no consumer and is dropped |
-| `turn-result`     | an assistant `text` block on a line whose `stop_reason` is `end_turn` | the turn's final answer — `outputFull` (anonymized, capped at 20k) and `outLen`. The same shape on a CHILD line becomes `subagent-output` instead |
-| `turn-interrupted` | `interruptedMessageId` on the next user line after an Esc, **or** Claude Code's auto-continue receipt — a `<synthetic>` assistant line that is not an API error, which it writes when it re-enters a session whose last round never finished | the previous turn was interrupted. After an Esc it is emitted BEFORE that line's `user-turn`, so the reducer closes the old turn before opening the new one. The receipt is recognised by its TEXT, not by the `<synthetic>` marker: the marker says only that no model wrote the line, while "this round is over" is read off the one wording measured to mean it — a future notice Claude Code writes the same way would otherwise close a turn that is still working. It is the ONLY record that a killed round is over — the `turn_duration` that would have closed it was owed by a process that died, and a transcript only appends — so without it the turn stays `live` for good, running a clock nobody is working under and counting it into the session's total. It carries `cutoff`, and a cutoff closes only a round that made a call: an Esc says the user stopped something, while a killed session says only that nothing more is coming, so a bare `/model` is left to the 0-call → done presentation rather than promoted to an interrupted work turn. `cutoff` rides on to `TurnNode`, because the distinction outlives the event: a cut round IS interrupted, but it is not an **Esc**, and every surface that reads an interruption as the user's CORRECTION — the retrospective's "abandoned to Esc", the verdict's "second correction in a row" — must exclude it. A crash is not a correction |
-| `turn-end`        | a `system` line with `subtype: 'turn_duration'`; main session only | the turn finished — `durationMs` and `messageCount`, both nullable. Claude Code's own measure, not one seedeep derives |
-| `agent-launch`    | `<forked-skill-launch>` on a `system`/`local_command` line  | a forked skill (`/code-review`) started a background agent — `launchedAgentId`, `skillName`, `description`. It is NOT a `tool_use`: this line is the only record that the agent exists, when it started and which turn asked for it |
-| `file-change`     | a `file-history-delta` line (`trackingPath`)               | Claude Code backed up one file it changed — its own /rewind ledger. It records ONLY what CC's own file-writing tools wrote: a file written by `python3`, by `cat >>` or by the build produces no delta at all, and WHICH session made a shell write is recorded nowhere on disk. So the Changed files card does not count this event — its number comes from the session's own commits via `GET /api/files` (`docs/session-output.md`), reproducible with `git show --stat`. The ledger's one remaining job is the session scratchpad, which lives outside the repo where git cannot see it: `isScratchPath` (`apps/server/src/core/text.ts`) classifies on the `~scratch` token `anon` produces, so a path is anonymized BEFORE it is tested. `trackingPath` has TWO shapes — absolute, or relative to the session's cwd, in which case `backup.realParentDir` names the directory — and `ledgerPath` resolves both. The reducer still attributes each delta to the open turn; the baseline `file-history-snapshot` stays ignored |
-| `tool-start`      | a `tool_use` content block                                 | a tool call began — id, name, anonymized `arg`; for an `Agent`/`Task` block also the `launchPrompt` + `subagentType` + the launch `description` (which heads the subagent's row — see the GUI shell); for a Task-family block a `taskRef` instead of an `arg` (see below) |
-| `tool-end`        | a `tool_result` content block                              | a tool call finished — `toolUseId`, `outputSize` (rendered char length); `error: true` when the result is a real FAILURE (a user refusal carries the same `is_error` flag but is NOT a failure — classified by `toolOutcome` in `apps/server/src/server/failure.ts`); for a foreground `Agent` result the inline `returned` payload; for a background one `launched` (a receipt: the subagent STARTED), for a `Workflow` also `workflow` (runId + name), and for a `TaskCreate` result `taskCreated` (the todo number it was given + its subject). A launch into the BACKGROUND carries `background` (taskId + who put it there), and it has two receipt shapes: a `Bash`'s `backgroundTaskId`, and a `Monitor`'s `taskId` **with** `timeoutMs` — the same kind of launch under a different field name. The second half of that gate is not decoration: a `TaskUpdate` receipt carries a todo's `taskId` and a `Workflow`'s carries a run's, and `taskId` alone would list both as running commands |
-| `agent-end`       | a `queue-operation` line whose content is a `<task-notification>`, OR a `TaskStop` receipt (`Successfully stopped task: <id>`) | a background subagent really finished — `toolUseId` (the spawn, **nullable**), `taskId` (`<task-id>`, the child's agentId), `status` (completed/failed/killed/stopped). Fires on every stop, so a resumed agent produces several: last wins, never latched — **except the instant a background COMMAND ended, which is first-wins**. Claude Code writes each notification twice (`enqueue`, then `remove` when its queue drains) with an identical payload but not at the same time — minutes apart in the worst case — so last-wins would date the end to the DRAIN rather than to the stop. The status and the sentence stay last-wins, where a repeat really is inert. **The event is gated on `toolUseId` OR `status`**, never on the spawn name alone: the subject is an AGENT and the line names it TWICE, so requiring the spawn drops the only signal a subagent with no spawn ever gets — and a skill forked into the background has none by construction (its `meta.json` carries no `toolUseId`). What makes a notification TERMINAL is the `status`: the same line type is written for progress (`event` + `summary`, no status), and that ends nothing. The reducer enforces it where the difference is destructive: a background COMMAND is closed only by a notification carrying a status, since applying a progress summary as its outcome would mark it `done` minutes early and measure its duration to the wrong instant. A progress notification carries a `<task-id>` and never a `<tool-use-id>`, so none can reach a command through this event at all — they are reported as `background-event` instead, which counts them against the task and ends nothing. **`toolUseId` is not always a spawn either**: after a `SendMessage` resume Claude Code keys the notification on the resume call. So the reducer routes by `toolUseId`, then `taskId → spawn`, then — naming no spawn we hold — records the end against the agentId itself. The line is also written for things that are not subagents (a background `Bash`/`Monitor` task, a `Workflow` run, a nested spawn): those name no agent, so nothing ever looks them up. `<task-id>` carries a type prefix — `a…` an agent (always naming a child file), `b…` a background shell task, `w…` a workflow run. **A `TaskStop` receipt is the other source of this event**, and the only end a stopped `Monitor` ever gets: Claude Code writes no notification for it and the liveness probe cannot answer for a monitor either, so without this the row would call itself running for the rest of the session. It names the TASK and not the call, so the reducer resolves it through `bgByTaskId`; its status is `stopped`, Claude Code's own word, which every surface already reads as a clean end |
-| `background-event` | a `queue-operation` line whose `<task-notification>` carries an `<event>` and NO `<status>` | a still-running background task reported something — today only a `Monitor`, whose stream is its whole output. `taskId` (the launch receipt's own id, the only link it carries — there is no `<tool-use-id>`), `event` (anonymized: a watched log line can hold anything). **Only the `enqueue` copy** is emitted: Claude Code writes the identical payload again as `remove` when the queue drains, and counting the line would double every event that happened to be drained. The reducer counts these per task id and keeps the latest — the row shows a count and one line, and none of them reach the activity feed, whose ring is `FEED_CAP` rows deep and has other things to hold |
-| `note` | an `attachment` line whose `hook_additional_context` comes from a TOOL hook (`hookEvent` `PreToolUse`/`PostToolUse`), OR a `<task-notification>` carrying nothing but a `<summary>` | something attached TEXT to the session that seedeep would never have derived — a hook warning about the file just written, a background review reporting findings. `toolUseId` (null when it is about the session and not a call), `hook`, `source` (the writer, when the text declares it as `[from <plugin> plugin]`), `text` (anonymized). **`attachment` is otherwise dropped wholesale** — nearly all of them are the bookkeeping every tool produces, twice per call. The gate is the hook's EVENT, and NOT the presence of `toolUseID`: a SessionStart injection carries `toolUseID: "SessionStart"`, a non-empty string that anchors nothing, so an id-only gate emits all of them as notes about a call that does not exist. The field takes exactly two shapes — `PostToolUse` with a real `toolu_…`, and `SessionStart` with that literal. The `content` is an array of BARE STRINGS, not of `{type:'text'}` blocks, which is why `renderedText` returns nothing for it. An UNANCHORED note also carries WHEN it arrived and in which turn: the complete-history list (`Expand all`) folds it in among the calls in time order, being the only surface with no cap, and one appended at the end would sit beside work it has nothing to do with. It is not a span, and the Trace never draws one — `SpanType` carries a `note` member that only that list ever produces. Deliberately not modelled as "a security finding": a type keyed on one plugin goes blind the day another one speaks |
-| `wakeup` | a `ScheduleWakeup` receipt (`toolUseResult.scheduledFor`) | the session arranged to wake itself up (a self-paced `/loop`): `toolUseId`, `at` (epoch ms, null when the receipt STOPPED the loop — `scheduledFor: 0` with `stopped: true`). NOT a background task: nothing runs, nothing holds a file open, there is nothing for the liveness probe to ask about. Last-wins in the reducer, because a dynamic loop re-arms every turn and only the newest instant is what the session is waiting for. **The firing is invisible** — a wakeup that goes off produces no line of its own, no `origin` and no `promptSource` that tells it from any other system prompt — so every surface shows this while the instant is ahead and stops showing it after, and none of them ever says it fired |
-| `command-vanished` | NO LINE — the server's liveness probe                     | nothing holds a background command's output file open any more, so its process is gone: `toolUseId`, `lastSeenAlive`. The only event with no source in the transcript, because the fact is not in it — see [Is a background command still alive?](#is-a-background-command-still-alive). It says a command STOPPED and never what it stopped with, so the reducer turns it into `unknown`, refuses it outright when an `outcome` is already there, and applies it idempotently (`seq: -1`, out of band, like `subagent-meta`) |
-| `workflow-agent`  | a run's `subagents/workflows/wf_<runId>/` dir + its `journal.jsonl` | one subagent of a Workflow run — `runId`, `phase` (`seen`/`started`/`result`). `started` minus `result` is the only record of how many are still working |
-| `subagent-meta`   | `agent-*.meta.json` sidecar + the child's model            | agentId → toolUseId link, type, model, and the sidecar's `description` — what the agent was launched to do, which for a forked skill is the ONLY name it has |
+| `turn-narration`  | an assistant `text` block on a line whose `stop_reason` is anything but `end_turn`; main session only; never the auto-continue receipt (see `turn-interrupted`), whose text no model wrote | mid-turn narration, the model saying what it is about to do: `text` (anonymized, capped at 2000) and `callId` (`message.id`), which is also the call whose tools form the Trace's round. A subagent's narration has no consumer and is dropped |
+| `turn-result`     | an assistant `text` block on a line whose `stop_reason` is `end_turn` | the turn's final answer: `outputFull` (anonymized, capped at 20k) and `outLen`. The same shape on a CHILD line becomes `subagent-output` instead |
+| `turn-interrupted` | `interruptedMessageId` on the next user line after an Esc, **or** Claude Code's auto-continue receipt, a `<synthetic>` assistant line that is not an API error, which it writes when it re-enters a session whose last round never finished | the previous turn was interrupted. After an Esc it is emitted BEFORE that line's `user-turn`, so the reducer closes the old turn before opening the new one. The receipt is recognised by its TEXT, not by the `<synthetic>` marker: the marker says only that no model wrote the line, while "this round is over" is read off the one wording measured to mean it, since a future notice Claude Code writes the same way would otherwise close a turn that is still working. It is the ONLY record that a killed round is over: the `turn_duration` that would have closed it was owed by a process that died, and a transcript only appends, so without it the turn stays `live` for good, running a clock nobody is working under and counting it into the session's total. It carries `cutoff`, and a cutoff closes only a round that made a call: an Esc says the user stopped something, while a killed session says only that nothing more is coming, so a bare `/model` is left to the 0-call → done presentation rather than promoted to an interrupted work turn. `cutoff` rides on to `TurnNode`, because the distinction outlives the event: a cut round IS interrupted, but it is not an **Esc**, and every surface that reads an interruption as the user's CORRECTION (the retrospective's "abandoned to Esc", the verdict's "second correction in a row") must exclude it. A crash is not a correction |
+| `turn-end`        | a `system` line with `subtype: 'turn_duration'`; main session only | the turn finished: `durationMs` and `messageCount`, both nullable. Claude Code's own measure, not one seedeep derives |
+| `agent-launch`    | `<forked-skill-launch>` on a `system`/`local_command` line  | a forked skill (`/code-review`) started a background agent: `launchedAgentId`, `skillName`, `description`. It is NOT a `tool_use`: this line is the only record that the agent exists, when it started and which turn asked for it |
+| `file-change`     | a `file-history-delta` line (`trackingPath`)               | Claude Code backed up one file it changed, in its own /rewind ledger. It records ONLY what CC's own file-writing tools wrote: a file written by `python3`, by `cat >>` or by the build produces no delta at all, and WHICH session made a shell write is recorded nowhere on disk. So the Changed files card does not count this event: its number comes from the session's own commits via `GET /api/files` (`docs/session-output.md`), reproducible with `git show --stat`. The ledger's one remaining job is the session scratchpad, which lives outside the repo where git cannot see it: `isScratchPath` (`apps/server/src/core/text.ts`) classifies on the `~scratch` token `anon` produces, so a path is anonymized BEFORE it is tested. `trackingPath` has TWO shapes, absolute or relative to the session's cwd, in which case `backup.realParentDir` names the directory, and `ledgerPath` resolves both. The reducer still attributes each delta to the open turn; the baseline `file-history-snapshot` stays ignored |
+| `tool-start`      | a `tool_use` content block                                 | a tool call began: id, name, anonymized `arg`; for an `Agent`/`Task` block also the `launchPrompt` + `subagentType` + the launch `description` (which heads the subagent's row, see the GUI shell); for a Task-family block a `taskRef` instead of an `arg` (see below) |
+| `tool-end`        | a `tool_result` content block                              | a tool call finished: `toolUseId`, `outputSize` (rendered char length); `error: true` when the result is a real FAILURE (a user refusal carries the same `is_error` flag but is NOT a failure, classified by `toolOutcome` in `apps/server/src/server/failure.ts`); for a foreground `Agent` result the inline `returned` payload; for a background one `launched` (a receipt: the subagent STARTED), for a `Workflow` also `workflow` (runId + name), and for a `TaskCreate` result `taskCreated` (the todo number it was given + its subject). A launch into the BACKGROUND carries `background` (taskId + who put it there), and it has two receipt shapes: a `Bash`'s `backgroundTaskId`, and a `Monitor`'s `taskId` **with** `timeoutMs`, the same kind of launch under a different field name. The second half of that gate is not decoration: a `TaskUpdate` receipt carries a todo's `taskId` and a `Workflow`'s carries a run's, and `taskId` alone would list both as running commands |
+| `agent-end`       | a `queue-operation` line whose content is a `<task-notification>`, OR a `TaskStop` receipt (`Successfully stopped task: <id>`) | a background subagent really finished: `toolUseId` (the spawn, **nullable**), `taskId` (`<task-id>`, the child's agentId), `status` (completed/failed/killed/stopped). Fires on every stop, so a resumed agent produces several: last wins, never latched, except the instant a background COMMAND ended, which is first-wins. Claude Code writes each notification twice (`enqueue`, then `remove` when its queue drains) with an identical payload but not at the same time (minutes apart in the worst case) so last-wins would date the end to the DRAIN rather than to the stop. The status and the sentence stay last-wins, where a repeat really is inert. The event is gated on `toolUseId` OR `status`, never on the spawn name alone: the subject is an AGENT and the line names it TWICE, so requiring the spawn drops the only signal a subagent with no spawn ever gets, and a skill forked into the background has none by construction (its `meta.json` carries no `toolUseId`). What makes a notification TERMINAL is the `status`: the same line type is written for progress (`event` + `summary`, no status), and that ends nothing. The reducer enforces it where the difference is destructive: a background COMMAND is closed only by a notification carrying a status, since applying a progress summary as its outcome would mark it `done` minutes early and measure its duration to the wrong instant. A progress notification carries a `<task-id>` and never a `<tool-use-id>`, so none can reach a command through this event at all: they are reported as `background-event` instead, which counts them against the task and ends nothing. `toolUseId` is not always a spawn either: after a `SendMessage` resume Claude Code keys the notification on the resume call. So the reducer routes by `toolUseId`, then `taskId → spawn`, then, naming no spawn we hold, records the end against the agentId itself. The line is also written for things that are not subagents (a background `Bash`/`Monitor` task, a `Workflow` run, a nested spawn): those name no agent, so nothing ever looks them up. `<task-id>` carries a type prefix: `a…` an agent (always naming a child file), `b…` a background shell task, `w…` a workflow run. A `TaskStop` receipt is the other source of this event, and the only end a stopped `Monitor` ever gets: Claude Code writes no notification for it and the liveness probe cannot answer for a monitor either, so without this the row would call itself running for the rest of the session. It names the TASK and not the call, so the reducer resolves it through `bgByTaskId`; its status is `stopped`, Claude Code's own word, which every surface already reads as a clean end |
+| `background-event` | a `queue-operation` line whose `<task-notification>` carries an `<event>` and NO `<status>` | a still-running background task reported something, today only a `Monitor`, whose stream is its whole output. `taskId` (the launch receipt's own id, the only link it carries, since there is no `<tool-use-id>`), `event` (anonymized: a watched log line can hold anything). **Only the `enqueue` copy** is emitted: Claude Code writes the identical payload again as `remove` when the queue drains, and counting the line would double every event that happened to be drained. The reducer counts these per task id and keeps the latest: the row shows a count and one line, and none of them reach the activity feed, whose ring is `FEED_CAP` rows deep and has other things to hold |
+| `note` | an `attachment` line whose `hook_additional_context` comes from a TOOL hook (`hookEvent` `PreToolUse`/`PostToolUse`), OR a `<task-notification>` carrying nothing but a `<summary>` | something attached TEXT to the session that seedeep would never have derived: a hook warning about the file just written, a background review reporting findings. `toolUseId` (null when it is about the session and not a call), `hook`, `source` (the writer, when the text declares it as `[from <plugin> plugin]`), `text` (anonymized). `attachment` is otherwise dropped wholesale, since nearly all of them are the bookkeeping every tool produces, twice per call. The gate is the hook's EVENT, and NOT the presence of `toolUseID`: a SessionStart injection carries `toolUseID: "SessionStart"`, a non-empty string that anchors nothing, so an id-only gate emits all of them as notes about a call that does not exist. The field takes exactly two shapes: `PostToolUse` with a real `toolu_…`, and `SessionStart` with that literal. The `content` is an array of BARE STRINGS, not of `{type:'text'}` blocks, which is why `renderedText` returns nothing for it. An UNANCHORED note also carries WHEN it arrived and in which turn: the complete-history list (`Expand all`) folds it in among the calls in time order, being the only surface with no cap, and one appended at the end would sit beside work it has nothing to do with. It is not a span, and the Trace never draws one: `SpanType` carries a `note` member that only that list ever produces. Not modelled as "a security finding": a type keyed on one plugin goes blind the day another one speaks |
+| `wakeup` | a `ScheduleWakeup` receipt (`toolUseResult.scheduledFor`) | the session arranged to wake itself up (a self-paced `/loop`): `toolUseId`, `at` (epoch ms, null when the receipt STOPPED the loop, with `scheduledFor: 0` and `stopped: true`). NOT a background task: nothing runs, nothing holds a file open, there is nothing for the liveness probe to ask about. Last-wins in the reducer, because a dynamic loop re-arms every turn and only the newest instant is what the session is waiting for. **The firing is invisible**: a wakeup that goes off produces no line of its own, no `origin` and no `promptSource` that tells it from any other system prompt, so every surface shows this while the instant is ahead and stops showing it after, and none of them ever says it fired |
+| `command-vanished` | NO LINE; the server's liveness probe                     | nothing holds a background command's output file open any more, so its process is gone: `toolUseId`, `lastSeenAlive`. The only event with no source in the transcript, because the fact is not in it; see [Is a background command still alive?](#is-a-background-command-still-alive). It says a command STOPPED and never what it stopped with, so the reducer turns it into `unknown`, refuses it outright when an `outcome` is already there, and applies it idempotently (`seq: -1`, out of band, like `subagent-meta`) |
+| `workflow-agent`  | a run's `subagents/workflows/wf_<runId>/` dir + its `journal.jsonl` | one subagent of a Workflow run: `runId`, `phase` (`seen`/`started`/`result`). `started` minus `result` is the only record of how many are still working |
+| `subagent-meta`   | `agent-*.meta.json` sidecar + the child's model            | agentId → toolUseId link, type, model, and the sidecar's `description`, which is what the agent was launched to do, which for a forked skill is the ONLY name it has |
 | `subagent-output` | a child assistant line with `stop_reason: "end_turn"`     | the verbatim text a subagent returned to the main session (its final answer) |
 
 ### The Task family takes references, not arguments
 
 `TaskUpdate`, `TaskGet`, `TaskOutput` and `TaskStop` do not name what they act on: they point
-at it — and at **two different task systems**, which the id field names apart: the task list
+at it, and at **two different task systems**, which the id field names apart: the task list
 spells it `taskId` and numbers rows sequentially (`{taskId: "1", status}`), while background
 tasks spell it `task_id` and carry a hex that **is a subagent's agentId**. Reading the wrong
 field yields no label at all. So the parser emits a **`taskRef`** (`id` + `kind`:
-`todo` or `agent`) rather than an `arg`, and the **reducer** — the only layer holding the
-cross-event state — resolves it into a label:
+`todo` or `agent`) rather than an `arg`, and the **reducer**, the only layer holding the
+cross-event state, resolves it into a label:
 
 - `todo` → the subject from the `TaskCreate` result that named that number (`#1 Fix the parser
   → in_progress`). The number exists ONLY in the result; the input has no id.
 - `agent` → the subagent's type, via the same `agentId → spawn` map `SendMessage` uses
-  (`docs-researcher`). Unresolved, it degrades to a short id — never a raw hex.
+  (`docs-researcher`). Unresolved, it degrades to a short id, never a raw hex.
 
 Both the snapshot and the live feed read that one resolved label (`EventContext.label`), so a
 call can never read one way in the feed and another in the drawer. `TaskCreate` is labelled by
-its `subject` directly, and `TaskList` — whose input is `{}` on every real call — keeps no
+its `subject` directly, and `TaskList`, whose input is `{}` on every real call, keeps no
 argument at all rather than being given an invented one.
 
 Every event also carries an optional **`agentId`**: `null` for the main session,
@@ -540,22 +540,22 @@ the subagent id for events read from a `subagents/agent-*.jsonl` child file. Eve
 must branch on `agentId` before touching main-session figures; a child's `usage`
 applied to the main fill is the exact bug that shipped once.
 
-**A subagent is born at its SPAWN, not at its child file.** The list of subagents is keyed
+A subagent is born at its SPAWN, not at its child file. The list of subagents is keyed
 by the spawning `Agent` tool_use id and created the moment that block is seen; the child file
 only enriches it (model, usage, output, real duration) and may arrive late or never. Keying
 the list on the child instead makes a whole class of launches invisible: a `Workflow` run's
 subagents have no spawn of their own in this session's log.
 
-**A launch receipt is not a completion.** A `tool_result` for an `Agent` block means "this
+A launch receipt is not a completion. A `tool_result` for an `Agent` block means "this
 subagent finished" only when the spawn was *foreground*. Since CC v2.1.198 subagents run in
 the background by default, and a background result carries `status: "async_launched"` and
-lands almost immediately after the spawn — it is a receipt saying the work *started*. Reading
+lands almost immediately after the spawn: it is a receipt saying the work *started*. Reading
 it as a completion makes every background subagent be born `done`, so the live monitor never
 shows one working. The real end arrives later, on its own line type
 (`queue-operation` → `agent-end`). The parser flags the receipt (`launched`), and only a
 foreground result ends a subagent.
 
-**Subagent returned output — the child jsonl is authoritative.** A subagent's
+Subagent returned output: the child jsonl is authoritative. A subagent's
 final answer is read from its child file (the last `end_turn` assistant line),
 not from the parent's `Agent` tool_result: a *background* (`isAsync`) subagent's
 parent tool_result is only a launch acknowledgement and carries no output. The
@@ -568,8 +568,8 @@ subagent that returns immediately while it keeps working).
 `usage` line (how full the window is right now), while the delta between
 consecutive usage lines drives the trend.
 
-**The denominator follows the calls, not the session head.** The window comes from
-`main.model`, which is the model of the LATEST main-session `usage` — never a value read
+The denominator follows the calls, not the session head. The window comes from
+`main.model`, which is the model of the LATEST main-session `usage`, never a value read
 once when the tab opened. Two states make the difference visible, and neither announces
 itself:
 
@@ -580,28 +580,28 @@ itself:
   same 188k reads as 19% full or 94% full depending on which model is believed.
 
 `main.model` is therefore the model in force NOW, and `main.models` every model the session
-has run on in first-seen order — a surface that shows only the last hides that anything
+has run on in first-seen order, since a surface that shows only the last hides that anything
 changed, and one that shows only the first is the bug itself. Each `TurnNode` carries the
 same pair scoped to its own calls (`models`, `efforts`), which is what lets a scoped widget
 name the model that turn actually ran on. `efforts` is empty on most turns: Claude Code only
 writes `effort` when one is configured, so the absence is the normal case and no surface may
 render a placeholder for it.
 
-**Two numbers, two questions — do not conflate them.** A `usage` line is the whole
+Two numbers, two questions, not to be conflated. A `usage` line is the whole
 prompt of ONE API call, so the reducer keeps its tokens in two shapes:
 
-- `main.breakdown` / `turn.breakdown` — the **last call**, absolute. It answers
+- `main.breakdown` / `turn.breakdown`: the **last call**, absolute. It answers
   "what is the window made of right now", so it (and only it) drives the Context bar.
   The last call that reached a MODEL, which is not every `usage` line: Claude Code
-  stamps `<synthetic>` on lines that called none — the "No response requested." it
-  writes when a killed session is resumed, and API-error lines — and gives them a
+  stamps `<synthetic>` on lines that called none (the "No response requested." it
+  writes when a killed session is resumed, and API-error lines) and gives them a
   `usage` block all the same, structurally a call's and all zeros. Taken as last-call
   state it reports an empty window, so the reducer refuses a line that names no model
   AND reports no tokens (`reportsWindow`). Both conditions: a real call can arrive
   without a model on the line, and can never read zero, having at least its system
-  prompt. The SUMS below are outside that guard — an all-zero line adds nothing to them.
+  prompt. The SUMS below are outside that guard, since an all-zero line adds nothing to them.
 - `main.cacheTotals` + `main.inputTotal` + `main.outputTotal` (and the per-turn
-  equivalents) — **summed over every call in the scope**. They answer "how many tokens
+  equivalents), **summed over every call in the scope**. They answer "how many tokens
   did this billing category cost", and they drive the **Session** card's ledger.
 
 The **Session** card's ledger reports the four categories Anthropic names in the
@@ -615,10 +615,10 @@ The **Session** card's ledger reports the four categories Anthropic names in the
 | Output       | `output_tokens`                |
 
 The four category rows are the **main thread's** consumption and are headed *main session*,
-because they and the Subagents row measure different things — a category versus an actor — that
+because they and the Subagents row measure different things, a category versus an actor, and
 both add to the hero; unlabelled they read as one four-item list and the hero stops looking like
 their sum. The card's hero is the whole-session **total** = the four categories summed, plus a
-separate **Subagents** row. That row is the sum of each subagent's cumulative **volume** —
+separate **Subagents** row. That row is the sum of each subagent's cumulative **volume**,
 Σ its own per-call `input+output+cache`, read from the child jsonl the watcher tails and
 folded once per `callId` exactly like the main sums. It is kept a separate row rather than
 folded into the four categories because a subagent's tokens are billed under its OWN context
@@ -626,56 +626,56 @@ window, not the main one. It is the same metric on both sides, which is what mak
 the hero comparable: a subagent's *last* call is not its volume, and reading one for the other
 understates a multi-call subagent by an order of magnitude. A **background** subagent writes no child jsonl, so its
 per-call usage is unavailable: its volume falls back to the parent-reported `totalTokens`
-(≈ its final context, not a true sum) and is flagged **estimated** — the Subagents row shows a
+(≈ its final context, not a true sum) and is flagged **estimated**, so the Subagents row shows a
 leading `~` when the total blends any such approximation. The per-subagent card mirrors the
-split: a **VOLUME** line (cumulative, no window frame — a volume can exceed the window) and a
+split: a **VOLUME** line (cumulative, no window frame, since a volume can exceed the window) and a
 **CONTEXT** bar (the subagent's final `fill` over its window), with the four categories in the
-drawer — drawn there as ONE stacked bar, because their meaning is the ratio between them, not
-four separate figures. It is a VOLUME view, not a cost one — the categories are additive tokens, deliberately
+drawer, drawn there as ONE stacked bar, because their meaning is the ratio between them and not
+four separate figures. It is a VOLUME view rather than a cost one: the categories are additive tokens, deliberately
 not price-weighted (cost is ccusage's lane, not seedeep's). Re-read (`cache_read`) dominates
-every real session — the same window handed back on every call, and the bulk of a subagent's
-volume — which is exactly the invisible churn seedeep exists to show.
+every real session, the same window handed back on every call and the bulk of a subagent's
+volume, which is exactly the invisible churn seedeep exists to show.
 
 The Subagents row opens into a **by-model** bar: the row's total split by which model burned it,
 one segment per model **family** (`opus`/`sonnet`/`haiku`/`fable`), biggest share first. It is
-subagent tokens ONLY — the main thread never enters it, the two staying apart by the reducer's
-`owner` — so the bar splits the figure directly above it, never the hero; it is absent when no
+subagent tokens ONLY: the main thread never enters it, the two staying apart by the reducer's
+`owner`, so the bar splits the figure directly above it and never the hero; it is absent when no
 subagent ran, because the row it explains is absent then too. The split is charged per CALL, not
 per agent: `subagent-meta` names one model per agent, but a subagent transcript can run on more
 than one family, and charging the whole volume to the declared model misattributes every token it
 spent elsewhere. An estimated volume, having no per-call detail, lands wholly on the agent's own
-model — the split always totals the row.
+model, so the split always totals the row.
 
 Summing per SCOPE, not per last call, is load-bearing: within a single call `cache_read`
 is the entire conversation prefix while `cache_creation` is only the newest increment,
 and a turn's LAST call is its cheapest (the final answer adds almost nothing), so a
 last-call reading understates a turn that re-created hundreds of thousands of tokens.
-**A line is not an API call.** Claude Code writes ONE LINE PER CONTENT BLOCK — thinking,
-each `tool_use`, text — and every one of those lines repeats the SAME `usage` block.
+A line is not an API call. Claude Code writes ONE LINE PER CONTENT BLOCK: thinking,
+each `tool_use`, text, and every one of those lines repeats the SAME `usage` block.
 Anything summed over calls therefore folds once per `message.id` (carried on the
 event as `callId`, with the `seq` as fallback for `<synthetic>` lines that have no id):
 `cacheTotals`, `inputTotal`, `outputTotal`, and `apiCalls`. Summing per LINE multiplies
 each call by its block count. The same guard also absorbs the stream's high-water re-send after a reconnect
-(`stream.ts` guards with `seq <`), which a SUM — unlike everything set-shaped in the
-reducer — would otherwise double-count.
-**And not every `usage` line is a call at all.** Claude Code's auto-continue receipt carries a full
+(`stream.ts` guards with `seq <`), which a SUM, unlike everything set-shaped in the
+reducer, would otherwise double-count.
+And not every `usage` line is a call at all. Claude Code's auto-continue receipt carries a full
 usage block, all zeros, having reached no model. The parser marks it `noCall`, and the reducer
-withholds `newCall` from it — not merely the counter, because `newCall` is the ONE signal that says
+withholds `newCall` from it, not merely the counter, because `newCall` is the ONE signal that says
 a fresh call happened and three surfaces read it: the header's count, the feed's row and the Trace's
 `api` span (with `callMs`, a latency that would be measured to a line that never called anything).
 Excluding it from the counter alone left the three disagreeing on screen. A FAILED call is not the
-same thing and raises all three — it reached the API. The two are told apart by `isApiErrorMessage`,
+same thing and raises all three: it reached the API. The two are told apart by `isApiErrorMessage`,
 never by the model: both are `<synthetic>`, and both report zero tokens.
 
 Every file-tailed event also carries a **`seq`**: a per-file line number assigned
 by whoever reads the lines (the watcher for the live tail, the replay reader for
 history). It is a POSITION, not a counter, so it rises with the tail and restarts
 with it: when a file shrinks, the tailer re-reads from offset 0 and the watcher
-resets the number in the same step — a re-delivery from 0, which the guards below
+resets the number in the same step, a re-delivery from 0 which the guards below
 already handle. (No Claude Code path produces that: compaction, `--resume` and
 `/rewind` all append, the last forking the DAG by appending a branch. The reset
 keeps the two ends of one fact together, and covers an edit from outside.)
-One `seq` per source line — a line yielding several events
+One `seq` per source line, so a line yielding several events
 (e.g. `usage` + `attribution` + `tool-start`) shares one `seq`. Out-of-band events
 carry `seq < 0` (a `subagent-meta` read from `meta.json` has no line position),
 and the reducer folds those idempotently.
@@ -687,12 +687,12 @@ a client keeps, and the exact test each one applies, are the wire contract:
 ## Consumers
 
 The core makes no assumptions about transport or rendering. A consumer imports
-the watcher, subscribes to its events, and renders them — a terminal UI, or a
+the watcher, subscribes to its events, and renders them: a terminal UI, or a
 locally-served web GUI. Keeping the transport out of the core is what lets the
 same event feed drive every front-end.
 
 Consumers fold the event stream with the **session-tree reducer**
-(`apps/server/src/core/session-tree.ts`) — the browser over a live stream, the corpus scanner
+(`apps/server/src/core/session-tree.ts`): the browser over a live stream, the corpus scanner
 over one file at a time: it maintains the main fill + token breakdown,
 each subagent (fill, model, state, launch prompt, returned output, tool calls,
 real duration), main and per-subagent tool nodes (name, duration, argument,
@@ -701,40 +701,40 @@ callers an immutable `snapshot()`. It exposes `onChange(cb)` (a bare "something
 changed" signal, for rendering) **and** `onEvent(cb, ctx)` (each applied event, for
 per-event UI like toasts and the activity feed). `onChange` carries **no payload**: a
 listener pulls `snapshot()` itself, when it is actually about to paint. Carrying one
-per event makes folding a session O(n²) — `snapshot()` is O(turns + tools + agents) —
+per event makes folding a session O(n²), while `snapshot()` is O(turns + tools + agents), so
 and the view, which coalesces its paints, would throw every one of them away. `ctx.turnIndex`
 is the turn the event belongs to: the reducer is
 the only layer that knows it (events carry no turn), and for a subagent's event it is
 the turn that *spawned* the subagent, so an async subagent outliving its turn still
 counts against the turn that asked for it.
 
-**The timeline holds everything the user sent, and each entry is classified by what it
-COST — never by its name.** A typed prompt and a slash command are indistinguishable in
+The timeline holds everything the user sent, and each entry is classified by what it
+COST, never by its name. A typed prompt and a slash command are indistinguishable in
 intent (`/paste-image fix this` is a prompt with a helper attached) but not in the log: a
 slash command carries no `origin`. Gating turns on `origin.kind: 'human'` therefore drops
-every one of them — a `/paste-image` round gets no turn at all, so nothing is live while
+every one of them: a `/paste-image` round gets no turn at all, so nothing is live while
 Claude works and its `turn_duration` lands on the previous turn. The parser reports what was
 sent and leaves the classification to the reducer, which decides from the
 token count (`TurnKind`):
-- **`work`** — it consumed tokens: typed prompts, and commands that run the model.
-- **`local`** — a command that closed without burning a single token, without an Esc, and
+- **`work`:** it consumed tokens, meaning typed prompts and commands that run the model.
+- **`local`:** a command that closed without burning a single token, without an Esc, and
   without launching an agent (`/model`, `/effort`). Cost through an agent is cost: a forked
   skill such as `/code-review` makes no call on this thread, so the token count alone would
   file it here. No list of local built-ins is kept anywhere: the token count is the proof,
   and it cannot go stale as Claude Code adds commands.
-- **`context`** — `/clear` and `/compact`, the two commands whose job IS to move the context
+- **`context`:** `/clear` and `/compact`, the two commands whose job IS to move the context
   window. A closed, intrinsic pair; `/compact` costs real tokens, so cost cannot separate it
-  from a work turn — only intent can, which is why these two names appear in the code.
+  from a work turn; only intent can, which is why these two names appear in the code.
 
-**Whose line it is is decided before what shape it has.** A headless `claude -p` line carries no
+Whose line it is is decided before what shape it has. A headless `claude -p` line carries no
 `origin` either, so reading the shape first would file `claude -p "/review
-this"` as a slash command — and turn detection keeps a command while it deliberately drops an sdk
+this"` as a slash command, and turn detection keeps a command while it drops an sdk
 prompt, so a headless run would grow a turn it never had. `promptSource` is therefore read ahead of
 both shapes rather than guarded inside one: an sdk line stays an sdk line and still names its
 session with the command's arguments.
 
-**A command is written in one of TWO shapes, and both are the user sending something.** The
-familiar one is the expansion — `<command-message>` / `<command-name>` / `<command-args>`. The other
+A command is written in one of TWO shapes, and both are the user sending something. The
+familiar one is the expansion: `<command-message>` / `<command-name>` / `<command-args>`. The other
 is the command exactly as it was typed, in plain text (`/code-review del diff`), with no `origin`, no
 `promptSource` and no tags. It is the rarer of the two, and reading only the tagged shape loses the
 whole round: the command gets no turn at all and its work is credited to the previous one. The gate
@@ -742,18 +742,18 @@ for the plain shape is
 `origin` **absent** (a task-notification is a `user` line with an origin of its own) and not
 `isMeta`, and the line must be a command and nothing else, anchored at both ends.
 
-**One invocation can write BOTH shapes, and they share a `promptId`.** The reducer folds them into
+One invocation can write BOTH shapes, and they share a `promptId`. The reducer folds them into
 one turn, keyed by `promptId` **and the command name**: a prompt QUEUED while a command runs
 inherits that command's `promptId`, so deduping on the id alone would swallow a human turn to save
 a duplicate one.
 
 `state: 'live'` means **working**, not merely open: an entry goes live only once it has
-consumed a token, or while an agent it launched is still running. Otherwise a `/model` —
+consumed a token, or while an agent it launched is still running. Otherwise a `/model`,
 which opens an entry and is never closed by a
-`turn_duration` — would pulse green forever. `turns` counts `work` entries only, so it keeps
+`turn_duration`, would pulse green forever. `turns` counts `work` entries only, so it keeps
 meaning "rounds of work" even though the timeline shows more than those.
 
-Skill and command counts exist twice, and deliberately: once for the session and once
+Skill and command counts exist twice: once for the session and once
 inside each `TurnNode`. A widget scoped to a turn reads the turn's own counts, so it
 can never show a session-wide number (`/clear ×3`) on a turn that used it once. Both
 are built by the same helper, so their shape and ordering cannot drift.
@@ -761,46 +761,46 @@ are built by the same helper, so their shape and ordering cannot drift.
 **The live intent panel (V1)** answers "what is the agent trying to do right now" from a datum
 the model already writes: a main-session `assistant` line that carries a **text block** but
 is **not** the turn's end (`stop_reason !== "end_turn"`) is mid-turn **narration**. The parser emits it as a `turn-narration`
-event (main session only — a subagent's narration has no consumer); the reducer keeps the
+event (main session only, since a subagent's narration has no consumer); the reducer keeps the
 latest per turn (`TurnNode.lastNarration`, last wins). The panel sits between the Live activity
-header and the feed; it shows the current intent — or the turn's final output (`TurnNode.result`)
-once the `end_turn` answer lands — and its age. The text is clamped to two lines; when it
+header and the feed; it shows the current intent, or the turn's final output (`TurnNode.result`)
+once the `end_turn` answer lands, and its age. The text is clamped to two lines; when it
 overflows, a `more` (revealed by measuring overflow after layout) opens the full text, rendered,
 in the output modal. No LLM: the extraction is pure, because the harness already makes the model
 narrate in short phrases. The activity feed below trades rows for the panel so the card's height
-barely moves — its visible cap drops as the panel grows, measured from the panel's line count after
-layout, while the ring still retains `FEED_CAP` = 13 for the drawer — with the full history in
+barely moves: its visible cap drops as the panel grows, measured from the panel's line count after
+layout, while the ring still retains `FEED_CAP` = 13 for the drawer, with the full history in
 Expand all and the Trace.
 
-**What the agent DID since it last spoke outranks what it said — once its words have had their
-moment.** A narration alone leaves the panel stale, not empty: one narration can stand unchanged
-for minutes while tool calls run under it. So the panel also carries an **activity group** — one
+What the agent DID since it last spoke outranks what it said, once its words have had their
+moment. A narration alone leaves the panel stale, not empty: one narration can stand unchanged
+for minutes while tool calls run under it. So the panel also carries an **activity group**: one
 line counting the turn's calls since its last word (`TurnNode.activity`, `ActivityGroup`).
 
 The handover is **not** immediate, and that is the whole difference between a live panel and an
 unreadable one. A narration is frequently the newest thing that happened for only a second or two,
 so giving the panel to the group on the turn's first call makes every narration flash past: the
 words are there and nobody can finish them. The last word (via `TurnNode.lastWordTs`) therefore
-holds the panel — for **as long as that particular word takes to read**, `narrationHoldMs` in
-`apps/server/src/core/activity-line.ts` — and only then does the group take over, for as long as
+holds the panel for as long as that particular word takes to read (`narrationHoldMs` in
+`apps/server/src/core/activity-line.ts`) and only then does the group take over, for as long as
 the silence lasts.
 
 The hold is `chars / 17 per second`, floored at 3s and capped by what the panel can actually SHOW:
 `.nowtext` is `-webkit-line-clamp: 2`, so past the two visible lines the text sits behind `more`
-and no amount of holding reveals it. A flat hold is wrong in both directions — the short
+and no amount of holding reveals it. A flat hold is wrong in both directions: the short
 narrations, which are the majority, are read long before it expires, and the long ones are cut off
-mid-sentence — which is why the hold is derived from the text rather than fixed. It runs from the
+mid-sentence, which is why the hold is derived from the text rather than fixed. It runs from the
 word's **first sighting**, never from its timestamp: Claude Code stamps a text block when it starts
 generating it but appends the line only once the block closes, so counting from the stamp spends
 most of the hold before the panel has anything to show. Because no event announces the deadline
-passing, the panel arms one entry on the shared 1s ticker that re-runs its own decision — and since
+passing, the panel arms one entry on the shared 1s ticker that re-runs its own decision, and since
 that makes it the one surface re-rendering OUTSIDE `render()` (which is what clears the counters),
 its counters carry `owner: 'now'` and it reclaims them on each pass. Without that reclaim the
 ticker list grows by an entry or two a second between events, each re-written on every tick.
 Three rules define the group itself:
 
-- **Derived, never accumulated.** The group is read off the tool ledger — a call counts when it
-  started after the turn's `lastWordTs`, the later of its last narration and its final output —
+- **Derived, never accumulated.** The group is read off the tool ledger: a call counts when it
+  started after the turn's `lastWordTs`, the later of its last narration and its final output,
   never tallied as events arrive, so a reconnect's re-sent line rewrites the same ledger entry
   instead of double-counting it. Because `snapshot()` runs on every event, the derivation is
   **memoised per turn** (`groupCache`) over a per-turn index of call ids (`toolIdsByTurn`), and a
@@ -808,10 +808,10 @@ Three rules define the group itself:
   or ended, or the turn spoke (`dirtyGroups`). Walking the whole ledger on every snapshot instead
   costs a large session's replay a double-digit percentage of its time; memoised, the derivation is
   free. A cache like this can only be tested by asking
-  for the snapshot after EVERY event, which is what the golden transcript does — a test that
+  for the snapshot after EVERY event, which is what the golden transcript does, and a test that
   snapshots once at the end cannot see a stale group.
-- **The group empties itself.** Any word from the agent — a new narration, or the turn's
-  `end_turn` answer — moves the cutoff, so the panel hands itself straight back to the agent's
+- **The group empties itself.** Any word from the agent, a new narration or the turn's
+  `end_turn` answer, moves the cutoff, so the panel hands itself straight back to the agent's
   voice, and a turn that ended normally has no group at all.
 - **Main session only.** A subagent's calls carry no `turnIndex` by construction, so they stay in
   their own lane instead of inflating the main panel.
@@ -827,7 +827,7 @@ the age chip, so the text does not move with the clock and needs no ticker entry
 The **age chip times the running CALL**, not the group: it answers "is something still going, and
 for how long", in the same unit as the feed rows below so the two read as one card. It shows the
 oldest call open for at least `RUNNING_AFTER_MS` = 1s (a lower bar would flash and vanish: most
-calls finish in a fraction of a second), and is otherwise ABSENT — most of a group's life has no
+calls finish in a fraction of a second), and is otherwise ABSENT, since most of a group's life has no
 call open that long, and the panel then shows the count with no number. A call crossing the
 one-second mark is nobody's event, so that chip appears on the shared 1s ticker.
 
@@ -838,7 +838,7 @@ flight at all. The chip times the slow calls, which are the ones worth timing.
 The line is seedeep counting, not the agent speaking, so it wears the same quote-less `.plain`
 voice as the waiting panel. Capped at three families it stays inside the two-line clamp, but the
 deferred overflow measure can still add `clamped` after the panel has rendered, which reveals
-`more` — so `more` opens the line in full rather than being left inert.
+`more`, so `more` opens the line in full rather than being left inert.
 
 The set of SSE event types the browser listens for lives in **one shared list**,
 `apps/server/src/client/event-types.ts`, imported by both the live stream (`stream.ts`) and
@@ -850,14 +850,14 @@ paths from drifting (a new event type wired to one but not the other).
 
 The web GUI is served by a small local server that bridges the watcher to the
 browser. It is a single process: the watcher tails the session files while the
-server streams what it emits to the page. There is no daemon — it runs while you
+server streams what it emits to the page. There is no daemon: it runs while you
 watch and stops on Ctrl-C.
 
 ```text
 watcher (EventEmitter) ──▶ server ──▶ browser
                             │  ├─ GET  /                  static page
-                            │  ├─ GET  /api/sessions      roster CATALOGUE — every session, stable half (JSON)
-                            │  ├─ GET  /api/live          roster LIVE half — running sessions (JSON, polled)
+                            │  ├─ GET  /api/sessions      roster CATALOGUE: every session, stable half (JSON)
+                            │  ├─ GET  /api/live          roster LIVE half: running sessions (JSON, polled)
                             │  ├─ GET  /api/digest        live DERIVED state per live session (JSON, polled)
                             │  ├─ GET  /api/session-stats per-session turn count (JSON)
                             │  ├─ GET  /api/stream        live events (SSE)
@@ -878,35 +878,35 @@ watcher (EventEmitter) ──▶ server ──▶ browser
                             │  └─ POST /api/restart       hand the port over to a successor
 ```
 
-Session data is deliberately one-directional: the server only ever pushes it to
+Session data is one-directional: the server only ever pushes it to
 the browser, and nothing seedeep reads is ever written back. The browser does
-POST two things — `/api/config` and `/api/restart` — and both act on seedeep's OWN
+POST two things, `/api/config` and `/api/restart`, and both act on seedeep's OWN
 state (its config file, its own process). The invariant is about the corpus, not
 about the socket.
 
-**Every route, its parameters, its responses, its status codes and the SSE wire format
-are in [api.md](api.md).** What follows is only why the surface has the shape it does.
+Every route, its parameters, its responses, its status codes and the SSE wire format
+are in [api.md](api.md). What follows is only why the surface has the shape it does.
 
 ### The roster is served in two halves
 
 Split by how fast each half changes. The catalogue carries only the fields that stop changing once
 a session's file exists, so a client fetches it once at boot and revalidates with an ETag; the live
 half carries the running sessions in full and is the only thing a client polls. That split is what
-makes polling affordable — the catalogue grows with every session ever written, the live half stays
+makes polling affordable: the catalogue grows with every session ever written, the live half stays
 a handful of records, and every additional client would otherwise pay the whole corpus again every
 few seconds.
 
 `core/roster.ts` owns both projections and the merge that rebuilds the whole (`toCatalogue`,
 `liveOf`, `mergeRoster`); the client reassembles inside `createRoster`, so every consumer above it
 still receives one plain roster. `mergeRoster` recomputes `isActive` from `lastActivity` and
-re-sorts by it, because both are derived — the split must not transport what it can derive, nor
+re-sorts by it, because both are derived: the split must not transport what it can derive, nor
 freeze an order that keeps moving. The contract that keeps this safe is
 `mergeRoster(catalogue, live) === roster`, asserted in `apps/server/tests/roster.test.ts` against
 fixtures and against a real roster from the machine running the tests.
 
-**A catalogue record taken while its session was live is PROVISIONAL**: its `subject` can predate
+A catalogue record taken while its session was live is PROVISIONAL: its `subject` can predate
 the first prompt, its `model` the first API call, and its `lastActivity` is `null` by construction.
-So a client refetches the catalogue on either of two signals, not one — the count changed (a session
+So a client refetches the catalogue on either of two signals, not one: the count changed (a session
 was born), **or** it holds a provisional record for a session the live payload has dropped (a
 session ended). Size alone cannot see the second, because a finished session keeps its file.
 
@@ -914,9 +914,9 @@ session ended). Size alone cannot see the second, because a finished session kee
 `current()` feeds the dropdown, so a row parked behind an unchanged key becomes a stale tab, while
 `onChange` redraws the picker, so firing it on every moved mtime would redraw forever.
 
-**Every reading runs under a 10 s deadline, and the poll's own liveness depends on it.** The next
+Every reading runs under a 10 s deadline, and the poll's own liveness depends on it. The next
 poll is armed when the current one settles, and `fetch` has no timeout of its own: a request sent
-down a half-open connection settles *never* — the browser has nothing to retransmit, so it waits for
+down a half-open connection settles *never*, since the browser has nothing to retransmit and waits for
 an answer that cannot come, and the picker, the busy dot, ended-detection and auto-open freeze
 together until the page is reloaded by hand. On expiry the request is aborted (a poll every 3 s
 would otherwise pile up sockets nobody will answer) and the reading fails into the existing "keep
@@ -928,16 +928,16 @@ the user actually had.
 
 ### The digest exists for a client that does not own the reducer
 
-`/api/stream` and `/api/replay` carry `NormalizedEvent`s — parsed lines, not meaning — so a client
+`/api/stream` and `/api/replay` carry `NormalizedEvent`s, parsed lines rather than meaning, so a client
 that wants to know what a session is DOING has to fold them itself. The digest is the answer for a
 client that cannot: derived state, already cooked, one entry per live session. The tray is the
 reason it exists.
 
 Three rules make an entry trustworthy:
 
-- **An entry is a JOIN, not a second derivation.** Every number in it comes from the same reducer
+- An entry is a JOIN, not a second derivation. Every number in it comes from the same reducer
   the browser runs, so the two surfaces cannot disagree about the same session.
-- **`turn.now` is `nowLine`'s answer, not a second one** (`apps/server/src/core/activity-line.ts`).
+- `turn.now` is `nowLine`'s answer, not a second one (`apps/server/src/core/activity-line.ts`).
   The browser's NOW panel calls that same function on the same inputs, so the rule about what a
   session is doing exists ONCE for both surfaces. The digest's copy is markdown-stripped and cut,
   because it serves clients that render no markdown and have no modal to open the full text in.
@@ -951,32 +951,32 @@ client that draws fewer is making that choice itself.
 ### One stream, and the four things that keep it connected
 
 Every event the watcher emits, across all sessions, is framed and pushed on **one** multiplexed SSE
-connection, each frame carrying its `sessionId`. One stream — not one per session — means opening or
+connection, each frame carrying its `sessionId`. One stream, not one per session, means opening or
 closing a view is pure client-side state and never leaks a connection.
 
 The stream also carries the one event the watcher does not emit: **`notification`**, the server's
 own verdict that something is worth interrupting the user for. The transition detector
 (`notify-watch.ts`) folds each reading of the digest and the engine (`notify-engine.ts`) gates its
-output per channel — the tray subscribes here, a configured webhook is POSTed to instead. The
+output per channel: the tray subscribes here, a configured webhook is POSTed to instead. The
 switches filter that output and never the detector's input, so turning one back on announces what
 happens next and not the backlog it slept through. Evaluation is skipped entirely when nobody is
 subscribed and no webhook is configured, which is what keeps an unwatched process idle.
 
-**Staying connected is not free**, and SSE does not give reconnection for free on its own. Four
+Staying connected is not free, and SSE does not give reconnection for free on its own. Four
 mechanisms make it true, each covering a failure the others do not:
 
 - **Heartbeat.** Every 15 s the server writes a `heartbeat` event to each client. A session can be
   silent for minutes (a background subagent writes only to its own file), and a connection carrying
-  nothing looks exactly like one that has died. It is a named *event* and not an SSE comment — a
+  nothing looks exactly like one that has died. It is a named *event* and not an SSE comment, because a
   comment reaches the socket but never the page, and the client's watchdog has to be able to hear
-  it — and it carries no `id:`, so it never shifts the numbering of the real events.
-- **A failed write closes the stream.** Evicting a dead client from the registry is not enough: the
+  it, and it carries no `id:`, so it never shifts the numbering of the real events.
+- A failed write closes the stream. Evicting a dead client from the registry is not enough: the
   browser is never told, so its `EventSource` stays `OPEN`, fires no error and never reconnects.
-  `ClientRegistry` closes the controller, which ends the response — the only thing the browser can
+  `ClientRegistry` closes the controller, which ends the response, the only thing the browser can
   act on.
-- **The client owns its reconnect.** `EventSource` retries by itself only while it is still
+- The client owns its reconnect. `EventSource` retries by itself only while it is still
   `CONNECTING`; a fatal error leaves it `CLOSED` for good. `stream.ts` watches `readyState`,
-  rebuilds the connection, and reports every transition through `onStatus` — the header pill is the
+  rebuilds the connection, and reports every transition through `onStatus`, so the header pill is the
   only thing on screen that speaks about the connection, since a card's `live` badge reports whether
   the SESSION is running.
 - **A watchdog on the heartbeat**, so a connection that is `OPEN` but silent is treated as lost.
@@ -985,7 +985,7 @@ A client recovers what it missed with `/api/replay?from=`, not by asking the str
 is no backlog and no `Last-Event-ID` handling. The `seq` marks that make live and replay safe to
 overlap are the wire contract, and they are specified in [api.md](api.md#the-sse-protocol).
 
-The replay→live seam is deliberately the server's business only up to the frame: the browser's
+The replay→live seam is the server's business only up to the frame: the browser's
 driver (`client/replay.ts`) decides what to drop, because only it knows what it has already folded.
 
 ### Reading one thing back
@@ -993,23 +993,23 @@ driver (`client/replay.ts`) decides what to drop, because only it knows what it 
 `/api/tool-output`, `/api/call-io`, `/api/agent-prompt`, `/api/commits`, `/api/files` and
 `/api/cards` all name a session and read it on demand rather than holding it in memory.
 
-**The path always comes from the roster, never from the query.** A caller can only name a session
-seedeep already discovered, so no path outside the corpus is reachable — this is the property that
+The path always comes from the roster, never from the query. A caller can only name a session
+seedeep already discovered, so no path outside the corpus is reachable. This is the property that
 makes the whole family safe to expose.
 
 ### The aggregate cache
 
 The **minute-zero retrospective**: corpus-wide aggregates shown on the Home surface at launch,
 without waiting for a live turn (`apps/server/src/server/aggregate-cache.ts`). It runs the real
-parser, reducer and verdict per session — the same code the live path runs, so the cache's numbers
+parser, reducer and verdict per session, the same code the live path runs, so the cache's numbers
 and the GUI's cannot diverge.
 
-**It reads each session's subagent transcripts too**, through `streamReplay`. Reading the parent
+It reads each session's subagent transcripts too, through `streamReplay`. Reading the parent
 alone leaves a large share of the corpus's billable tokens out of every aggregate, because a
 subagent writes its own file. Invalidation therefore stamps the children as well
 (`subagent-files.ts`, `subagentStamp`): a child can be written when the parent is not, and the
 parent's `(size, mtime)` alone would serve a summary missing that child. Where those files live is
-defined once, in `subagent-files.ts`, and both replay and the cache read it from there — including
+defined once, in `subagent-files.ts`, and both replay and the cache read it from there, including
 the Workflow run ids, which come from the directory rather than from the transcripts inside it: a
 run writes its `journal.jsonl`, the only record that a workflow subagent started or stopped, before
 its agents' transcripts exist.
@@ -1028,32 +1028,32 @@ ranks SESSIONS against each other in a time window.
 The unit is a **weighted token count** (`apps/server/src/core/token-weight.ts`), never a cost in
 currency. Every API call is weighted twice and summed over the session and its subagents:
 
-- **Per token type** — `cache read ×0.1 · cache write ×2 · input ×1 · output ×5`. Anthropic
+- **Per token type:** `cache read ×0.1 · cache write ×2 · input ×1 · output ×5`. Anthropic
   publishes these, expressed in tokens, as the Priority Tier burndown rates
   ([Service tiers](https://platform.claude.com/docs/en/api/service-tiers)): *"These burndown rates
   reflect the relative pricing of each token type."* Cache writes take the **1-hour** rate (2.00,
   not the 5-minute 1.25) because the cache lifetime is an hour on a subscription.
-- **Per model** — Haiku ×1 · Sonnet ×2–3 · Opus ×5 · Fable ×10, derived from the price list and
+- **Per model:** Haiku ×1 · Sonnet ×2–3 · Opus ×5 · Fable ×10, derived from the price list and
   **seedeep's own**: Anthropic publishes no cross-model token ratio, and structurally never needs
-  one (it partitions budgets — a separate Opus limit, Priority Tier commitments per model version).
+  one (it partitions budgets: a separate Opus limit, Priority Tier commitments per model version).
   The surface states this distinction rather than hiding it. An unrecognised model id weighs **0**,
   never an invented ratio; a merely NEWER id falls back to its family, so a future `claude-opus-9-9`
   is not silently free.
 
-Weighting is applied **once per call**, inside the reducer's existing per-`callId` guard — Claude
+Weighting is applied **once per call**, inside the reducer's existing per-`callId` guard, because Claude
 Code repeats a call's usage block on every content-block line, so weighing per line would multiply
 a call by its block count. `main.weighted` and `weightedSubagents` are kept apart (the two sides of
-the reducer's `owner === null` branch) and summed deliberately.
+the reducer's `owner === null` branch) and summed together.
 
-**A session's weight is whole-session, not Σ its turns.** `SessionSummary.turns` holds only closed
-WORK turns — right for a turn retrospective, wrong for a session total: an unclosed final turn, or
+A session's weight is whole-session, not Σ its turns. `SessionSummary.turns` holds only closed
+WORK turns, right for a turn retrospective and wrong for a session total: an unclosed final turn, or
 an sdk session (which never writes `turn_duration`), would contribute nothing.
 
 ## Post-turn verdict
 
 At the end of every turn, seven **deterministic** detectors (zero LLM) run over data the snapshot
 already holds (`apps/server/src/core/verdict.ts`): a **wasted subagent** (a large output returned to
-main — a heuristic lower bound), **compaction** mid-turn, a second consecutive **Esc**, a cold
+main, a heuristic lower bound), **compaction** mid-turn, a second consecutive **Esc**, a cold
 **resume**, a **context** fill ≥70% of the model's window, an **exploration** (≥8 files read into
 main with nothing changed and nothing delegated), and an **unverified ship** (real code committed
 with no check run anywhere earlier in the session). The worst finding sets the turn's severity
@@ -1062,17 +1062,17 @@ with no check run anywhere earlier in the session). The worst finding sets the t
 
 Three rules constrain what may become a detector:
 
-- **Every detector cites a public source.** A rule defensible only by one user's private
+- Every detector cites a public source. A rule defensible only by one user's private
   conventions is a rule written for one user, and seedeep ships to other people; the quote lives
   next to the threshold in `verdict.ts`.
-- **No detector compares a turn to the user's other turns.** A turn that spends more because it
+- No detector compares a turn to the user's other turns. A turn that spends more because it
   DID more is not waste, and a personal-baseline comparison reports size rather than waste.
-- **A rule looks only BACKWARD.** Only the *second consecutive* interruption is a finding: a turn
+- A rule looks only BACKWARD. Only the *second consecutive* interruption is a finding: a turn
   that turns out to be the first of a streak is a lone Esc at the moment it closes, and a
   forward-looking rule would make a finding appear retroactively on a turn already rendered. A lone
   Esc is prescribed practice, not a defect.
 
-**A finding costs nothing to compute**: every detector reads the snapshot the reducer already
+A finding costs nothing to compute: every detector reads the snapshot the reducer already
 produced, in one pass, so the verdict cannot become a reason to keep data around.
 
 ## The GUI shell
@@ -1098,54 +1098,54 @@ Four of their properties belong to the shell rather than to what they draw: **Se
 nothing on switch, having no answer until there is a question; **Compare** fetches on tab switch
 rather than at boot, so a launch landing on a session tab does not pay for a corpus refresh;
 **Home** is never closable, so an empty workspace never reads as a broken page, and its classes are
-all `rt-`-prefixed because the stylesheet has no CSS scoping; and **a row opens the session it
-describes** through the picker's own `openFromDropdown`, so a row and a pick cannot open a session
+all `rt-`-prefixed because the stylesheet has no CSS scoping; and a row opens the session it
+describes through the picker's own `openFromDropdown`, so a row and a pick cannot open a session
 two ways.
 
-**`apps/server/src/client/` is rendering and transport; the meaning it draws comes from
-`apps/server/src/core/`.** What lives under `client/` is the DOM (the shell, the bento, the Trace,
+`apps/server/src/client/` is rendering and transport; the meaning it draws comes from
+`apps/server/src/core/`. What lives under `client/` is the DOM (the shell, the bento, the Trace,
 the widgets), the SSE plumbing (`stream.ts`, `replay.ts`, `event-types.ts`) and browser-local state
 (`tab-store.ts`, `end-guard.ts`, the client half of the roster split). Everything that turns events
 into meaning is core, and the test for which side a module belongs on is not "does it compile in a
-browser" — it is **whether it derives**. A module that reduces or selects goes in `core/`; a module
+browser": it is **whether it derives**. A module that reduces or selects goes in `core/`; a module
 that paints, listens or remembers stays in `client/`. That is also the only rule for splitting one:
 `graph.ts` is the client's largest module and stays one, because splitting it per widget would hand
 the drawer alone **25** bindings out of `createGraph`'s closure, and a module taking 25 parameters
-is the same closure with a form to fill in — what DID come out is `graph-derive.ts`, the pure
+is the same closure with a form to fill in. What DID come out is `graph-derive.ts`, the pure
 derivations, with session state (`ended`, the clock) as a parameter. Extract what becomes
 *testable*, not what merely becomes *shorter*.
 
-**The client ships as one bundle.** `index.html` loads a single module, so there is exactly one
+The client ships as one bundle. `index.html` loads a single module, so there is exactly one
 entry point: `bun run build:client` bundles `apps/server/src/client/app.ts` into
 `apps/server/public/lib/app.js` (committed, so the repo runs without a build step), and
 `apps/server/public/` therefore holds only the page, its stylesheet (`public/css/`, one file per
-sub-feature, `<link>`ed in cascade order) and that artifact. The rule the layout enforces: **a
-shared module is resolved once.** Registering each module as its own entry point bundles it
-independently — a module imported by two entries is inlined into both, so the page loads two copies
+sub-feature, `<link>`ed in cascade order) and that artifact. The rule the layout enforces: a
+shared module is resolved once. Registering each module as its own entry point bundles it
+independently: a module imported by two entries is inlined into both, so the page loads two copies
 of the same reducer. Adding a module is free (import it; the bundler follows).
 
 The tab rules:
 
-- **A session that starts gets a tab — once.** One rule covers the first visit and every session
+- A session that starts gets a tab, once. One rule covers the first visit and every session
   started later: a live, interactive session not offered before opens a tab. "Offered" is
   remembered (`known`, persisted next to the tab set), which separates *offer it once* from *reopen
-  what I closed* — a closed tab is gone from the tab set but stays in `known`, so it never returns,
+  what I closed*: a closed tab is gone from the tab set but stays in `known`, so it never returns,
   not on the next poll and not after a refresh; `known` is pruned to the live sessions, since one
   that has ended can never re-trigger. It opens in the **background** (the exception is an empty
   screen, where a tab nobody is looking at would leave the page blank), and **automated runs are
   excluded**, since a headless `claude -p` registers as an open session for the length of its run
   and would otherwise pop a content-less tab on every git push.
-- **The workspace survives a refresh.** The open tabs, their order and the active one are saved to
+- The workspace survives a refresh. The open tabs, their order and the active one are saved to
   `localStorage` on every change and restored at boot, and the saved set decides which tabs
-  **exist**, so a tab you closed stays closed. Storage is best-effort — guarded at the access, not
-  only at the call, because reading `localStorage` throws outright where storage is disabled — and
+  **exist**, so a tab you closed stays closed. Storage is best-effort, guarded at the access rather than
+  only at the call, because reading `localStorage` throws outright where storage is disabled, and
   a dead storage degrades to opening the live sessions, the first-visit behaviour.
-- **A tab says which session it is, and its state is never words.** The label is
+- A tab says which session it is, and its state is never words. The label is
   `<project> · <subject>`, the subject cut to 30 chars, because the project alone cannot tell two
   sessions of one project apart; state rides on other channels (pulse, dimming) since `· ended`
   eats the room the subject needs, with the `title` spelling it out for assistive tech so a class
   is never the only channel.
-- **The picker pins what is already open**, since picking such a session switches to its tab rather
+- The picker pins what is already open, since picking such a session switches to its tab rather
   than opening a second. The pin is pushed by `app.js` on every open/close: the roster's identity
   key is built from the sessions themselves (id, liveness, status, subject), so it does not change
   when a tab opens and could never drive this.
@@ -1154,53 +1154,53 @@ And the connection rules:
 
 - **One shared live connection.** The whole GUI opens a single `/api/stream` `EventSource`; a
   client-side router dispatches each event to the tab that subscribed to its `sessionId`. Opening
-  or closing a tab only mutates a handler map — it never opens or closes a connection, so tabs
-  cannot leak feeds. **Replay is separate and ephemeral**: each replay opens its own `/api/replay`
+  or closing a tab only mutates a handler map and never opens or closes a connection, so tabs
+  cannot leak feeds. Replay is separate and ephemeral: each replay opens its own `/api/replay`
   `EventSource` that self-closes at `replay-end`.
 - **Active tab = replay then live.** An active tab first subscribes to the live feed but buffers
   it, replays its history from the start (so the view shows the real accumulated fill immediately),
-  then flushes the buffered live events the replay did not already emit — deduped on
-  `(sessionId, seq)` — and continues live, losing no event written during the replay and doubling
+  then flushes the buffered live events the replay did not already emit, deduped on
+  `(sessionId, seq)`, and continues live, losing no event written during the replay and doubling
   none. Until the replay ends the tab shows a skeleton loader and the views paint **nothing**: the
   Graph absorbs every event but draws only at the handoff, in a single pass, because a large
   session's history is thousands of events and painting through that flood rebuilds the whole bento
-  per coalesced tick. The loader cannot hang — `startReplay` fires the handoff exactly once, on
+  per coalesced tick. The loader cannot hang: `startReplay` fires the handoff exactly once, on
   `replay-end`, on a dead connection, or on `stop()`.
-- **A read that was CUT reopens itself**, after a wait that doubles up to 30s, until one reaches
-  `replay-end` — the only frame that says the history is all here. The loss a cut causes is not
+- A read that was CUT reopens itself, after a wait that doubles up to 30s, until one reaches
+  `replay-end`, the only frame that says the history is all here. The loss a cut causes is not
   spread evenly: the server sends the parent transcript whole and only then each child, so a cut in
   the child phase costs every subagent and no main-session line. The reopen asks only past what each
-  file holds **whole** — a line is several events sharing one `seq`, so the line a read died on is
-  never claimed — and requests whole any file the tab has never seen, which is what makes the
+  file holds **whole**, since a line is several events sharing one `seq`, so the line a read died on is
+  never claimed, and requests whole any file the tab has never seen, which is what makes the
   children arrive complete. A tab whose session has ENDED needs this most: nothing else would ever
   ask again.
-- **Nothing the tab already holds is delivered twice.** A re-read is sent a line from its top, so
-  the tab counts how many of that line's events it holds and skips exactly that many — the same
+- Nothing the tab already holds is delivered twice. A re-read is sent a line from its top, so
+  the tab counts how many of that line's events it holds and skips exactly that many, the same
   offset-into-a-line the live path keeps, on the side that had none. It matters because the
   consumers are not idempotent, which is what the reducer's own idempotence hides: the feed appends
   a second row and re-points its index (so the first row never gets its duration), the Trace opens a
-  duplicate span stuck on `running`, and the toast rail — armed at the handoff — announces a tool
+  duplicate span stuck on `running`, and the toast rail, armed at the handoff, announces a tool
   that ran minutes ago. The record is of what is HELD, not a budget spent as it is used: a read that
   skips a line still holds it, and the read after that must skip it again.
-- **Until the history is complete, the live feed is HELD, not applied.** Two reasons, and the second
+- Until the history is complete, the live feed is HELD, not applied. Two reasons, and the second
   is the one that bites: a line from the file's tail applied before the middle would put the newest
   turn ahead of every turn that precedes it, and the resume mark reads the live frontier as proof
-  that everything below it is held — so a tab holding lines 0–2 and a stray line 500 would resume
+  that everything below it is held, so a tab holding lines 0–2 and a stray line 500 would resume
   from 499 and lose the middle for good, then reach `replay-end` and call itself complete. The
   reader keeps the loader a while longer, which is the truth. The handoff (`onLive`) waits for a read
-  that COMPLETES; `stop()` releases it too — including between two attempts, when no read is in
-  flight at all — since a closing tab has no later read to wait for.
-- **The reopen gives up on futility, never on a count.** A read that advances resets the counter, so
+  that COMPLETES; `stop()` releases it too, including between two attempts when no read is in
+  flight at all, since a closing tab has no later read to wait for.
+- The reopen gives up on futility, never on a count. A read that advances resets the counter, so
   a slow or flaky path is never penalised however many rounds it takes; three consecutive reopens
-  that gain no ground end it, because that read is not coming back — a server-side throw on one
+  that gain no ground end it, because that read is not coming back: a server-side throw on one
   line, a proxy cutting at a fixed byte count, a child file that will not open. It also gives up
   when the roster says the session is GONE: a deleted session answers 404 forever, and an
   `EventSource` cannot read a status, so it fires the same contentless `error` a dropped path does.
-  Either way it hands off what the tab holds — keeping the loader up for a history that is never
+  Either way it hands off what the tab holds, since keeping the loader up for a history that is never
   coming is the same freeze this replaced, reached from the other side. A tab that gave up keeps a
   history with a hole in it, so the live frontier stays untrusted for good (see the previous rule):
   a later resync asks from what was actually read. Giving up is a verdict on the attempts, never on
-  the tab: an ask from OUTSIDE — the live stream recovering, the session being resumed — is new
+  the tab: an ask from OUTSIDE (the live stream recovering, the session being resumed) is new
   information and starts its own budget, backoff and futility count both. Carrying the spent one
   made that recovery path a dead letter, abandoning the ask on its first cut with no retry at all.
 - **A live roster.** The roster is re-fetched on a light timer: a newly-born session appears in
@@ -1214,8 +1214,8 @@ toasts armed only after the replay hands off to live, so history never floods th
 exist and what each shows is [features.md](features.md). Four of its rules are structural, not
 visual:
 
-- **Every drawer is laid out the same way, and the order encodes rank**: a header (kind chip,
-  title, and an identity line carrying only what the entity IS — type, model, owner — never a
+- Every drawer is laid out the same way, and the order encodes rank: a header (kind chip,
+  title, and an identity line carrying only what the entity IS (type, model, owner) and never a
   measurement), then 2–3 KPI tiles for the facts it actually raises, then bars for anything that
   is a proportion, then the content blocks, then a `Details` list for bookkeeping. A fact the
   snapshot does not carry is DROPPED, never rendered as a dash.
@@ -1226,37 +1226,37 @@ visual:
   source for the other two. A breadcrumb (`BackEntry`) appears only where the surface you came FROM
   was itself a drawer and got replaced: the Trace and a feed row stay visible behind it, the
   all-activity list does not.
-- **`Expand all` reads the span store, never the feed's ring**, whose cap is about the size of a
-  median turn and whose eviction is destructive. It is the card's list, longer — never a different
+- `Expand all` reads the span store, never the feed's ring, whose cap is about the size of a
+  median turn and whose eviction is destructive. It is the card's list, longer, and never a different
   one: `ACTIVITY_TYPES` keeps only the span types the two `feed.push` sites emit (`api`, `tool`,
   `subspan`, `spawn`), since the store also holds each turn's `prompt` and `result`, which are turn
   STRUCTURE. Subagent spans live **only** inside `turn.spawns[].lanes[].spans`, never in
   `turn.spans`, so the flatten must merge both or omit everything a subagent did while still
   looking complete.
-- **A subagent toast names the model the spawn runs on** and never WAITS for it: it fires with the
+- A subagent toast names the model the spawn runs on and never WAITS for it: it fires with the
   model line reserved and `syncSubToastModels` fills it in place on the next render. Filling in is
-  the normal case — Claude Code writes the child's sidecar BEFORE the parent's assistant line, so
+  the normal case, since Claude Code writes the child's sidecar BEFORE the parent's assistant line, so
   the `subagent-meta` firing the toast usually precedes anything that could name the model; when
   the `Agent` tool-start (carrying `spawnModel`) wins instead, the lookup falls back to
   `state.snapshot()`.
 
-**Selecting a turn scopes EVERY widget, the feed included.** Context, cache, skills, commands,
+Selecting a turn scopes EVERY widget, the feed included. Context, cache, skills, commands,
 activity, main tools and subagents all read the turn-scoped snapshot; the Session card's footer and
 the timeline strip stay session-wide because they are the navigator. The activity feed is the one
 widget not driven by snapshots (it folds raw events), so it scopes itself: its ring retains the
-last `FEED_CAP` activities **per turn**, not globally — a session-wide cap would have already
+last `FEED_CAP` activities **per turn**, not globally, because a session-wide cap would have already
 evicted an older turn's events by the time you select it, leaving that turn permanently empty.
 
-Two rules govern the text seedeep puts on screen. **A pending prompt takes over the NOW panel**
+Two rules govern the text seedeep puts on screen. A pending prompt takes over the NOW panel
 from the roster rather than from the transcript, ticking on CC's own `statusUpdatedAt` rather than
 on the poll that noticed, and names the tool it is waiting to approve only WHEN THE TRANSCRIPT HAS
-IT — for a gated `Bash` it does not, which is why `pendingTool` is nullable. And **prompts and
+IT, while for a gated `Bash` it does not, which is why `pendingTool` is nullable. And **prompts and
 results render as markdown** (`client/markdown.ts`) built with `createElement`/`textContent`,
 **never `innerHTML`**: the content is arbitrary session text, so markup in a prompt must be text,
 not structure, and a link with a non-`http(s)`/`mailto` scheme stays literal. The `user-turn` event
 carries the **whole** prompt (same 20k cap and `anon()` pass as a turn's result) because a view can
 shorten a prompt to a line but cannot recover what the parser dropped, so the banner shows a
-derived one-liner (`promptLine()`) plus an **Input** button opening the original — offered when the
+derived one-liner (`promptLine()`) plus an **Input** button opening the original, offered when the
 DATA was shortened, which is known outright, or when the LAYOUT ellipsized the line, which is
 *measured* with a `ResizeObserver` (an inactive tab is `display:none`, where a one-shot measurement
 would read zero).
@@ -1278,26 +1278,26 @@ browser auth flow, the Settings panel and `SEEDEEP_HOME` have a reference of the
 A running server writes one record per process under `<seedeep home>/servers/<pid>.json`, and the
 console verbs read it. Three rules make that safe:
 
-- **Liveness is never taken from the file.** A record outlives a process that died without cleaning
+- Liveness is never taken from the file. A record outlives a process that died without cleaning
   up, so a reader proves the process with `process.kill(pid, 0)` and treats the record as a claim
   rather than a fact.
-- **One file per pid, never one shared file.** Two servers on one machine is a legitimate state — a
-  checkout running beside an installed release — and a single shared file makes the second erase
+- **One file per pid, never one shared file.** Two servers on one machine is a legitimate state (a
+  checkout running beside an installed release) and a single shared file makes the second erase
   the first.
-- **The URL is rebuilt, never read back from the record.** A record carries no token, so a verb
+- The URL is rebuilt, never read back from the record. A record carries no token, so a verb
   that needs a reachable URL composes it from the configuration it has just read.
 
 A detached start sends its output to `<seedeep home>/server.log`, created and kept `0600`: it holds
 the startup banner, which in remote mode carries a token.
 
 `--help` and `--version` win wherever they appear in the arguments, and an unknown argument is an
-error rather than a silent default — a typo that starts a server on the wrong port is worse than one
+error rather than a silent default: a typo that starts a server on the wrong port is worse than one
 that starts nothing.
 
-**The `/seedeep` command file is refreshed, never re-created.** The file seedeep writes into Claude
+The `/seedeep` command file is refreshed, never re-created. The file seedeep writes into Claude
 Code's `commands/` directory ends with a marker naming the version and carrying a digest of the
 body. On start seedeep rewrites it only while that digest still matches what it last wrote: a file
-the user has edited becomes theirs and is left alone, and a file the user deleted is not put back —
+the user has edited becomes theirs and is left alone, and a file the user deleted is not put back,
 deleting it is a choice.
 
 Which verb does what, and what a user types to get it, is in [install.md](install.md).
@@ -1307,15 +1307,15 @@ Which verb does what, and what a user types to get it, is in [install.md](instal
 `update-check.ts` holds the only outbound request seedeep makes on its own, and the cache that keeps
 it to one an hour.
 
-**The clock is the cache, not a timer.** Nothing is scheduled: an answer older than an hour is
+The clock is the cache, not a timer. Nothing is scheduled: an answer older than an hour is
 refetched by whoever asks next, so ten clients in that hour cost one request and a server nobody
 talks to costs none. A timer would have to be created and cleared at shutdown, and would keep
-fetching for a portal closed a week ago. A failed check has a cooldown of its own — 15 minutes,
-deliberately shorter than the TTL, because a failure has no answer worth preserving.
+fetching for a portal closed a week ago. A failed check has a cooldown of its own, 15 minutes,
+shorter than the TTL, because a failure has no answer worth preserving.
 
-**Only `latest` is stored; the standing is derived** at read time, so a cache written before an
+Only `latest` is stored; the standing is derived at read time, so a cache written before an
 upgrade cannot claim the new build is out of date.
 
 The verbs a user TYPES pass `force`, skip the cache and ask npm, then leave the fresh answer in it
-for the surfaces that only read — which is why four surfaces report the same version without four
+for the surfaces that only read, which is why four surfaces report the same version without four
 requests. `GET /api/update` is the one endpoint all of them read ([api.md](api.md)).

--- a/docs/claude-code-upgrades.md
+++ b/docs/claude-code-upgrades.md
@@ -1,7 +1,7 @@
 # Surviving a Claude Code upgrade
 
 seedeep reads session logs it does not own. Anthropic changes their shape between
-releases, without notice, and seedeep would keep parsing — quietly producing
+releases, without notice, and seedeep would keep parsing, quietly producing
 nothing where it used to produce a turn, a subagent, a token count.
 
 This is not hypothetical. Measured across 3087 real session files (~264k lines,
@@ -16,9 +16,9 @@ This is not hypothetical. Measured across 3087 real session files (~264k lines,
 
 ## The one idea
 
-**Presence is conclusive; absence is not.**
+Presence is conclusive; absence is not.
 
-Seeing a field once proves it exists — no sample size needed. NOT seeing it
+Seeing a field once proves it exists, with no sample size needed. NOT seeing it
 proves nothing, because most fields are conditional: `compactMetadata` exists only
 if you compacted, `interruptedMessageId` only if you pressed Esc. Measured: at a
 *fixed* release, two halves of the same logs differ by 4 fields. A checker that
@@ -35,10 +35,10 @@ described in [The rest closes itself](#the-rest-closes-itself).
 ### The radar — `bun test`
 
 Reports fields Claude Code has **added** that seedeep has never seen. Runs in the
-suite over the newest sessions (~106ms), and **never fails the build**: a new
+suite over the newest sessions (~106ms), and never fails the build: a new
 field cannot break seedeep, it is at most an opportunity.
 
-**That sentence is about FIELDS, and it does not extend to VALUES** — see
+That sentence is about FIELDS, and it does not extend to VALUES. See
 [When a value changes](#when-a-value-changes-and-why-the-radar-cannot-see-it), which is a
 different failure with a different guard.
 
@@ -52,19 +52,19 @@ The known set (`apps/server/data/known-fields.json`) only ever grows, so it can 
 a source of flaky failures.
 
 **What it looks at:** the top-level keys of every line type, plus the keys inside
-the nested containers seedeep's parser actually dereferences —
+the nested containers seedeep's parser actually dereferences,
 `OBSERVED_CONTAINERS` in `apps/server/src/server/schema-known-fields.ts`: `message`,
 `message.usage`, `toolUseResult`, `compactMetadata`, `origin`. A container is on
 that list because seedeep reads it; when the parser starts reading a new one, add
 its dotted path there and re-run `--update`.
 
-The list is explicit rather than a recursive walk on purpose. `message.content[]`
+The list is explicit rather than a recursive walk. `message.content[]`
 carries each tool's `input`, whose keys are defined by the tool or the MCP server,
-not by Claude Code — walking down blindly would bury the report in fields that say
+not by Claude Code, and walking down blindly would bury the report in fields that say
 nothing about the schema.
 
 Honest limit: the radar sees only what arrives from now on. A field that already
-existed when the set was generated is "known" and stays silent — and a container
+existed when the set was generated is "known" and stays silent, and a container
 absent from `OBSERVED_CONTAINERS` is invisible entirely. That is how
 `toolUseResult.backgroundTaskId` (today the only reliable sign that a `Bash` ran
 in the background) went unreported: `toolUseResult` was recorded as one key, and
@@ -72,7 +72,7 @@ nothing looked inside it.
 
 ### The probe — `bun run apps/server/probe/run.ts`
 
-Answers the question the radar cannot: **is a field seedeep reads gone?**
+Answers the question the radar cannot: is a field seedeep reads gone?
 
 It drives a real Claude Code session in a pseudo-terminal, *provokes* each event
 (a typed prompt, a slash command, Esc, a tool call, a subagent), and then checks
@@ -95,16 +95,16 @@ on `-p` would verify those vacuously and report green on a dead parser.
 ## When a value changes, and why the radar cannot see it
 
 Everything above is about the shape of the logs. seedeep also reads several **closed
-vocabularies** — small sets of strings whose meaning is Claude Code's to define — and a change
-there fails differently: not with a missing field, but with a value that falls through to "unknown"
+vocabularies**, small sets of strings whose meaning is Claude Code's to define, and a change
+there fails differently. There is no missing field: a value falls through to "unknown"
 and quietly downgrades what the user sees.
 
 It has already happened once, and it is worth stating plainly because nothing in the guard reported
 it. Claude Code writes `status: "shell"` in `~/.claude/sessions/<PID>.json` while a command the
 session launched in the background is still running and the turn is over. seedeep did not know the
-word, dropped it to `null`, and a session with no status is filed under *Idle* on purpose — so a
-session with work still running read as idle for months. **A user reported it; no test could
-have.** Two blind spots overlapped: the radar watches field NAMES, and it watches TRANSCRIPTS,
+word, dropped it to `null`, and a session with no status is filed under *Idle*, so a
+session with work still running read as idle for months. A user reported it; no test could
+have. Two blind spots overlapped: the radar watches field NAMES, and it watches TRANSCRIPTS,
 while this is a VALUE in the PID file.
 
 The vocabularies seedeep reads today, all of them exposed the same way:
@@ -116,66 +116,66 @@ The vocabularies seedeep reads today, all of them exposed the same way:
 | `entrypoint` | `cli` `sdk-cli` `sdk-py` | the tray's interactive-only filter mis-sorts a species |
 | `<task-id>` prefix | `a…` agent · `b…` background · `w…` workflow | a notification is routed to the wrong subject |
 
-Two guards cover the first, and they are deliberately different from the two above:
+Two guards cover the first, and they differ from the two above:
 
 - **A claim in the contract (C25).** The probe launches a background command, lets the turn end,
   and requires `status: "shell"` while it runs. This is the only mechanism that can hold Claude
-  Code to a *value* — provoke it, and absence becomes proof, exactly as for a field.
+  Code to a *value*: provoke it, and absence becomes proof, exactly as for a field.
 - **A one-shot warning at runtime** (`open-sessions.ts`). An unrecognised status is logged once per
   value, on the machine that is actually watching sessions pass through every state they have. A
   test-suite scan was considered and rejected in its place: the PID file exists only for sessions
-  open at that instant, so the suite would see one session in whatever state it happened to be in —
+  open at that instant, so the suite would see one session in whatever state it happened to be in,
   which is precisely how `shell` went unseen.
 
-Neither fails the build. An unknown value is not a crash: the session simply makes no claim, and a
-guard that stopped the server over Claude Code's vocabulary would be worse than the bug.
+Neither fails the build. An unknown value is not a crash: the session simply makes no claim. Stopping the
+server over a word Claude Code changed would cost more than the missing claim does.
 
-**A third kind of thing the radar cannot see: a PATH LAYOUT (C26).** seedeep finds a background
+A third kind of thing the radar cannot see: a PATH LAYOUT (C26). seedeep finds a background
 command's output file at `<tmp>/claude-<uid>/<slug>/<session>/tasks/<taskId>.output`, because that
-file is what gets asked whether the command's process still exists — the only way a command whose
-end Claude Code never writes can stop counting. The parsed path cannot be used for it (`anon()`
-masks the session uuid inside it before it reaches an event), so the SHAPE is the mechanism. The
-same probe run that provokes `shell` checks the receipt names that shape. If it ever moves, the
-resolution simply returns nothing and every probe answers "no verdict" — a feature that has gone
-quiet is indistinguishable from one with nothing to report, which is why it needs a claim rather
-than a runtime warning.
+file is what gets asked whether the command's process still exists, which is the only way a command
+whose end Claude Code never writes can stop counting. The parsed path cannot be used for it
+(`anon()` masks the session uuid inside it before it reaches an event), so the SHAPE is the
+mechanism. The same probe run that provokes `shell` checks the receipt names that shape. If it ever
+moves, the resolution simply returns nothing and every probe answers "no verdict": a feature that
+has gone quiet is indistinguishable from one with nothing to report, which is why it needs a claim
+rather than a runtime warning.
 
-**A field whose only proof is a keystroke (C27).** A background command has three possible authors,
+A field whose only proof is a keystroke (C27). A background command has three possible authors,
 and the receipt names each with a different field: the model asked (`run_in_background` in the launch
-input), the call's own timeout promoted it (`timedOutAfterMs` — the CALL's timeout, not a constant:
+input), the call's own timeout promoted it (`timedOutAfterMs`, the CALL's timeout and not a constant:
 45s–600s across 22 local promotions, matching the `timeout` the model asked for), or the user pressed
 Ctrl+B (`backgroundedByUser`). Measured over 221 background receipts in 515 sessions on 2026-08-09, the
 three are mutually exclusive, and the last is the only one with no fallback: read as "neither of the
 other two", a receipt written before `timedOutAfterMs` existed turns a timeout into a model choice.
-The radar cannot hold a field it has merely seen once, and no amount of real sessions can either —
-the gesture is a keystroke nobody presses on purpose. So scene 14 presses it: a command launched in
-the FOREGROUND, then Ctrl+B, and a receipt that must say who did it. `provoked` reads the shape of
-that receipt (a foreground launch that came back with a task id and no timeout) and never the field
-under test.
+The radar cannot hold a field it has merely seen once, and no amount of real sessions can either,
+because the gesture is a keystroke nobody presses on purpose. So scene 14 presses it: a command
+launched in the FOREGROUND, then Ctrl+B, and a receipt that must say who did it. `provoked` reads the
+shape of that receipt (a foreground launch that came back with a task id and no timeout) and never
+the field under test.
 
 ## Three outcomes, never two
 
 | | meaning |
 |---|---|
 | **HOLDS** | the event was provoked and the field is there |
-| **BROKEN** | the event was provoked and the field did NOT appear — seedeep is broken on this release. **Gesture claims only**: a model claim in this state is UNPROVEN, never BROKEN (see below) |
+| **BROKEN** | the event was provoked and the field did NOT appear, so seedeep is broken on this release. **Gesture claims only**: a model claim in this state is UNPROVEN, never BROKEN (see below) |
 | **UNPROVEN** | the probe could not make the event happen, so it learned *nothing* |
 
-UNPROVEN is not a soft failure — it is an honest "I don't know". Calling it a pass
+UNPROVEN is an honest "I don't know" rather than a soft failure. Calling it a pass
 would be the one lie that makes the whole guard worthless.
 
 Claims split by what the probe can guarantee:
 
-- **gesture** — the probe performs the act itself (typing, pressing Esc). Absence
+- **gesture:** the probe performs the act itself (typing, pressing Esc). Absence
   is proof.
-- **model** — someone else decides: Claude may route differently, an MCP server
+- **model:** someone else decides. Claude may route differently, an MCP server
   may be absent, Claude Code may refuse to compact a small session. Absence proves
   nothing, so these are never reported as broken.
 
 ## What "certified" means
 
-A release is added to `apps/server/data/certified-versions.json` **only when every gesture
-claim HOLDS**. "Nothing broke" is not "I checked": a run that provokes nothing
+A release is added to `apps/server/data/certified-versions.json` only when every gesture
+claim HOLDS. "Nothing broke" is not "I checked": a run that provokes nothing
 breaks nothing, and an earlier version of this guard signed off a release having
 proven 13 claims of 25.
 
@@ -185,7 +185,7 @@ printed as a checklist instead.
 ## The rest closes itself
 
 The probe cannot make Claude delegate or pick a skill. But ordinary use produces
-subagents, skills and MCP calls on the new release within days — and presence is
+subagents, skills and MCP calls on the new release within days, and presence is
 conclusive, so a field found in a real session written by that release **proves**
 it is alive. On each run the probe scans real sessions and closes what it finds,
 with nobody doing anything.
@@ -194,7 +194,7 @@ Two rules keep that sound, and both have tests:
 
 1. Only lines whose `version` **is** the target count. Confirming a new release
    with an old release's data is the exact failure this guard exists to prevent.
-2. Subagent transcripts carry no `version`, so it is inherited from the parent —
+2. Subagent transcripts carry no `version`, so it is inherited from the parent,
    and only when that parent has exactly **one** version. A session that spans an
    upgrade cannot attribute its children, so it is discarded rather than guessed.
 
@@ -215,7 +215,7 @@ TEST THESE BY HAND — the probe could not prove them:
       if it is wrong, the break is at server/parser.ts
 ```
 
-A claim names the file that reads the field, and a symbol inside it where one exists — never a
+A claim names the file that reads the field, and a symbol inside it where one exists, never a
 line number. `schema-contract-readers.test.ts` fails when a path or a symbol named there stops
 existing, which is the check a line number could never carry.
 
@@ -239,11 +239,11 @@ evidence and close the claim on its own.
   directory that never exists.
 - Some state never reaches the transcript at all. A **pending approval** lives only
   in `~/.claude/sessions/<PID>.json` (`status: "waiting"` + `waitingFor`), so scene 12
-  is checked from samples of that file taken WHILE the session is alive — and every
+  is checked from samples of that file taken WHILE the session is alive, and every
   distinct state is kept, because a state the session passes through is invisible to a
   probe that records only the first sighting. Its ground truth is the refusal the
   transcript records once the prompt is declined (`C24`), never the field under test.
-- A Bash command run **inside the working directory is auto-approved by the sandbox** and
+- A Bash command run inside the working directory is auto-approved by the sandbox and
   raises no dialog. Provoking a permission prompt needs a command that has to escape it
-  (network access, a write outside the cwd) — the first attempt used `touch` and proved
+  (network access, a write outside the cwd). The first attempt used `touch` and proved
   nothing at all.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -4,8 +4,8 @@ Everything seedeep reads at startup and everything the Settings panel writes: on
 precedence chain, one security posture. What the endpoints that read and write it look like on the
 wire is in [api.md](api.md); what a user types to change any of it is in [install.md](install.md).
 
-seedeep reads its configuration from `~/.seedeep/config.json` (owned entirely by seedeep;
-not a Claude Code file). The file is optional — a missing file means all built-in defaults
+seedeep reads its configuration from `~/.seedeep/config.json` (owned entirely by seedeep,
+and not a Claude Code file). The file is optional: a missing file means all built-in defaults
 apply and the first run works without it. A malformed or unreadable file falls back silently
 to the defaults without rewriting.
 
@@ -25,7 +25,7 @@ interface SeedDeepConfig {
              // true, true, false, true
     webhook: { needsYou: boolean; fails: boolean; finishes: boolean;
                url: string; headers: Record<string, string>; template: string };
-             // same three defaults, and OFF until `url` is set — nothing leaves the
+             // same three defaults, and OFF until `url` is set, so nothing leaves the
              // machine unasked
   };
   tls: {
@@ -45,7 +45,7 @@ CLI flag `>` env var `>` config file `>` built-in default.
 | `port`         | `--port`    | `SEEDEEP_PORT`     |
 | `host`         | `--host`    | `SEEDEEP_HOST`     |
 | `open`         | `--no-open` | `SEEDEEP_OPEN`     |
-| `tls.commonName` | —         | `SEEDEEP_TLS_CN`   |
+| `tls.commonName` | none      | `SEEDEEP_TLS_CN`   |
 
 The `auth.token` is generated automatically (32 random bytes, base64url-encoded) on the
 first run when the field is absent or empty, then written back to the config file. It
@@ -67,7 +67,7 @@ all interfaces and is treated as non-loopback (the server is reachable from the 
 The decision is made from the **configured host, never from the peer**: with remote access on,
 a request arriving from `127.0.0.1` gets TLS and the token check like any other, because the
 listener has one certificate and one policy. So "seedeep is on this machine" does not imply "no
-credentials needed" — a client on the same machine configures itself exactly like a remote one
+credentials needed", and a client on the same machine configures itself exactly like a remote one
 (`docs/tray.md`). The 401's body is `{"error":"unauthorized"}`, and that shape is part of the
 contract: it is how a client tells a seedeep asking for a token apart from something unrelated
 listening on the same port.
@@ -81,25 +81,25 @@ When `host` is not loopback, seedeep generates a self-signed RSA-2048 certificat
 `tls.commonName` is required for non-loopback operation. seedeep refuses to start with a
 clear error if it is absent.
 
-It must also be a name a certificate can carry — an RFC 1123 hostname or an IPv4 address
+It must also be a name a certificate can carry: an RFC 1123 hostname or an IPv4 address
 (`isValidCertName`, `core/cert-name.ts`). The name is interpolated into openssl's
-`subjectAltName=` list, where **a comma starts another entry**: a name carrying one would
+`subjectAltName=` list, where a comma starts another entry, so a name carrying one would
 quietly produce a certificate covering something else. No shell is involved (`spawn` takes an
 argv array, so there is no command injection) and the blast radius is the user's own
-certificate — but a silent surprise is worse than a refusal. `POST /api/config` answers 400 and
+certificate, but a silent surprise is worse than a refusal. `POST /api/config` answers 400 and
 stores nothing, and `ensureTlsCert` throws as well, because the value also arrives from
 `config.json` and `SEEDEEP_TLS_CN`, which no request handler sees. The predicate lives in its own
-import-free module because **the browser needs the same one**: a panel that accepts what the
-server refuses is worse than no check at all. LIMIT: an IPv6 literal is refused — its colons
+import-free module because the browser needs the same one: a panel that accepts what the
+server refuses is worse than no check at all. LIMIT: an IPv6 literal is refused, since its colons
 cannot be told from the SAN's own `TYPE:value` separator without a full parser.
 
 Surrounding whitespace is refused, not trimmed: openssl trims it while writing the SAN, so a
 padded name yields a certificate for the trimmed name while the coverage check asks about the
-padded one — the certificate is then judged not to cover its own name and is regenerated on every
+padded one, and the certificate is then judged not to cover its own name and is regenerated on every
 start. The invariant that guards it lives in `tls.test.ts`: whatever the predicate accepts, the
 certificate generated for it must come back `reused`.
 
-**Everything the server answers on goes in the SAN**, and the `commonName` is the first of
+Everything the server answers on goes in the SAN, and the `commonName` is the first of
 them:
 
 | SAN entry | Why |
@@ -109,7 +109,7 @@ them:
 | **every** non-internal IPv4 address of the machine | one is picked at random on any box with a VPN, Tailscale or Docker |
 
 The `commonName` in the SAN is not a detail: browsers ignore the deprecated CN field, so a name
-that is only in `/CN=` is certified by nothing — and **a self-signed certificate hides that**,
+that is only in `/CN=` is certified by nothing, and a self-signed certificate hides that,
 because the name error lands inside the trust warning the user has already accepted. IPv4 only: an
 IPv6 host is covered by setting `tls.commonName` to the literal, whereas enumerating IPv6 would add
 the machine's temporary privacy addresses, which the OS rotates.
@@ -117,24 +117,24 @@ the machine's temporary privacy addresses, which the OS rotates.
 #### When the certificate is replaced
 
 A stored pair is **reused** whenever it certifies the current `commonName`, and **replaced**
-when it does not — including a file the TLS stack cannot parse, which could not have served a
+when it does not, including a file the TLS stack cannot parse, which could not have served a
 connection anyway. Coverage is asked of `X509Certificate.checkHost`/`checkIP`, so the answer
 follows the same RFC 6125 rules a client applies rather than seedeep's reading of the SAN text.
 
-**The name is the only trigger, never the address set.** Two consequences are the point of that
-rule: the addresses change on their own — a VPN coming up is enough — and replacing the
+The name is the only trigger, never the address set. Two consequences are the point of that
+rule. The addresses change on their own, since a VPN coming up is enough, and replacing the
 certificate changes its fingerprint, so keying on them would give a pin that fires with the
-weather; and a certificate the *user* supplied for their own domain covers its own name, so
+weather. And a certificate the *user* supplied for their own domain covers its own name, so
 seedeep leaves it alone even though it carries no `localhost`.
 
-A replacement invalidates any pin already taken. That is a pin doing its job, not breaking, but
+A replacement invalidates any pin already taken. That is a pin doing its job rather than breaking, but
 it is the one event a user cannot infer from a new fingerprint they have no old value to compare
-against — so `startServer` reports `tlsCertOrigin` and the CLI says so in words, immediately
+against, so `startServer` reports `tlsCertOrigin` and the CLI says so in words, immediately
 before printing the new value.
 
 #### The fingerprint
 
-The fingerprint is the SHA-256 of the served **leaf** certificate's DER bytes, formatted `AA:BB:…` —
+The fingerprint is the SHA-256 of the served **leaf** certificate's DER bytes, formatted `AA:BB:…`,
 the same digest and formatting `openssl x509 -in cert.pem -noout -fingerprint -sha256` prints, so it
 can be checked with a tool that shares none of seedeep's code. It is RUNTIME state, never written to
 `config.json`, and is `null` (the field absent) in loopback mode, where there is nothing to pin.
@@ -143,28 +143,28 @@ A browser gets past a self-signed certificate with a one-time click; a non-brows
 **pin** it instead, so the value is obtainable three ways:
 
 - **stdout, on every start** in remote mode (`main.ts`), not only on the run that generated the
-  file — a value readable once cannot be checked a week later, when the client is actually set up.
+  file, because a value readable once cannot be checked a week later, when the client is actually set up.
 - **The Settings panel**, TLS Certificate → Fingerprint, with a Copy button. This is the
   out-of-band channel: read on the machine seedeep runs on, compared on the machine the client
   runs on.
-- **`GET /api/config`**, as `tls.fingerprint`. Safe on an unauthenticated endpoint — the
-  certificate itself is presented in the clear on every handshake — and a **convenience, not a
+- **`GET /api/config`**, as `tls.fingerprint`. Safe on an unauthenticated endpoint, since the
+  certificate itself is presented in the clear on every handshake, and a **convenience rather than a
   channel of trust**: a fingerprint fetched over the very connection being verified proves nothing
   on its own, which is why the Settings panel exists.
 
-The client-side behaviour — when to show it, what happens on a mismatch — belongs to the tray
+The client-side behaviour, meaning when to show it and what happens on a mismatch, belongs to the tray
 (`docs/tray.md`), not here.
 
 ## Off-LAN access: seedeep ships no tunnel
 
 Remote mode covers the local network. Reaching seedeep from outside it is deliberately not
-seedeep's job — NAT and firewall traversal are solved problems, and re-solving them here would
+seedeep's job: NAT and firewall traversal are solved problems, and re-solving them here would
 add a second, weaker security surface next to the token. Two supported shapes:
 
-- **SSH port-forward** — `ssh -L 44842:127.0.0.1:44842 user@host`, with `host` left on loopback.
+- **SSH port-forward:** `ssh -L 44842:127.0.0.1:44842 user@host`, with `host` left on loopback.
   The tunnel is the authentication and no certificate is involved; nothing is exposed on any
   interface of the remote machine.
-- **An existing VPN or overlay network** — run in remote mode and reach the machine over the
+- **An existing VPN or overlay network:** run in remote mode and reach the machine over the
   private address the VPN assigns it. The Bearer token and TLS still apply.
 
 ## Browser auth flow
@@ -181,24 +181,24 @@ to open the browser on first launch).
 
 Opening the URL triggers `initAuth()` (called once at page load in `app.ts`): the token
 is extracted from the query string, stored in `localStorage` under `seedeep-token`, and
-removed from the URL via `history.replaceState` — so it never appears in browser history
+removed from the URL via `history.replaceState`, so it never appears in browser history
 or `Referer` headers. The token persists across browser restarts with no expiry; to
 revoke access, generate a new token via Settings → Regen and save.
 
-**`?session=<id>` — the portal's one other URL parameter**, and the seam with the tray, which
+`?session=<id>` is the portal's one other URL parameter, and the seam with the tray, which
 hands a session over rather than replicating it (`docs/tray.md`). Applied at boot AFTER the saved
 workspace and after the auto-open rule, and it ACTIVATES: it is the only thing on the page the user
 did a moment ago, so it outranks both what they were last looking at and a session that happened to
 start. Read by `requestedSession` (`client/sessions.ts`), which bounds the value because it reaches
-the screen but does NOT check it against a UUID shape — the id format is Claude Code's to change.
+the screen but does NOT check it against a UUID shape, since the id format is Claude Code's to change.
 An id no session answers to opens nothing, and the parameter is stripped either way, for the same
 reason the token is: a reload must not yank the tab back to where one click sent it once. The two
-parameters coexist — a tray URL carries both.
+parameters coexist, and a tray URL carries both.
 
 All subsequent API calls go through `authFetch`, which reads the token from `localStorage`
 and adds `Authorization: Bearer <token>`. SSE connections (EventSource) cannot carry
-custom headers, so `AuthEventSource` appends `?token=<token>` to the stream URL instead —
-the server accepts the token from either the `Authorization` header or the `?token=` query
+custom headers, so `AuthEventSource` appends `?token=<token>` to the stream URL instead. The
+server accepts the token from either the `Authorization` header or the `?token=` query
 parameter on every `/api/*` route except `GET /api/config`.
 
 When the user generates a new token via Regen, the server adopts it immediately, with no restart.
@@ -211,29 +211,29 @@ The settings drawer (gear icon in the header) lets the user change configuration
 editing `config.json` directly. It loads on open (`GET /api/config`) and POSTs each change as it is
 made.
 
-**It is an editor of the FILE, not a view of the process.** The fields show the configuration as a
-start would resolve it right now — `config.json` under this process's flags and environment — and a
+It is an editor of the FILE, not a view of the process. The fields show the configuration as a
+start would resolve it right now, meaning `config.json` under this process's flags and environment, and a
 save merges the request onto the file **re-read at that moment**, so a save of one field cannot undo
 an edit it never mentioned. What stays the process's own is what no edit can change: `version`, the
-certificate fingerprint, and `restart_pending` — which is precisely the statement that the file and
+certificate fingerprint, and `restart_pending`, which is precisely the statement that the file and
 the process have diverged.
 
 A value pinned by a CLI flag or an environment variable is shown as the flag sets it, not as the
 file says: that is what this server runs and what every restart will keep running. The field stays
-editable and still writes — it is the configuration for the day this server starts without the
-flag — and `overrides` on the same response names which fields are held and by what (`flag` or
+editable and still writes, since it is the configuration for the day this server starts without the
+flag, and `overrides` on the same response names which fields are held and by what (`flag` or
 `env`), which the panel prints under each one. Only fields whose override actually DIFFERS from the
 file are reported: a flag repeating what the file says overrides nothing anyone can observe.
 
 The `***` redactions (the auth token, the webhook URL and its headers) mean **"keep the stored
-value"**, resolved against that same file — the source the panel read them from, so the mask can
+value"**, resolved against that same file, the source the panel read them from, so the mask can
 only ever put back the value it stood for.
 
-**A broken file is repaired, never overwritten — and a missing one is not a config either.** Reading
+A broken file is repaired, never overwritten, and a missing one is not a config either. Reading
 it has three outcomes, and `readConfigFile` separates them: `null` when it does not exist, a THROW
 when it exists and cannot be parsed, the config otherwise. `readConfig` stays lenient on top of it
 (a server must still start on a broken file) and `readConfigStrict` takes the defaults for a missing
-one — but a caller that WRITES may take neither shortcut, or built-ins would land on top of the
+one, but a caller that WRITES may take neither shortcut, or built-ins would land on top of the
 user's token, port and certificate name on the first save made for any other reason. So `POST
 /api/config` merges onto the file only when there IS one that parses, and onto the running config
 otherwise. `resolveConfig` carries the same rule to startup: handed `fileIsUsable: false` it
@@ -242,8 +242,8 @@ its owner repairs the file, and never the file itself. Every entry point goes th
 (`readFileConfig` in `main.ts`), the subcommands included: a command that only reports must not
 write.
 
-**The panel has no Save button.** Every control writes as it changes: a toggle on the click, a text
-field on `change` — leaving it or pressing Enter — and never on each keystroke, or typing `45999`
+The panel has no Save button. Every control writes as it changes: a toggle on the click, a text
+field on `change`, meaning on leaving it or pressing Enter, and never on each keystroke, or typing `45999`
 would post `4`, then `45`, then `459`. A port the server could not bind is omitted from the body
 rather than sent, so an empty field cannot write `port: 0` on the way past.
 
@@ -252,13 +252,13 @@ rather than sent, so an empty field cannot write `port: 0` on the way past.
 | Port | Always | Requires restart |
 | Host | Always | `127.0.0.1` = loopback (default), `0.0.0.0` = LAN; requires restart |
 | Open browser on start | Always | Toggles `config.open` |
-| Notifications — Tray | Always | The four events the menu-bar app may interrupt for. They live in `notifications.tray`, so the tray reads whichever server it is connected to rather than a file of its own |
-| Notifications — Webhook | Behind **Send to a webhook…** | URL, headers and body template, plus its own three switches. Empty URL means the channel is off, which is how it ships — nothing leaves the machine unasked. The URL is redacted like the token: for Slack, Discord and ntfy it IS the credential |
+| Notifications, Tray | Always | The four events the menu-bar app may interrupt for. They live in `notifications.tray`, so the tray reads whichever server it is connected to rather than a file of its own |
+| Notifications, Webhook | Behind **Send to a webhook…** | URL, headers and body template, plus its own three switches. Empty URL means the channel is off, which is how it ships, so nothing leaves the machine unasked. The URL is redacted like the token: for Slack, Discord and ntfy it IS the credential |
 | Auth token | Always | Always displayed as `***`; **Regen** generates a new token client-side, and warns that saving it locks out every other client |
 | Access URL | Always | Computed live from the current form values; includes `?token=` in remote mode; **Copy** writes the full URL to the clipboard |
-| Common name | Remote mode only | The name the certificate certifies; required in remote mode, and refused unless it is a hostname or an IPv4 address — while it is missing or unusable nothing in the panel is written at all. Changing a name that already produced a certificate warns that the certificate — and its fingerprint — will be replaced |
-| Fingerprint | Remote mode only | Read-only SHA-256 of the certificate the server is presenting; **Copy** writes it to the clipboard. Server state, so nothing in the panel can change it — a new certificate needs a restart. Empty (placeholder) when the running server has no certificate, i.e. a remote host was typed into the form but not yet restarted into |
-| Version (About) | Always | Read-only. The release the RUNNING server reports (`version` on `GET /api/config`), never the number this bundle was built from — a stale `build:client` would otherwise make the portal claim a version the server is not. A server that reports none leaves the dash: this is the one string a bug report quotes verbatim, so a guess here is worse than an admission |
+| Common name | Remote mode only | The name the certificate certifies; required in remote mode, and refused unless it is a hostname or an IPv4 address. While it is missing or unusable nothing in the panel is written at all. Changing a name that already produced a certificate warns that the certificate, and its fingerprint, will be replaced |
+| Fingerprint | Remote mode only | Read-only SHA-256 of the certificate the server is presenting; **Copy** writes it to the clipboard. Server state, so nothing in the panel can change it, and a new certificate needs a restart. Empty (placeholder) when the running server has no certificate, i.e. a remote host was typed into the form but not yet restarted into |
+| Version (About) | Always | Read-only. The release the RUNNING server reports (`version` on `GET /api/config`), never the number this bundle was built from, since a stale `build:client` would otherwise make the portal claim a version the server is not. A server that reports none leaves the dash: this is the one string a bug report quotes verbatim, so a guess here is worse than an admission |
 
 The Access URL field derives its token from (in priority order): the `pendingToken` just
 generated by Regen, then the token in `localStorage` (from a prior visit via the startup
@@ -274,7 +274,7 @@ Validation is shared, not duplicated: the panel refuses a Common name with the s
 `isValidCertName` the server uses, so the field can say why immediately instead of relaying a 400,
 and a rejection from `POST /api/config` is reported as the failure it is.
 
-**An invalid Common name reveals the TLS section even in loopback mode** — the only reason that
+**An invalid Common name reveals the TLS section even in loopback mode**, the only reason that
 section is ever shown outside remote mode. The name is still on its way to `config.json`, so it
 still blocks every write, and a refusal whose reason sits inside a hidden section is a dead end with
 no way out of the panel.
@@ -284,37 +284,37 @@ no way out of the panel.
 Three values are BOUND at startup and cannot be revisited by the process holding them: `port`,
 `host`, and the certificate's common name. `auth.token` joins them: a save can rotate a token live,
 but only one the PANEL generated, because a token edited straight into `config.json` is never in a
-request — the panel reads it redacted and posts `***`. A restart is what applies that one.
+request, as the panel reads it redacted and posts `***`. A restart is what applies that one.
 
 `open` is in neither state: it is spent the moment the browser opened, so nothing can apply it, and
 announcing it would teach the reader to ignore the announcement.
 
-**Two states, because there are two cures.** `save_pending` holds the notification settings the
-panel has IN CLEAR — every switch and the webhook's template — which is exactly what pressing
+Two states, because there are two cures. `save_pending` holds the notification settings the
+panel has IN CLEAR, meaning every switch and the webhook's template, which is exactly what pressing
 **Apply now** re-posts. Everything the panel is shown REDACTED goes to `restart_pending` instead:
 the auth token, the webhook's address and its headers. The panel posts `***` for each and the merge
 resolves that back to the value already there, so a state raised on one of them could not be cleared
 by the button offering to clear it.
 
-**Apply now reloads before it posts.** The banner can arrive from the background refresh with the
-drawer already open, and that path leaves the form alone so it cannot wipe out half-typed input — so
+Apply now reloads before it posts. The banner can arrive from the background refresh with the
+drawer already open, and that path leaves the form alone so it cannot wipe out half-typed input, so
 posting the fields as they stand would write the user's own change back out. Reloading first is also
 what the button means: apply what the file says.
 
-**`restart_pending` compares two `applyPrecedence` results, never the file.** Configuration arrives
+`restart_pending` compares two `applyPrecedence` results, never the file. Configuration arrives
 through a four-layer chain (CLI flags → env → file → defaults), and `POST /api/restart` respawns
 with `process.argv.slice(2)` intact, so a server started with `--port 9000` goes on ignoring the
-file's port after every restart — comparing against the file alone would light a permanent signal no
+file's port after every restart, and comparing against the file alone would light a permanent signal no
 button could clear. The two sides are what this process resolved at startup and what a fresh start
 would resolve to now: the same flags and the same environment, over `config.json` re-read at request
 time. Both go through the one function, so they cannot drift apart.
 
-- It is recomputed per request and never cached — a cached answer is how a file edited in an editor
+- It is recomputed per request and never cached, because a cached answer is how a file edited in an editor
   stays invisible.
 - It rides `GET /api/config`, so every surface reads one verdict: the portal (a dot on the
   Settings button, a banner in the drawer, the `Restart now` button), the tray (a line above the
   bands, asked when the popover opens), and `seedeep status` (a line under `serving`). The dot is
-  ONE mark for both states — it is the only thing visible with the drawer closed, and two dots on
+  ONE mark for both states, since it is the only thing visible with the drawer closed and two dots on
   one button could not be told apart; which state it is belongs to the drawer, whose job the dot is
   to get opened.
 - `POST /api/config` derives its answer from the same comparison, taken AFTER the write, never from
@@ -327,7 +327,7 @@ A token generated in the panel takes effect immediately, with no restart.
 
 | Method | Path | Auth required | Purpose |
 |--------|------|---------------|---------|
-| `GET`  | `/api/config` | Never | The configuration a start would resolve to now — `config.json` under this process's flags and environment, never the copy it is holding (token redacted as `"***"`, `tls.cert`/`tls.key` omitted, `tls.fingerprint` added in remote mode) — plus `version` and `restart_pending`, which are runtime state, not config: both describe the process answering and neither is written back to `config.json`. It rides this route because the version has to be readable before anything else is, which on a remote host means before a token exists. The exemption goes no further than that: `dev` is withheld from an unauthenticated caller (see *Which build is answering*) |
+| `GET`  | `/api/config` | Never | The configuration a start would resolve to now, meaning `config.json` under this process's flags and environment and never the copy it is holding (token redacted as `"***"`, `tls.cert`/`tls.key` omitted, `tls.fingerprint` added in remote mode), plus `version` and `restart_pending`, which are runtime state rather than config: both describe the process answering and neither is written back to `config.json`. It rides this route because the version has to be readable before anything else is, which on a remote host means before a token exists. The exemption goes no further than that: `dev` is withheld from an unauthenticated caller (see *Which build is answering*) |
 | `POST` | `/api/config` | On non-loopback | Partial merge onto `config.json` **re-read at that moment** + atomic write, so a save cannot undo an edit it never mentioned; the runtime copy takes the same merge for what applies without a restart. Returns the redacted config read back + `restart_pending`, never a diff of the request (see *A restart the process itself knows is due*) |
 
 ## Resetting
@@ -335,51 +335,51 @@ A token generated in the panel takes effect immediately, with no restart.
 `rm -rf ~/.seedeep/` removes all seedeep-owned state: the config, the certificate and its key, the
 aggregate cache, the two indexes (`search-index.jsonl`, `cards-index.jsonl`), the update-check
 cache, the per-process records under `servers/`, and `server.log`. seedeep rebuilds everything from
-scratch on the next run — every byte of it is derived from transcripts seedeep does not own.
+scratch on the next run, since every byte of it is derived from transcripts seedeep does not own.
 
 ## Moving it: `SEEDEEP_HOME`
 
 Everything above lives under **one** directory, and `seedDeepDir()` is the only code that knows its
-name — `SEEDEEP_HOME` moves everything under it together, not the config alone. That is the point:
+name. `SEEDEEP_HOME` moves everything under it together, not the config alone. That is the point:
 half a relocation is worse than none, since a run whose config moved but whose caches did not still
 rewrites the other copy's index, and the symptom (a corpus rebuilt on every start) names nothing. A
 test enumerates the paths, and a second one fails if any other module ever spells `'.seedeep'`
 itself.
 
-It exists so a checkout can run beside an installed release — `bun run dev` sets it, and
+It exists so a checkout can run beside an installed release. `bun run dev` sets it, and
 CONTRIBUTING.md explains when that matters. The damage it prevents does not need the two to run at
 once: a dev run that changes the port from the settings panel is what the installed server reads on
 its next start. A relative value is resolved against the process's cwd, so a dev script can point it
 inside the checkout. Unset for a user, which is every release.
 
-**The tray answers to the same variable**, and to no other: it keeps its own two files in
-`<SEEDEEP_HOME>/tray`, so one name selects a whole world — this server and the tray watching it. A
-GUI app inherits no shell environment, which is what makes the installed tray the installed world
-with nothing to configure ([`tray.md`](tray.md#running-it)).
+The tray answers to the same variable, and to no other: it keeps its own two files in
+`<SEEDEEP_HOME>/tray`, so one name selects a whole world, this server and the tray watching it. A
+GUI app inherits no shell environment, so the installed tray reads the installed state with no
+configuration ([`tray.md`](tray.md#running-it)).
 
 ## Which build is answering
 
 `GET /api/config` carries **`dev`**: true when the server is a checkout, false when it is a released
 executable. The portal reads it once at load and, when it is true, renames the tab to *seedeep dev*
-and puts a chip beside the brand (`client/build-mark.ts`). A release shows nothing — a badge every
-install carries is a badge nobody reads.
+and puts a chip beside the brand (`client/build-mark.ts`). A release shows nothing: there is
+nothing there to tell apart.
 
 The same response carries **`version`**, and unlike the chip the brand states it on **every**
-portal, in muted monospace right of the wordmark: it is not a badge but a fact, and it is the one
-number a bug report quotes — the settings panel still holds it, but reading it there is a panel you
-have to go open. On a checkout both marks show, version first — `seedeep 0.12.0 dev`. It is the
+portal, in muted monospace right of the wordmark. It is a fact rather than a badge, and it is the one
+number a bug report quotes: the settings panel still holds it, but reading it there is a panel you
+have to go open. On a checkout both marks show, version first, as `seedeep 0.12.0 dev`. It is the
 release the SERVER reported and never a constant compiled into the bundle: `public/lib/` is a build
 artifact, so a stale `build:client` would otherwise print a version nothing is running. A server too
-old to report one draws nothing at all — a dash beside the wordmark reads as a broken page, and this
+old to report one draws nothing at all, because a dash beside the wordmark reads as a broken page, and this
 is the value that must never be guessed.
 
 It exists because the two seedeeps on a machine are **indistinguishable by their content**: the
 sessions come from `~/.claude/projects`, which belongs to Claude Code, so a dev portal and an
-installed one list exactly the same work. Everything else is separate — config, certificate, token,
-caches, records — and none of that is on screen.
+installed one list exactly the same work. Everything else is separate (config, certificate, token,
+caches, records) and none of that is on screen.
 
-**Only to a caller that has authenticated.** `GET /api/config` answers without a token, but that
-exemption was granted for one reason — the version has to be readable before a token exists — and
+Only to a caller that has authenticated. `GET /api/config` answers without a token, but that
+exemption was granted for one reason, that the version has to be readable before a token exists, and
 `dev` is not in that class: nothing needs it before authenticating, and it is the only field here
 that tells a stranger something about the operator's machine they could not already know (host and
 port are what they used to arrive). On loopback there is no token to present and nothing to prove,

--- a/docs/features.md
+++ b/docs/features.md
@@ -9,13 +9,13 @@ The README is the short version. The design behind these surfaces is in
 [`CHANGELOG.md`](CHANGELOG.md).
 
 > Every figure below is a **cropped still of a synthetic session** on a fictional
-> project, cut by `bun run doc-shots` — never a screenshot somebody took. Most come
+> project, cut by `bun run doc-shots`, never a screenshot somebody took. Most come
 > from a real recorded session, replayed. The rest come from a written transcript
 > (`apps/server/scripts/doc-scenes.ts`), because some states cannot be provoked on
 > request: an API call does not fail when you ask it to, Claude Code refuses to
 > compact a small session, and a retrospective is about a corpus rather than a
-> session. Those transcripts are synthetic in content and faithful in shape — the
-> same rule the test fixtures follow — and each is run through the real parser and
+> session. Those transcripts are synthetic in content and faithful in shape (the
+> same rule the test fixtures follow) and each is run through the real parser and
 > reducer by a test that asserts the state its figure claims.
 >
 > Each figure is declared in `apps/server/data/doc-shots.json` with the source files
@@ -23,13 +23,13 @@ The README is the short version. The design behind these surfaces is in
 > have made false. Nothing else can: no test looks at a PNG. What it names are
 > **candidates, not verdicts**: the map is per-file and `client/graph.ts` draws every
 > widget, so a single edit there names most of them at once. Whether a figure really
-> went false is the author's call — did what it *shows* change? — and
-> `bun run doc-shots` re-cuts it — `--ids <shot>` for one figure, nothing for all.
+> went false is the author's call (did what it *shows* change?), and
+> `bun run doc-shots` re-cuts it: `--ids <shot>` for one figure, nothing for all.
 > `--verify` settles it by re-cutting the suspects and **comparing the pixels**, but it
 > costs minutes, so it belongs to a release rather than to every push.
 >
-> **A release is not a reason to re-cut anything.** The two Settings figures print the
-> server's version, so a release does date them — but a figure documents the surface it
+> A release is not a reason to re-cut anything. The two Settings figures print the
+> server's version, so a release does date them, but a figure documents the surface it
 > photographs, not the version that happened to be running, and a stale number in it
 > makes nothing it claims false. The only thing that invalidates a figure is a change to
 > what it SHOWS.
@@ -37,8 +37,8 @@ The README is the short version. The design behind these surfaces is in
 ## The workspace — one tab per session
 
 seedeep is one page holding **a tab per session**, and the strip across the top is
-where you find one at a glance. A session that starts gets a tab by itself —
-**once**, so one you close stays closed — named `<project> · <first prompt>`, which
+where you find one at a glance. A session that starts gets a tab by itself,
+**once**, so one you close stays closed, named `<project> · <first prompt>`, which
 is what keeps two sessions of the same project apart. The open set, its order and
 which tab is active all survive a refresh.
 
@@ -46,12 +46,12 @@ State is shown rather than spelled, because the words would eat the room the
 subject needs: the dot **pulses** while the session is generating, turns **amber**
 when it has stopped and is waiting for YOU, and **red** when its last call to the
 model failed and nothing has succeeded since. A finished session goes quiet and its
-whole tab dims — that is a property of the tab, not a badge on it. The three states
-share one dot on purpose: they answer the same question, and a second marker would
+whole tab dims, which is a property of the tab rather than a badge on it. The three states
+share one dot: they answer the same question, and a second marker would
 turn the strip into a dashboard. Hovering spells out what the classes say, and gives
 a cut label its full text back.
 
-To open one that has no tab, the **session picker** — a glass combobox at the end of
+To open one that has no tab, the **session picker**, a glass combobox at the end of
 the header. Type to filter over the prompt, the model, the project or the id; every
 row leads with the session's own first prompt, next to a model chip and how long ago
 it ran. Sessions already open are pinned, and the roster splits **Human** from
@@ -59,15 +59,15 @@ it ran. Sessions already open are pinned, and the roster splits **Human** from
 of what a working machine accumulates, and unsplit they bury the handful of sessions
 anyone actually picks.
 
-The fixed surfaces — Home, Compare and Search — are not tabs, because a tab is a
+The fixed surfaces (Home, Compare and Search) are not tabs, because a tab is a
 session: they live in the header menu (☰), left of the wordmark.
 
 ## The live session view
 
-A live-first cockpit: the **Context** card — a dial and a real token breakdown —
+A live-first cockpit: the **Context** card, a dial and a real token breakdown,
 next to the live monitor (**Subagents · live**: the running subagents, each with its
 context filling in real time and its current action), and the **Live activity** feed
-filling the right — the two live signals at a glance. When what the session has
+filling the right: the two live signals at a glance. When what the session has
 running is background commands rather than subagents, that card is titled
 **Running · live** and monitors those instead: same place, same question, whichever
 kind of work is in flight.
@@ -75,7 +75,7 @@ kind of work is in flight.
 <img src="assets/shots/context-dial.png" width="459" alt="The context card: 263.1k of a 1.0M window, 26%, split by cache read, cache write and input">
 
 *The number is the whole point, so it is the biggest thing on the card. The bar
-below it is the same figure split by what it is made of — mostly context read back
+below it is the same figure split by what it is made of, mostly context read back
 from cache, which is billed too.*
 
 ### NOW — what it is doing, in one line
@@ -86,13 +86,13 @@ question you actually opened the tab for. Its label says which kind of answer it
 landed, `intent` for the words a settled turn left behind, and **`waiting for you`**
 when the session has stopped on you.
 
-What it shows, in order of preference, is the agent's own words — the narration it
-just wrote, or the turn's result — held long enough to be read and clamped to two
+What it shows, in order of preference, is the agent's own words: the narration it
+just wrote, or the turn's result, held long enough to be read and clamped to two
 lines, with **more** opening the full text. When there are no words to quote it says
 what is true instead of going blank: which tools are running and for how long, or
 `Started — no output yet`, or that a subagent is running in the background, or that
-one has returned and the turn is working on the result. It deliberately never says
-"waiting" for any of those — that word is reserved for the opposite state, the one
+one has returned and the turn is working on the result. It never says
+"waiting" for any of those: that word is reserved for the opposite state, the one
 where the session is stopped on you.
 
 A turn that is neither running nor left any words behind has no *now* to report, and
@@ -102,7 +102,7 @@ the panel is simply not there.
 
 The feed interleaves the **API calls** themselves with the tools each one
 triggered, every call carrying its latency. Click a call to read its **input and
-output** on demand — the model's text and tool args, plus the per-call token split
+output** on demand: the model's text and tool args, plus the per-call token split
 (cached context vs what was new) and the reasoning **effort** that call ran at,
 where Claude Code recorded one.
 
@@ -110,7 +110,7 @@ where Claude Code recorded one.
 
 *Read it top to bottom: every `API call` carries the time it took, the tools it
 fired sit under it, and anything a subagent did is tagged `SUBAGENT`. The panel at
-the top is the model's own last words — the turn's output as it arrives.*
+the top is the model's own last words, the turn's output as it arrives.*
 
 ### Toasts — what just happened, without looking away
 
@@ -121,9 +121,9 @@ side. Each rail holds five at most and evicts its oldest, so a burst is bounded 
 construction.
 
 They are timed by how much there is to take in: a tool toast is a **1.5s** glance, a
-spawn stays **5s** — long enough to also name the **model** it runs on, filled in the
+spawn stays **5s**, long enough to also name the **model** it runs on, filled in the
 moment that becomes knowable, since three quarters of subagents run on a different
-model than the session did — and a verdict announcement holds **8s**.
+model than the session did, and a verdict announcement holds **8s**.
 
 **Every tool toasts.** The single exception is `Agent`, and it is routing rather
 than suppression: a spawn already has the richer toast on the bottom rail, so a bare
@@ -132,24 +132,24 @@ than suppression: a spawn already has the richer toast on the bottom rail, so a 
 ### How much work it took, before you look for it
 
 The bar above the widgets answers the size of the session in one line, in **two
-groups**: how much work — turns, API calls, tool calls — and how long — the current
+groups**: how much work (turns, API calls, tool calls) and how long: the current
 turn, and every turn summed. The grouping is the readable part: five figures with
 four different units, set side by side without separators, read as one number with
 stray words in it. Selecting a turn re-scopes the bar to that turn, with the same
-two counts scoped along. Each count is named for what it counts — `33 API calls`,
-not `33 calls` — and hovering the group glosses them in the order they appear, which
+two counts scoped along. Each count is named for what it counts (`33 API calls`,
+not `33 calls`) and hovering the group glosses them in the order they appear, which
 is the only place that can say the number leaves the subagents out.
 
-Both counts already existed — the calls under the token ledger, the tools under
-four file paths in Main tools — and neither could be found, which is a placement
+Both counts already existed, the calls under the token ledger and the tools under
+four file paths in Main tools, and neither could be found, which is a placement
 problem and not a missing figure. The breakdowns stay where they are: `Bash 255 ·
 Edit 104 · Read 23` means something next to the tools that consumed the context,
 and nothing at all in a summary line.
 
 ### Which model, and how full that makes it
 
-Whatever scope you are looking at **names the model it ran on** — the banner and
-the Session card — because that model *is* the context window's denominator: a
+Whatever scope you are looking at names the model it ran on, the banner and
+the Session card both, because that model *is* the context window's denominator: a
 session that switched shows the one in force now and what it was before, so a
 changed window can never look like a full one. `/model` mid-session moves the bar,
 because 1M and 200k are not the same bar.
@@ -158,11 +158,11 @@ because 1M and 200k are not the same bar.
 
 *Three subagents of one turn, and three different denominators: the Haiku one is
 measured against 200k while the other two run on 1M. 15.6k is the smallest of the
-three figures and the fullest window on the card — which is why a percentage is
+three figures and the fullest window on the card, which is why a percentage is
 worth nothing until you know what it is a percentage of.*
 
 While a turn is open its **elapsed counts up**, and the session states how long it
-has **worked** — the sum of its turns, not the wall-clock span. The two differ by
+has **worked**: the sum of its turns, not the wall-clock span. The two differ by
 3× in the median session.
 
 ### The stats strip
@@ -171,20 +171,20 @@ Three equal-height cards: **Session** (tokens by API category plus turn KPIs),
 **Skills used** beside **Commands**, and **Changed files**.
 
 In the Session card the main-thread categories are headed *main session*, and the
-**Subagents** figure below them opens into a **by-model** bar — the subagent tokens
+**Subagents** figure below them opens into a **by-model** bar, so the subagent tokens
 split by which model actually burned them (charged per call, so a subagent that ran
 on two models shows as two), never mixing in the main thread.
 
 <img src="assets/shots/session-tokens.png" width="459" alt="The Session card: 2.9M tokens billed, 2.5M of them cache reads, and the subagents split across sonnet, haiku and opus">
 
 *One turn billed **2.9M** tokens, and **2.5M** of them are context read back from
-cache — the figure a session's own footer never shows you. Below it, the subagents'
+cache, the figure a session's own footer never shows you. Below it, the subagents'
 ~140.9k split by the model that actually burned it.*
 
 **Commands** chips are clickable: each opens a drawer listing every turn the
 command was typed in, with its per-turn count; clicking a turn scopes the whole
 view to it. **Skills** chips open a drawer showing model invocations (times the
-model called the Skill tool) and active turns — distinct from user-typed
+model called the Skill tool) and active turns, distinct from user-typed
 `/commands`, which appear in Commands.
 
 <img src="assets/shots/skills-commands.png" width="459" alt="The Skills and Commands card: the code-review skill, and the model, compact and code-review commands with their counts">
@@ -193,7 +193,7 @@ model called the Skill tool) and active turns — distinct from user-typed
 **commands you typed**. Each chip opens a drawer listing the turns it appeared in.*
 
 The **Changed files** widget answers *what did this touch*: a total plus a
-proportional bar per file extension, counted from **git** — the files of the
+proportional bar per file extension, counted from **git**: the files of the
 commits that session produced, so the number is one you can reproduce with
 `git show --stat`. Its description names the commits it counted, and a session that
 has not committed says so rather than showing a figure nothing can back.
@@ -201,7 +201,7 @@ has not committed says so rather than showing a figure nothing can back.
 Counting Claude Code's own file-history ledger instead would under-report badly:
 it records only what CC's own editing tools wrote, so a file rewritten by a shell
 command or produced by a build is invisible to it. And which session made a shell
-write is recorded nowhere at all, so it is never guessed. The ledger is still read for the one thing git cannot see — the
+write is recorded nowhere at all, so it is never guessed. The ledger is still read for the one thing git cannot see, the
 per-session scratchpad Claude Code uses for throwaway scripts, which lives outside
 your repository and gets its own row instead of inflating the total. A page the
 session published with the Artifact tool gets a row of the same kind: it is not a
@@ -212,14 +212,14 @@ listed under it as links. Full rules: [`session-output.md`](session-output.md#ch
 
 <img src="assets/shots/changed-files.png" width="459" alt="The Changed files card: four files in two commits, split by extension, and a row saying one artifact was published">
 
-*Four files, and the description names where the number came from — `Files in 2
+*Four files, and the description names where the number came from: `Files in 2
 commits`, which you can check with `git show --stat`. Under the bars, the page this
 session published: not a file that changed, so never part of the count.*
 
 ### The output row — Main tools · Commits · Cards
 
 At 50/25/25: what the session ran to get there, what it shipped, and what it was
-working on. All three are always on the page — a widget that appeared only once it
+working on. All three are always on the page, because a widget that appeared only once it
 had content could not report that there is none, so Commits and Cards carry their
 own empty state instead.
 
@@ -230,7 +230,7 @@ own empty state instead.
   (chars or ms).
 
   The full list is **grouped by turn**, each group collapsed behind a header
-  stating how many calls it holds and how much output they cost — so the question
+  stating how many calls it holds and how much output they cost, so the question
   "which turn ate the window" is answered before you open anything. The size
   ranking lives INSIDE the group, which is what keeps the ranking and the
   chronology from having to fight over one list. Every row carries a `#N` fixed in
@@ -239,19 +239,19 @@ own empty state instead.
   ![Main tools: four Read calls of 23k characters each at the top, then the tool types as counts](assets/shots/main-tools.png)
 
   *Four reads of the same file, 23k characters each, are most of what filled the
-  window in the figure above — which is the kind of thing you only argue about once
+  window in the figure above, which is the kind of thing you only argue about once
   you can see it.*
-- **Commits** — the commits that session produced, each opening on GitHub or
+- **Commits:** the commits that session produced, each opening on GitHub or
   GitLab, or marked `local` when it is not pushed. Attributed from the commit's own
   hash in the call that made it, so two sessions working on one repo never claim
   each other's work. Full rules: [`session-output.md`](session-output.md#commits).
 
   <img src="assets/shots/session-commits.png" width="344" alt="The Commits card: two commits, both marked local, each with its short hash and subject">
 
-  *Two commits, and neither has been pushed — so the card says `local` rather than
+  *Two commits, and neither has been pushed, so the card says `local` rather than
   offering a link that would 404. The hash is the proof: it is the one the session's
   own `git commit` printed.*
-- **Cards** — the tracker cards the session touched, each opening on its tracker.
+- **Cards:** the tracker cards the session touched, each opening on its tracker.
   Read from the calls that named them, never from a key typed in a prompt, where
   most key-shaped strings name no tracker at all (`GPT-4`, `UTF-8`). A row says
   whether the session **changed** the card or only **read** it. Full rules:
@@ -259,13 +259,13 @@ own empty state instead.
 
   <img src="assets/shots/tracker-cards.png" width="344" alt="The Cards card: two tracker cards with their titles, one badged read, the other changed by the session">
 
-  *Two cards, and the difference is the point: one the session moved, one it only
-  looked at — which the `read` badge says and the description counts.*
+  *Two cards: one the session changed, one it only looked at. The `read` badge marks
+  the second, and the description counts both.*
 
 ### The subagents grid
 
 The full grid sits below, in launch order. Click a subagent to see its launch
-prompt, the tools it called, and — the point — **the verbatim output it returned to
+prompt, the tools it called, and, the point of the card, **the verbatim output it returned to
 the main session**.
 
 ![Six subagents in launch order, three done and three running, each with its model, volume, context and what it returned](assets/shots/subagents-grid.png)
@@ -277,36 +277,34 @@ each is measured against that model's own window.*
 <img src="assets/shots/subagent-drawer.png" width="549" alt="A subagent's drawer: model, duration, tool calls, what it returned, its launch prompt, and the verbatim text it handed back">
 
 *The drawer, scrolled: what the parent asked it to do (`LAUNCH PROMPT`), and under
-it `RETURNED TO MAIN` — the text the main session actually received, verbatim. This
-is the one thing a transcript reader cannot reconstruct by eye, because the parent's
-own log holds only the tool call and the result.*
+it `RETURNED TO MAIN`: the text the main session actually received, verbatim. The parent's
+own log holds only the tool call and its result, so this text is not in it.*
 
 A subagent appears the instant it is **launched** (not when its transcript shows
-up) and stays `running` for as long as it really works — background subagents
+up) and stays `running` for as long as it really works, since background subagents
 included, which is now Claude Code's default. It ends as `done`, `failed` or
 `killed`; `unknown` means seedeep never learned its fate rather than pretending to
-know. A **workflow run** takes one aggregate row — fleet size, how many of its
-subagents are still working, tokens, and the model breakdown — instead of flooding
+know. A **workflow run** takes one aggregate row: fleet size, how many of its
+subagents are still working, tokens, and the model breakdown, instead of flooding
 the grid with the ~100 it spawns.
 
 #### Background commands share that card
 
 A session launches shell commands into the background as readily as it launches
-subagents, and each one gets a catalogue row that outlives it — so a command that
+subagents, and each one gets a catalogue row that outlives it, so a command that
 **failed** is still there to be found, which is the one thing you needed to be told.
 
-The card holds both lists behind two tabs, and it grows them **only when both have
-something in them**: with commands and no subagents (or the reverse) it is simply
-the one list, with no switch to press. The tab you land on is always Subagents — a
-default that moved on its own would leave you unsure what you were reading — and
+The card holds both lists behind two tabs, and it grows them only when both have
+something in them: with commands and no subagents (or the reverse) it is simply
+the one list, with no switch to press. The tab you land on is always Subagents, since a
+default that moved on its own would leave you unsure what you were reading, and
 the closed tab carries **its count and its failures on its own label**, so nothing
 that needs attention is hidden behind an unmarked door.
 
-![The bottom card on its Background commands tab: six commands in launch order — two done, two failed with their exit codes, one still running and one monitor carrying its event count — beside a Subagents tab carrying the count of the other list](assets/shots/background-commands.png)
+![The bottom card on its Background commands tab: six commands in launch order (two done, two failed with their exit codes, one still running and one monitor carrying its event count) beside a Subagents tab carrying the count of the other list](assets/shots/background-commands.png)
 
 *The same card, switched to its other catalogue. The tab you are not on carries its
-own count, and its failures with it — which is what makes hiding one list behind a
-tab safe.*
+own count, and its failures with it, so nothing is hidden by the tab that is closed.*
 
 A command reaches the background three ways, and the rows say which when it is not
 the obvious one: the agent asked for it, **the call's own timeout** promoted a
@@ -315,30 +313,30 @@ ask for up to ten), or **you** pressed `Ctrl+B` and took it away from the agent.
 reader, and it is much the commonest, so its rows stay bare; the other two carry a chip,
 `auto-backgrounded` and `backgrounded by you`, on the live row, on the catalogue row
 it becomes, and in the drawer both open. A command whose receipt is too old to say
-which it was reads as the bare case: an omitted chip, never a wrong one.
+which it was gets no chip, rather than a chip that might be wrong.
 
 Each command is one line: what it was launched to do (Claude Code's own
 `description`, the name it quotes back when the command ends), its state, the turn
-that started it, its exit code, and **how long the command itself ran** — launch
+that started it, its exit code, and **how long the command itself ran**, not the launch
 instant to the notification that ended it, which for a killed build can be hours.
 A command still running has no duration to state, so it states its **age** instead,
 ticking, exactly as the live row above does: one command described two ways on one
 screen was a discrepancy, not a nuance.
 The row's duration is never the launch call's, which closes in milliseconds and
-measures nothing — and never the SECOND copy of the notification either: Claude
+measures nothing, and never the SECOND copy of the notification either: Claude
 Code writes it twice, and the later copy is written when its queue drains, long
 after the command actually stopped.
 
-**A `Monitor` is one of these commands.** It is Claude Code's watcher — a `tail -f`
-on a build log, a poll of a CI run — and it behaves like any background command:
+A `Monitor` is one of these commands. It is Claude Code's watcher, a `tail -f`
+on a build log or a poll of a CI run, and it behaves like any background command:
 armed once, running for as long as it watches, ended by a notification.
 
-**What ends a monitor is not what ends a shell command.** A background `Bash`
-announces its own death twice over — a notification, and the moment it lets go of
+What ends a monitor is not what ends a shell command. A background `Bash`
+announces its own death twice over: a notification, and the moment it lets go of
 its output file, which is what seedeep asks the machine when the notification never
 comes. A monitor does neither: it holds no file open, and stopping it writes no
-notification at all. What it does write is the `TaskStop` itself —
-*"Successfully stopped task: …"*, naming the task —
+notification at all. What it does write is the `TaskStop` itself,
+*"Successfully stopped task: …"*, naming the task,
 and that sentence is what closes the row. Without it a monitor you stopped would go
 on calling itself *still running* for the rest of the session.
 
@@ -349,61 +347,61 @@ activity feed would leave room for nothing else there. The count is what tells a
 monitor that is working from one that has been silent since it was armed.
 
 Its drawer adds the full command, the sentence Claude Code wrote when it ended (the
-only place the exit code exists) and the **output file** — the path where the
+only place the exit code exists) and the **output file**, the path where the
 command's output was written. The notification that ends a command carries it in a
 tag of its own, and the launch receipt carries the same path in prose (`Output is
 being written to: …`), which is what makes it readable for a command whose end is
 never written at all.
 
-**A scheduled wakeup shares the band, and it is not a command.** When a session paces
-itself (a `/loop` with no interval), it arranges to wake itself up later — nothing
+A scheduled wakeup shares the band, and it is not a command. When a session paces
+itself (a `/loop` with no interval), it arranges to wake itself up later, and nothing
 runs in the meantime, nothing holds a file open, there is nothing to probe. It is a
 commitment, so it gets a row of its own, amber rather than green, saying when it will
 wake and how long that is from now.
 
 The row stops being drawn the moment its instant passes, and that is deliberate:
-Claude Code writes **nothing** when a wakeup fires — no line, no marker that tells it
-from any other system message — so seedeep can say what the session is waiting for and
+Claude Code writes **nothing** when a wakeup fires: no line, no marker that tells it
+from any other system message, so seedeep can say what the session is waiting for and
 never that it happened. A countdown running into the negative would be claiming a wait
 that is over; saying "fired" would be claiming knowledge that is not on disk.
 
 A command whose end **Claude Code never wrote** is the one row seedeep cannot read
 off the transcript: some launches get no notification ever, and the rule "launched,
 nothing said" means *still running* for as long as the session stays open. seedeep
-asks the machine instead — nothing holding its output file open means the process
-is gone — and the row reads **`unknown`** with its duration as a bound
+asks the machine instead, since nothing holding its output file open means the process
+is gone, and the row reads **`unknown`** with its duration as a bound
 (`≥ 4m 20s`, the last instant it was seen alive). Never `done`: the check learns
 that something stopped, not what it stopped with. The mechanism is in
 [`docs/architecture.md`](architecture.md#is-a-background-command-still-alive).
 
 The cockpit above keeps its half of the job, and only that half: it draws **what is
 still running**, and nothing else. A command that failed or was never reported is
-*counted* there and never drawn — the line reads `2 commands failed below · 1 never
+*counted* there and never drawn: the line reads `2 commands failed below · 1 never
 reported below`, the same way that card already points at a subagent that has
 finished. A card headed LIVE must never list the dead. The count is what keeps the
 failure from vanishing in silence; the catalogue below is where it is actually
 stated.
 
-Every entity — subagent, tool call, tool type, API call, skill — opens a **detail
+Every entity (subagent, tool call, tool type, API call, skill) opens a **detail
 drawer**; drill-down clicks (e.g. a tool inside a subagent's drawer) show a
 **breadcrumb** so you can navigate back without losing context.
 
 The view reconstructs identically live and in replay; an **ended** session drops
-the live chrome — the monitor collapses to a one-line summary, and the LIVE badge
+the live chrome: the monitor collapses to a one-line summary, and the LIVE badge
 yields to a quiet "ended". That state is not final: `claude --resume` continues the
-SAME session, so when its process comes back the tab you already have **goes live
-again by itself** — the dim lifts, the badge returns, and the tab reads the lines
+SAME session, so when its process comes back the tab you already have goes live
+again by itself: the dim lifts, the badge returns, and the tab reads the lines
 written while it was frozen. Nothing has to be reopened, and no refresh is needed.
 
 ## The turn as a lens
 
 The **Timeline**, the strip across the top of the session, shows **everything you
-sent** — typed prompts and slash commands alike — and colours each entry by what it
+sent**, typed prompts and slash commands alike, and colours each entry by what it
 actually cost: a round of work (green
 while it is burning tokens, red if you hit Esc), a context event (`/clear`,
 `/compact`, a compaction), or a local command that cost nothing.
 
-![The timeline: eight things sent, coloured by what each cost — a work turn, a grey local command, a red interrupted turn, a violet compaction](assets/shots/timeline-strip.png)
+![The timeline: eight things sent, coloured by what each cost: a work turn, a grey local command, a red interrupted turn, a violet compaction](assets/shots/timeline-strip.png)
 
 *One column per thing you sent, and the colour is the cost: green while a turn burns
 tokens, **red** where Esc cut one off, **grey** for a local command that cost nothing,
@@ -411,17 +409,17 @@ tokens, **red** where Esc cut one off, **grey** for a local command that cost no
 
 Click one and **every widget re-scopes to it**: context, token usage, tools,
 subagents, skills, commands, and the activity feed. Prompts and results open in
-full, rendered as markdown. An interrupted turn is the point of the whole view:
-everything it consumed, and no answer to show for it.
+full, rendered as markdown. On an interrupted turn this shows
+everything it consumed with no answer to show for it.
 
 ## A verdict on every turn, both faces
 
-Seven deterministic checks (no LLM) score each turn for waste — a subagent that
+Seven deterministic checks (no LLM) score each turn for waste: a subagent that
 returned a large output, a mid-turn compaction, a second Esc in a row, a **cold
 resume**, a context window ≥70% full, an **exploration** that read many files and
 changed nothing, or code **committed with no check** run anywhere in the session.
 
-Every check quotes the public Claude Code documentation that justifies it —
+Every check quotes the public Claude Code documentation that justifies it,
 including the one that says a *single* Esc is the recommended behaviour, not waste.
 No check compares a turn to your other turns: how BIG a turn was is not the same
 as waste.
@@ -440,12 +438,12 @@ cost, and what went well.
 
 *The lens dims everything else and names what each flagged turn did: one read nine
 files and changed nothing, the next pulled a **7.8k-character** subagent report into
-the main context. Both are lower bounds — a check says only what it can prove.*
+the main context. Both are lower bounds: a check says only what it can prove.*
 
 ### One turn, as a card you can post
 
-**⇪ Share** — on every row of the lens, and on the banner of a turn you have scoped
-into — renders that turn as a PNG: what it spent, that figure against the p50, p90
+**⇪ Share**, on every row of the lens and on the banner of a turn you have scoped
+into, renders that turn as a PNG: what it spent, that figure against the p50, p90
 and p95 of its own bucket, every finding with its price, what it did right, and a
 strip of what the turn actually DID (API calls, tool calls, subagents, tokens
 re-read from cache, the model and its effort). A verdict with no activity behind it
@@ -456,29 +454,29 @@ baseline, the card says exactly that instead of inventing a multiple.
 
 *The card of the turn the lens flagged, in the preview that opens first: **⬇ Download**
 is a separate click, so a card you did not mean to make never reaches your disk. The
-button belongs to the turn it sits on, never to whatever the view is scoped into —
+button belongs to the turn it sits on, never to whatever the view is scoped into,
 the turn you are reading is always the turn the card describes.*
 
-**Nothing in the card can name your work**, and it says so along its own foot: no
-prompt, no file path, no project or session name — the only word that comes from
+Nothing in the card can name your work, and it says so along its own foot: no
+prompt, no file path, no project or session name. The only word that comes from
 your setup is the *type* of a subagent a finding quotes (`general-purpose` above).
-That is what makes it postable without a review pass over it first.
+So it can be posted without reading it through first.
 
 The page draws its own PNG, from the data it is already showing: no server, no second
-browser, nothing sent anywhere — which is also why it works from the compiled
+browser, nothing sent anywhere, which is also why it works from the compiled
 executable, where a headless Chrome could never be bundled.
 
 ## When a session is waiting for YOU
 
 A session stopped at an approval dialog (or an `AskUserQuestion`) is normally
-indistinguishable from an idle one — nothing about it reaches the logs. seedeep
+indistinguishable from an idle one, because nothing about it reaches the logs. seedeep
 reads it from Claude Code's own live session state and shows it: the tab dot turns
 **amber**, an amber toast announces it, and the Live activity's NOW panel says what
-it is waiting to approve and for how long — clearing itself the moment you answer.
+it is waiting to approve and for how long, clearing itself the moment you answer.
 seedeep only *shows* it; it never answers for you.
 
-A session whose host publishes no state of its own — the desktop app's
-**Code** tab, a headless run — has this read off its transcript instead. That
+A session whose host publishes no state of its own (the desktop app's
+**Code** tab, a headless run) has this read off its transcript instead. That
 reaches a question the model asked you, and not a tool waiting for your
 approval: a call awaiting a yes and a call that is running are the same line,
 so such a session reads as working rather than amber.
@@ -487,12 +485,12 @@ so such a session reads as working rather than amber.
 
 *Amber means the session cannot move until you do, and the age keeps counting so a
 minute lost is a minute you can see. This state is the one thing in seedeep that
-comes from outside the transcript — it is in Claude Code's live session file, which
+comes from outside the transcript: it is in Claude Code's live session file, which
 is why a stopped session looks exactly like a thinking one everywhere else.*
 
 ## When a session is BROKEN
 
-An API call that fails — an expired login, a session limit, an overloaded server —
+An API call that fails (an expired login, a session limit, an overloaded server)
 ends the turn and leaves the session sitting there. It is the quietest failure
 there is: a failed call is usually the last model line its session ever writes,
 and nothing on screen says so.
@@ -501,26 +499,26 @@ seedeep makes it a state rather than a passing message: the tab dot turns **red*
 the menu-bar icon turns red above every other signal, the tray panel files the
 session under **Broken** with the message Claude Code itself showed, and a
 notification says which session broke. It clears itself on the next call that
-succeeds — never on a timer.
+succeeds, never on a timer.
 
 ![The feed of a broken session: the last API call carries the message Claude Code showed, and nothing follows it](assets/shots/broken-session.png)
 
-*The last thing this session ever wrote. The message is Claude Code's own, verbatim —
+*The last thing this session ever wrote. The message is Claude Code's own, verbatim,
 seedeep never paraphrases what failed, because the wording is what tells you whether
 to wait, log in again, or switch model.*
 
 ## Failures stand out
 
 A tool that failed or an API call that errored (rate limit, auth, prompt too long)
-carries a red badge wherever it appears — the Live activity feed, both Expand-all
-lists, and the drawer — and reddens its Trace span, with a folded round/chapter
+carries a red badge wherever it appears (the Live activity feed, both Expand-all
+lists, and the drawer) and reddens its Trace span, with a folded round/chapter
 flagged red so a failure buried in a collapsed group is still visible. A tool the
 *user* refused (an Esc on the permission prompt) is not a failure and is never
 flagged.
 
 ![The feed with a failed Read carrying a red ERROR badge, and the calls around it succeeding](assets/shots/failed-tool.png)
 
-*The badge sits on the row itself, so a failure is visible without opening anything —
+*The badge sits on the row itself, so a failure is visible without opening anything,
 and the call after it succeeded, which is why this is a badge and not a session state.*
 
 ## When something else has a warning for you
@@ -533,17 +531,17 @@ otherwise pass through a session and leave no mark on any surface.
 
 seedeep shows it where it belongs, and *where* depends on what it is about:
 
-- **A note about one call** — the common case, and the security plugin about a `Write`
-  or an `Edit` is nearly all of it — marks that call. A ⚑ on its Trace block, a chip in
+- **A note about one call**, the common case, and the security plugin about a `Write`
+  or an `Edit` is nearly all of it, marks that call. A ⚑ on its Trace block, a chip in
   its drawer, and the text itself in the drawer, verbatim, above the call's own
   arguments. It is a warning about what that call did, so it sits with the call and
   nowhere else.
-- **A note about the session** — work that ran with no call of its own, like the
-  background security review — goes into the activity feed, because there is no row it
+- **A note about the session**, work that ran with no call of its own like the
+  background security review, goes into the activity feed, because there is no row it
   could be attached to. Pinning it on whichever call happened to be open would be an
   invention. The feed is a glimpse, though: it holds thirteen rows per turn, and a
   finding you have to catch within ten activities is one you will miss. So the note is
-  **also in Expand all**, the turn's complete history and the one list with no cap — in
+  **also in Expand all**, the turn's complete history and the one list with no cap, in
   time order, which lands it right after the call that provoked it. It is the only row
   there that is not a call, so it is named in amber and carries no duration.
 
@@ -556,12 +554,12 @@ drawer behind it shows what was written, verbatim.
 The chip in the eyebrow is what tells you there is something to read before you open it.*
 
 Nothing here is modelled as "a security finding". What the transcript records is that
-something had text to say, and the writer names itself in it — a plugin, a hook you
+something had text to say, and the writer names itself in it: a plugin, a hook you
 wrote yourself. A feature keyed on one plugin's name would go blind the day another one
 speaks.
 
-The marks are amber, never red: a call somebody warned about is not a call that failed,
-and the two can be true of the same row at once.
+The marks are amber rather than red. A warning and a failure are separate states, and a
+row can carry both.
 
 ## Nothing is hidden from you
 
@@ -574,17 +572,17 @@ selected. Every row opens the same detail drawer as the rest of the app.
 
 Across the whole session that list is thousands of rows, so it arrives **grouped
 by turn**: one collapsible header per turn saying how much is inside, and only the
-most recent one open. Nothing is hidden — a group builds its rows the moment you
+most recent one open. Nothing is hidden: a group builds its rows the moment you
 open it, and typing in the filter opens every group that has a match. What you
 opened stays open: following a row into its detail and coming back by the crumb
-returns you to the list as you left it — and until you open one yourself, the
+returns you to the list as you left it, and until you open one yourself the
 newest turn is the one that greets you, however far the session has moved on.
 Scoped to a single turn there is nothing to group by, and the list stays flat.
 
 <img src="assets/shots/expand-all.png" width="549" alt="The complete activity list: 46 activities, 19 tool calls, 24 API calls over 3m32s, with each subagent's API calls and reads indented under the Agent spawn that launched them">
 
 *Forty-six activities where the card itself holds twelve. The three `Agent` rows
-are spawns, and what each subagent did sits indented underneath — its own API
+are spawns, and what each subagent did sits indented underneath: its own API
 calls and reads, tagged with the agent type, in the order they happened.*
 
 ## Trace — the whole session as one flow diagram
@@ -594,15 +592,15 @@ place into the strip of what actually happened.
 
 ![One turn in the Trace: 41 steps, one failed, folded into two chapters, a spawn block for three parallel subagents, and the closing round](assets/shots/trace-chapters.png)
 
-*One turn, 41 steps, and none of them hidden: the two grey blocks are chapters —
-`R1–10` and `R11–18` — that expand in place, while the landmarks stay out where you
+*One turn, 41 steps, and none of them hidden: the two grey blocks are chapters,
+`R1–10` and `R11–18`, that expand in place, while the landmarks stay out where you
 can see them. The teal block IS the spawn of three parallel subagents, the red edge
 on the first chapter is the failed step inside it, and the row above says `1 failed
 step` so a failure folded into a group is still visible from outside.*
 
 Built to stay readable at real scale (a turn can hold hundreds of steps):
-consecutive rounds of work fold into **chapters** you expand in place, while the landmarks —
-spawns, skills, replies — always stay visible. Live, the newest block glows and the
+consecutive rounds of work fold into **chapters** you expand in place, while the landmarks,
+spawns, skills and replies, always stay visible. Live, the newest block glows and the
 view follows it; a spawn block IS its subagent (launch intent, tools, real
 duration) and unfolds the child's own flow as a parallel lane below, filling
 **while the agent runs**. Every block clicks through to the same drawer as the rest
@@ -614,22 +612,22 @@ First entry of the header menu (☰, left of the wordmark), never closable, and
 filled before you run anything: it reads the sessions already on disk, so an empty
 workspace never looks like a broken page.
 
-**With nothing to show it opens with the REASON, not with a pitch** — *"seedeep
+With nothing to show it opens with the REASON, not with a pitch: *"seedeep
 needs a Claude Code session. There is none on this machine yet."*, then what to do
 (`claude`, in any project) and what is being watched (`~/.claude/projects`), with
 the privacy claim attached to the directory that makes it checkable rather than
 standing alone as a promise. That box has to be true in three different situations,
 which is why it has three forms: a machine with no session, a session that exists
 but has closed no turn (*"There are sessions here, none with a finished turn yet"*
-— and it says the session is watchable **now**, from the picker), and a
+and it says the session is watchable **now**, from the picker), and a
 retrospective that has not arrived, where the claim about the machine is dropped
 because nothing was read. Which form appears comes from the **roster**, never from
 the retrospective: the latter counts only sessions that finished a turn, so a
 transcript with none is absent there and present in the picker directly above the
-box. No count is printed — the number would be a third way of stating a figure the
+box. No count is printed, because the number would be a third way of stating a figure the
 page already gives twice.
 
-It answers *how do I actually use this agent* — your median turn against its p95,
+It answers *how do I actually use this agent*: your median turn against its p95,
 the tokens spent (the COMPLETE figure, cache reads included, because those are
 billed too), API calls, how many turns wasted tokens, what you abandoned to Esc,
 and the hours you spent working.
@@ -637,14 +635,14 @@ and the hours you spent working.
 The hero is the **turn-size distribution**: the shape of how you spend new tokens,
 with your p50 and p95 marked on it. Alongside, **activity** follows the time
 filter: `7d` draws one bar per day ("6d ago → today"), `30d` one bar per calendar
-week over the last ~30 days, and all-time the full weekly cadence — readable three
+week over the last ~30 days, and all-time the full weekly cadence, readable three
 ways from tabs in the card: `tokens` (the volume of work), `turns` (split crit /
 warn / clean), and `hours` (time actually worked).
 
 Below: where the waste comes from, tokens split by the model that spent them
 (**subagents counted under their own model**, so a Haiku explorer inside an Opus
 session shows up as Haiku), tool calls by type, and the verdict split. A
-`7d / 30d / all` filter switches window instantly — all three ride in one response,
+`7d / 30d / all` filter switches window instantly, since all three ride in one response,
 nothing refetches. A persistent, incremental cache keeps the tab instant: a full
 corpus scan takes seconds, which is too slow for a launch surface, so only what
 changed on disk is ever re-read.
@@ -662,46 +660,46 @@ flat: an Opus token and a Haiku token are not the same thing, and the raw total 
 overwhelmingly cache re-reads, so an unweighted ranking just sorts by how long a
 session stayed open.
 
-A row is three stacked lines — the prompt, every fact about the session on one line
+A row is three stacked lines: the prompt, every fact about the session on one line
 (project, the model its main thread ran on, when it ran, API calls, the complete token
 count with cache reads included, the subagents' share), then the bar at full
-width — and the bar carries two facts at once: its length is the session's weight,
+width, and the bar carries two facts at once: its length is the session's weight,
 its segments are the model mix, so *how heavy* and *why* are one object.
 
 Sessions the weighting moved by 3 places or more say so (`▲N vs unweighted`), the
-sessions below the cut are still summed rather than quietly dropped, and **clicking
-a row opens that session's own tab**, so the leaderboard is the way in and not just
+sessions below the cut are still summed rather than quietly dropped, and clicking
+a row opens that session's own tab, so the leaderboard is the way in and not just
 a report.
 
 The weights per kind of token are Anthropic's own published burndown rates; the
 ratio between models is derived from the price list and marked as ours, since
 Anthropic publishes none. It is a **token count, never a cost in dollars**, and it
-never invents an "equivalent" unit — a permanent *how this is computed* block
+never invents an "equivalent" unit, and a permanent *how this is computed* block
 explains the number instead of a label nobody could interpret.
 
 ![Compare: five sessions ranked by tokens weighted by model, each row carrying the prompt, the facts and a bar segmented by model mix](assets/shots/compare-leaderboard.png)
 
 *Each bar says two things at once: its length is the session's weight, its segments are
-the model mix — so the Haiku session's 106.6k tokens weigh less than the Sonnet one's
-27.5k. The permanent *how this is computed* block is there because a number nobody can
-interpret is worse than no number.*
+the model mix, so the Haiku session's 106.6k tokens weigh less than the Sonnet one's
+27.5k. The permanent *how this is computed* block spells out the
+weighting, so the number can be checked rather than taken on trust.*
 
 ## Search — find the session that solved it
 
 The menu's third surface: type the two or three words you remember and get the
-sessions whose **dialogue** holds all of them — your prompts and Claude's answers,
+sessions whose **dialogue** holds all of them: your prompts and Claude's answers,
 never the raw transcript (injected instructions, system reminders and tool results
 match twice as often and say nothing about what a session was for). Every word is
 an AND term.
 
-Rows are ranked by **density** — occurrences per 1k characters of dialogue —
+Rows are ranked by **density**, occurrences per 1k characters of dialogue,
 because ranking by raw occurrences ranks session *length*: the longest session wins
 a query it barely touched, while the short one that was entirely about it sits
 fifth. `occurrences` and `recent` are one click away, and each order sorts by the
 number the row prints.
 
 Paste a **commit hash** instead and the search also asks git which session produced
-it — the hash of a commit lives in the output of the command that made it, which
+it: the hash of a commit lives in the output of the command that made it, which
 the dialogue index excludes, so the session that did the work is exactly the one
 text search misses. Same rows, same order, only more of them.
 A **tracker id** (`ABC-12`, `#42`) works the same way and for the same
@@ -711,7 +709,7 @@ search never pays for it.
 
 Each row shows the passages that matched, attributed to **you** or **claude** and
 highlighted, and carries two ways out: **open the session in a tab**, or take its
-**full session id** — spelled out on the row, one click to copy — for
+**full session id**, spelled out on the row and one click to copy, for
 `claude --resume`; the same chip makes the picker's id copyable too. Automated
 `sdk-*` runs are kept aside behind a control that states its own count, never
 dropped, and nothing is truncated. The index is seedeep's own file, incremental and
@@ -720,40 +718,39 @@ per query. Full rules: [`search.md`](search.md).
 
 ![Search: the sessions whose dialogue holds every word, each row showing the matched passages attributed to you or claude](assets/shots/search-results.png)
 
-*Two words, and the ranking is the point: the SHORTEST session is first, because it
-mentioned them once in very little dialogue. Ranking by raw occurrences would have put
-the longest session on top, which is how a search comes to answer with the session you
-were not looking for.*
+*Two words, and the SHORTEST session ranks first: it mentioned them once in very little
+dialogue. Ranking by raw occurrences instead would have put the longest session on top,
+which is a ranking of session length.*
 
 ## The menu-bar tray
 
-The same signal where you are already looking. The icon **turns while a session is
-working**, goes **amber, and still, the moment one stops and needs you**, and
-**red when one of them breaks** — motion means *running, nothing for you to do*, so
+The same signal where you are already looking. The icon turns while a session is
+working, goes amber, and still, the moment one stops and needs you, and
+**red when one of them breaks**. Motion means *running, nothing for you to do*, so
 the thing you can act on is the thing that holds still, and a session whose call
 failed outranks one merely waiting, because an approval resumes the instant you
 answer it and a failed call does not resume at all.
 
-A notification when either happens, and optionally one when a session finishes —
+A notification when either happens, and optionally one when a session finishes.
 one title and one line, never the detail. A click opens a small panel of your live sessions
-ordered by urgency — **Broken**, *Needs you*, *Working*, *Idle*: what each one is
+ordered by urgency (**Broken**, *Needs you*, *Working*, *Idle*): what each one is
 asking for or what failed, what it says it is doing, its newest call, how full its
-context is. Only the sessions a person is actually in — headless `claude -p` runs
+context is. Only the sessions a person is actually in, since headless `claude -p` runs
 never appear.
 
 It is a **pure HTTP client** of the same API the browser uses: it parses no
 transcript and owns no reducer, so the meaning it shows is the server's, computed
-once. What it does hold is a handful of presentation rules copied deliberately —
-chiefly *what counts as waiting on you* — each pinned to the server's by a test,
+once. What it does hold is a handful of presentation rules copied from it,
+chiefly *what counts as waiting on you*, each pinned to the server's by a test,
 because a client that links no code cannot import one.
 
 ![The tray panel on a live session: the sessions ordered by urgency, each with what it is doing and how full its context is](assets/tray.gif)
 
-*The same session as everything above, from the menu bar — the one surface that is a
+*The same session as everything above, from the menu bar, the one surface that is a
 recording rather than a crop, because the tray is a native app and not a page.*
 
 Packaged by CI from a tag into a universal DMG and a Windows `-setup.exe`,
-**unsigned**. **Used daily on macOS, and in a VM on Windows** — see [Which platforms have
+**unsigned**. **Used daily on macOS, and in a VM on Windows**; see [Which platforms have
 actually been run](../README.md#which-platforms-have-actually-been-run), because this project
 does not call a thing measured when it has not been. Full rules:
 [`tray.md`](tray.md).
@@ -769,13 +766,13 @@ on every API route.
 <img src="assets/shots/settings-panel.png" width="549" alt="The settings panel: port 45999, host 127.0.0.1, the auth token redacted behind a Regen button, the access URL, and the version of the server answering">
 
 *The panel as every install starts: bound to `127.0.0.1`, so the token is inert
-and there is no certificate to pin — the TLS block appears only once you name
+and there is no certificate to pin, so the TLS block appears only once you name
 another host. **Version** is the server that answered this request, not the one
 you installed.*
 
 <img src="assets/shots/settings-remote.png" width="549" alt="The same panel on a server bound to a LAN address: a banner announcing remote access, the TLS block with its common name and the certificate's SHA-256 fingerprint, and an https access URL carrying the token">
 
-*The same panel with the host named — the whole second posture in one picture. The
+*The same panel with the host named: the whole second posture in one picture. The
 banner is the warning that the browser will meet a self-signed certificate; the
 **Common name** is what that certificate is issued for; while it is missing or
 unusable nothing in the panel is written at all, so a remote host cannot be
@@ -784,22 +781,22 @@ warning away has to pin. It is the RUNNING server's certificate, so it fills in 
 after the restart, and the access URL turns `https` and carries the token. Turning it
 on: [`install.md`](install.md#remote-access).*
 
-That version is beside the wordmark too, on every portal — it is the number a bug
+That version is beside the wordmark too, on every portal, because it is the number a bug
 report quotes, and it says which of two seedeeps you are looking at. A portal served
 from a **checkout** says so as well, with a `dev` chip and a browser tab reading
 `seedeep dev`: both watch the same sessions (the transcripts belong to Claude Code,
 not to seedeep), so a dev portal and an installed one show identical content, and the
 tab you are about to change a setting in would otherwise be a coin toss. A released
-build carries no chip — a badge present on every install is a badge nobody reads.
+build carries no chip: there is nothing there to tell apart.
 
-Configuration lives in `~/.seedeep/config.json` — CLI flag over environment
-variable over file over default — and the settings panel edits it in place. No
+Configuration lives in `~/.seedeep/config.json`, with CLI flag over environment
+variable over file over default, and the settings panel edits it in place. No
 tunnel ships with `seedeep`: an SSH port-forward or a VPN already solves that, and
 re-solving it would only add a second, weaker way in. How to turn it on:
 [`install.md`](install.md#remote-access).
 
-**A server keeps the port, host and certificate name it started with**, so a config
-changed since — in the panel or in an editor — is a file saying one thing and a
+A server keeps the port, host and certificate name it started with, so a config
+changed since, in the panel or in an editor, is a file saying one thing and a
 process doing another. An amber dot on the Settings button says so with the panel
 closed, and the panel explains it with the button that ends it; the tray says it above
 its sessions and `seedeep status` prints it. It is the SERVER's comparison, against
@@ -808,47 +805,47 @@ by `--port` is not pending, because a restart would go on ignoring the file ther
 
 ## The engine underneath
 
-- **Core engine** — read-only, runtime-agnostic watcher + parser: session
+- **Core engine:** read-only, runtime-agnostic watcher + parser: session
   discovery, incremental tailing, and a normalized per-session event stream
   (context fill, attribution, compaction, subagent tree).
-- **Local server** — serves a page and streams live events to the browser over a
+- **Local server:** serves a page and streams live events to the browser over a
   single multiplexed SSE feed, plus a read-only session roster and a read-only
   replay stream for finished sessions.
-- **GUI shell** — one tabbed page (the workspace above), with **replay** for
+- **GUI shell:** one tabbed page (the workspace above), with **replay** for
   finished sessions and a per-tab subscription over the shared feed, so a dozen
   open tabs still cost one connection and closing one leaks nothing.
 
 
 ## Notifications
 
-seedeep tells you when a session **stops on you**, when one **breaks**, and — if
-you ask for it — when one **hands the turn back**. The server decides all three:
+seedeep tells you when a session **stops on you**, when one **breaks**, and, if
+you ask for it, when one **hands the turn back**. The server decides all three:
 it holds the transitions, the switches and the wording, so a banner and the panel
 row it belongs to can never describe one event in two ways.
 
-Each **delivery channel has its own switches**. The same moment can be worth a
+Each delivery channel has its own switches. The same moment can be worth a
 banner on the machine you are sitting at and not worth a push somewhere else, and
-one shared set cannot say that. Both sets are edited from the portal's Settings —
+one shared set cannot say that. Both sets are edited from the portal's Settings,
 the tray's four under *Tray notifies you when*, the webhook's three beside its
-URL — because the server is what holds them, and a second place to answer one
+URL, because the server is what holds them, and a second place to answer one
 question is one place too many.
 
 The **webhook** is off until it has a URL, and it is the only thing in seedeep
 that sends session data off the machine (see `install.md`). It POSTs to any
-address with your headers and your template — `{{title}}`, `{{body}}`,
-`{{project}}`, `{{subject}}`, `{{kind}}` — so ntfy, Pushover, Telegram or a script
+address with your headers and your template (`{{title}}`, `{{body}}`,
+`{{project}}`, `{{subject}}`, `{{kind}}`) so ntfy, Pushover, Telegram or a script
 of your own all work without seedeep knowing any of them. A URL on its own is
 already a working webhook: an empty template posts the body. It never retries: a
 missed notification is better than one replayed minutes late.
 
-**A notification is one title and one line**: which session, and what happened —
+A notification is one title and one line: which session, and what happened:
 `atlas — add a retry to the uploader` / `Waiting for your approval — Bash`. Not the
 command awaiting approval, not the error text, not what the turn did. You cannot act
 on a banner anyway (approving still means going back to the terminal), a banner
 truncates that second line first, and all of it is one click away in the panel. It
-also keeps the webhook honest: that is the one channel whose payload leaves your
-machine, and it carries no more than the banner beside you does.
+also bounds the webhook, the one channel whose payload leaves your machine: it sends
+the same title and line, and nothing more.
 
-A turn that ends says **`Turn finished`**, not "finished" — the session has not
+A turn that ends says **`Turn finished`**, not "finished", because the session has not
 ended, it has become yours again. A turn **you** interrupted is never announced:
 if you pressed Esc you already know.

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,10 +1,10 @@
 # Installing, running and updating seedeep
 
 `seedeep` runs a small local server that watches your sessions and streams them to
-a page in your browser — one process, no daemon, stopped with Ctrl-C. Two channels
+a page in your browser. One process, no daemon, stopped with Ctrl-C. Two channels
 ship the same executable; a third runs it from a clone.
 
-> **The Windows build has been used in a VM**, several times, which found defects since fixed.
+> The Windows build has been used in a VM, several times, which found defects since fixed.
 > The Linux arm64 build was used on Ubuntu 24 in a VM; its x64 build has been started, never used.
 > [Which platforms have actually been run](../README.md#which-platforms-have-actually-been-run)
 > says exactly what each of those covers.
@@ -16,8 +16,8 @@ npm i -g seedeep                       # or: bun install -g seedeep --trust
 seedeep                                # watch, serve, and open the browser
 ```
 
-**A package manager is needed to install it, never to run it**: the package carries
-the compiled executable — its own runtime and the whole browser GUI inside it — and
+A package manager is needed to install it, never to run it. The package carries
+the compiled executable, with its own runtime and the whole browser GUI inside it, and
 the install puts that file on your PATH. Installing this way also raises no
 first-launch warning on macOS: the quarantine flag behind that dialog is set by the
 browser that downloads a file, and never by a package manager.
@@ -29,9 +29,9 @@ reports success and `seedeep` prints the one command that finishes the job
 
 ## The plain download — no runtime at all
 
-Take the file for your platform from [the latest release](../../../releases/latest)
-— `seedeep-server_<version>_macos-arm64`, `…_macos-x64`, `…_linux-x64`,
-`…_linux-arm64`, `…_windows-x64.exe`, `…_windows-arm64.exe` — make it executable, and run it:
+Take the file for your platform from [the latest release](../../../releases/latest),
+one of `seedeep-server_<version>_macos-arm64`, `…_macos-x64`, `…_linux-x64`,
+`…_linux-arm64`, `…_windows-x64.exe` or `…_windows-arm64.exe`, make it executable, and run it:
 
 ```sh
 chmod +x seedeep-server_*            # macOS and Linux
@@ -39,11 +39,11 @@ chmod +x seedeep-server_*            # macOS and Linux
 ```
 
 The `chmod` is not a formality: a downloaded file never arrives executable, and without it the
-Finder has no way to tell a program from a document — a double-click answers *"There is no
-application set to open the document"*, which is the missing execute bit and not a broken
+Finder has no way to tell a program from a document. A double-click answers *"There is no
+application set to open the document"*, which is the missing execute bit rather than a broken
 download. It is a command-line program either way, so the terminal is where it is run.
 
-**That file is not an installer — it is the program.** It installs nothing,
+That file is the program, not an installer. It installs nothing,
 registers nothing, and puts nothing on your PATH: it carries its own runtime and the
 whole GUI inside, so downloading it is the entire step. Running it leaves
 `~/.seedeep/` behind for its own settings and caches, and nothing else.
@@ -55,20 +55,20 @@ move it yourself:
 mv seedeep-server_* /usr/local/bin/seedeep   # now `seedeep` works anywhere
 ```
 
-That step is optional for running it — and required for `/seedeep` inside Claude
+That step is optional for running it, and required for `/seedeep` inside Claude
 Code, which calls `seedeep` by name. Installing from npm does it for you.
 
 It is the same executable either way, and it is what a headless box reached over
 SSH needs. macOS refuses an unsigned download on first launch: the way through is
 **System Settings → Privacy & Security → Security → Open Anyway**, then your login
-password — the same gesture the tray needs, described in
+password, the same gesture the tray needs, described in
 [`tray.md`](tray.md#packaging-and-releases). The Linux builds need glibc
 (Debian, Ubuntu, Fedora…), not musl.
 
 ### Checking a download came from here
 
 Unsigned is not the same as unattributable. Every release asset carries a build
-provenance attestation — a public, tamper-evident record that this exact file was built
+provenance attestation, a public and tamper-evident record that this exact file was built
 by seedeep's release workflow from the tagged commit, and by nothing else:
 
 ```sh
@@ -76,8 +76,8 @@ gh attestation verify seedeep-server_<version>_macos-arm64 -R duqaXxX/seedeep
 ```
 
 It answers with the workflow and the commit that produced the file, or it fails. That is
-a different question from the one macOS asks — Gatekeeper wants to know who *signed* the
-app, and nobody did; this says where the bytes came from, which is the question a
+a different question from the one macOS asks: Gatekeeper wants to know who *signed* the
+app, and nobody did, while this says where the bytes came from, which is the question a
 stranger downloading a 60 MB executable actually has. The npm packages carry their own
 [provenance](https://www.npmjs.com/package/seedeep), generated by npm itself.
 
@@ -94,48 +94,48 @@ bun start -- --no-open    # do not open the browser automatically
 ## The commands
 
 `seedeep --help` prints the same two tables, and `--version` the number alone, for a
-script to read. Everything below works however it was installed — `seedeep open`,
-`bun start -- --port 9000`, `./seedeep-server_… --no-open` are the same program.
+script to read. Everything below works however it was installed: `seedeep open`,
+`bun start -- --port 9000` and `./seedeep-server_… --no-open` are the same program.
 
 | | |
 |---|---|
-| `seedeep` | watch, serve, and open the browser — stays in the foreground, ends with Ctrl-C |
+| `seedeep` | watch, serve, and open the browser; stays in the foreground, ends with Ctrl-C |
 | `seedeep open` | open the GUI, starting the server first if it is down |
 | `seedeep start` | start the server detached, without opening a browser |
-| `seedeep stop` | stop the running server — SIGTERM, so it closes down rather than dying |
+| `seedeep stop` | stop the running server with SIGTERM, so it closes down rather than dying |
 | `seedeep restart` | replace the running server with a fresh one |
 | `seedeep status` | what state this machine is in ([below](#seedeep-status)) |
 | `seedeep report` | what a session cost and where its tokens went ([below](#seedeep-report)) |
-| `seedeep update` | say how *this* installation updates — prints the command, never runs it |
+| `seedeep update` | say how *this* installation updates; prints the command, never runs it |
 | `seedeep self-update` | run that command, then restart the server ([below](#seedeep-self-update)) |
 | `seedeep install-command` | write the `/seedeep` slash command into Claude Code |
 
 | Flag | Commands | |
 |---|---|---|
 | `--port <n>` | serve, open, start, stop, restart, status, self-update | the port (default 44842) |
-| `--host <addr>` | serve | the bind address — anything but loopback turns on TLS and a token ([Remote access](#remote-access)) |
+| `--host <addr>` | serve | the bind address; anything but loopback turns on TLS and a token ([Remote access](#remote-access)) |
 | `--no-open` | serve | do not open the browser |
 | `--session <id>` | report | a session other than this directory's newest |
 | `--full` | report | one line per turn as well |
 | `--offline` | update | skip the version check, the one network call seedeep makes |
 | `--force` | install-command | replace a command file you edited |
 
-*serve* in that middle column is the bare `seedeep` — the foreground server of the
+*serve* in that middle column is the bare `seedeep`, the foreground server of the
 first row, which is what you get when you name no command at all.
 
 With a server already running on a different port than your config's, `seedeep
-open` prints what is running rather than picking one — `seedeep open --port <port>`
+open` prints what is running rather than picking one, and `seedeep open --port <port>`
 says which.
 
 ### `seedeep status`
 
-The one command that acts on nothing: it answers *what state is this machine in* —
-the server (up or down, on which port, **which version it is actually serving**,
+The one command that acts on nothing. It answers *what state is this machine in*:
+the server (up or down, on which port, which version it is actually serving,
 which is not the version you installed until you restart it, and whether
 `config.json` has changed since it started), whether `/seedeep`
 exists and whose it is, and whether a newer release is out. That last line comes from
 the cache the server already keeps, so `status` needs no network and never waits on
-one. A server that is down is a state, not a failure: the exit code is 0 whatever it
+one. A server that is down is a state rather than a failure: the exit code is 0 whatever it
 finds.
 
 ## `/seedeep` inside Claude Code
@@ -146,10 +146,10 @@ seedeep install-command   # once: writes ~/.claude/commands/seedeep.md
 
 The command file it writes calls `seedeep` **by name**, so the binary has to be on
 your PATH under that name. From npm it already is. From a downloaded file it is not
-until you move it there (see above) — otherwise `install-command` succeeds and
+until you move it there (see above), and otherwise `install-command` succeeds and
 `/seedeep` then fails with *command not found*.
 
-**On native Windows it needs one line of configuration.** The command file carries a
+On native Windows it needs one line of configuration. The command file carries a
 single shell line, and Claude Code runs it in the shell it has: with Git Bash on the
 machine that is Bash, and without it the PowerShell tool, which splits that line into
 more than one operation and stops on the part it has no rule for. `/seedeep` then
@@ -164,7 +164,7 @@ in `%USERPROFILE%\.claude\settings.json`:
 }
 ```
 
-Restart Claude Code afterwards — settings are read at startup. If the file already
+Restart Claude Code afterwards, since settings are read at startup. If the file already
 exists, merge the `permissions` key into it rather than replacing the file. Installing
 [Git for Windows](https://git-scm.com/downloads/win) fixes it too, by giving Claude Code
 the Bash tool the line is written for. Inside WSL none of this applies: the shell there
@@ -175,29 +175,29 @@ After that, any Claude Code session has these:
 | | |
 |---|---|
 | `/seedeep` or `/seedeep open` | opens the GUI, starting the server first if it is down |
-| `/seedeep start` | starts the server without opening a browser — the counterpart of `stop` |
+| `/seedeep start` | starts the server without opening a browser, the counterpart of `stop` |
 | `/seedeep stop` | ends the running server, the way Ctrl-C in its terminal would |
 | `/seedeep restart` | replaces the running server with a fresh one |
-| `/seedeep status` | the state of this machine — server, served version, `/seedeep`, update |
+| `/seedeep status` | the state of this machine: server, served version, `/seedeep`, update |
 | `/seedeep report` | what this session cost and where its tokens went; `report full` adds a line per turn |
-| `/seedeep update` | says how *this* installation is updated — it prints the command, and never runs it |
+| `/seedeep update` | says how *this* installation is updated; it prints the command, and never runs it |
 | `/seedeep self-update` | installs that version and restarts the server, without leaving the session (macOS and Linux) |
 
 Every one of those words exists on the console too, spelled the same
 ([The commands](#the-commands)). A server
 started this way keeps running when the session ends, because it is started
-detached, exactly like one you launched yourself; `stop` is what ends it, and it
+detached, exactly like one you launched yourself. `stop` is what ends it, and it
 asks with SIGTERM rather than killing, so the server closes down properly.
 
 ### `seedeep report`
 
-`report` needs no server at all — it reads the session's own transcript — and on the
-console it needs no session id either: `seedeep report` takes the **newest session
-of the directory you are in**, and says so before printing. Never one from another
-project — that would be the one way to be wrong that the report's own first line
+`report` needs no server at all, since it reads the session's own transcript, and on the
+console it needs no session id either: `seedeep report` takes the newest session
+of the directory you are in, and says so before printing. Never one from another
+project, which would be the one way to be wrong that the report's own first line
 could not make obvious. `--session <id>` picks any other.
 
-It is deliberately small: it is printed INTO the session it describes, so its two
+It is small by design. It is printed INTO the session it describes, so its two
 standing blocks stay the same size whatever the session's length, and the last line
 tells you what the report itself cost. Only `report full`, which prints a line per
 turn, grows.
@@ -206,8 +206,8 @@ turn, grows.
 
 The command file records which seedeep wrote it, and after you have installed it
 once, seedeep keeps it current on its own: **every server start refreshes it** when
-it is older than the binary, and says so in one line. Nothing is created that way —
-only a file you asked for, by running `install-command`, is ever touched — and a
+it is older than the binary, and says so in one line. Nothing is created that way,
+since only a file you asked for by running `install-command` is ever touched, and a
 file you edited becomes yours and is left alone for good (`--force` is the only way
 back). If no server of yours ever starts, the next `/seedeep` you use tells you
 instead. `seedeep install-command` does it by hand at any time.
@@ -218,29 +218,29 @@ part of installing seedeep, and no upgrade does it behind your back.
 ## Updating seedeep
 
 **Updating seedeep itself** is `seedeep update`. It asks npm which version is
-current, reads where this executable actually lives — a package manager's
-`node_modules`, or a file you downloaded — and prints the one command that updates
-*that*. It never runs it — that is what `seedeep self-update` below is for.
+current, reads where this executable actually lives (a package manager's
+`node_modules`, or a file you downloaded) and prints the one command that updates
+*that*. It never runs it, which is what `seedeep self-update` below is for.
 
-That version check is **the only outbound request seedeep makes on its own** — the one
-exception being the [notification webhook](#data-flow), off until you configure it — and for the
-surfaces that poll — the portal's Settings panel, the tray, the line after
-`seedeep open` — it happens **at most once an hour**: the answer is cached, so the
+That version check is the only outbound request seedeep makes on its own, the one
+exception being the [notification webhook](#data-flow), off until you configure it. For the
+surfaces that poll, meaning the portal's Settings panel, the tray and the line after
+`seedeep open`, it happens **at most once an hour**: the answer is cached, so the
 three read one check rather than three.
 
-**The commands you type ask npm anyway.** `seedeep update` and `seedeep self-update`
+The commands you type ask npm anyway. `seedeep update` and `seedeep self-update`
 ignore that cache and go to the registry, because the reason to type either is
-usually having just heard there is a new version — and an answer from earlier in the
+usually having just heard there is a new version, and an answer from earlier in the
 hour would tell you that you are current when you are not. The fresh answer replaces
 the cache, so nothing else on the machine re-asks after it.
 `seedeep update --offline` skips the network entirely (and wins over the rule above),
-and a registry that cannot be reached never withholds the advice — you are still told
+and a registry that cannot be reached never withholds the advice: you are still told
 how this install would update.
 
 When a newer version exists you are told once per release: a notification from the
 tray (switchable off in its Settings, with the other three), a line in the portal's
 About section, and a line after `seedeep open` / `seedeep start`. Nothing updates by
-itself — npm documents no background or scheduled update, for global packages or any
+itself, since npm documents no background or scheduled update, for global packages or any
 other kind, and none of those notices installs anything. If you want it automatic,
 that belongs in your own scheduler (`npm update -g seedeep` on a cron), where you
 decided it.
@@ -262,50 +262,50 @@ It refuses, with the sentence that resolves each case instead of a half-done ins
 
 | | |
 |---|---|
-| a downloaded executable | there is nothing to install — replace the file with the new release |
+| a downloaded executable | there is nothing to install; replace the file with the new release |
 | a checkout | `git pull`, and the next `bun start` is the new code |
 | Windows | a running `.exe` cannot be replaced: `seedeep stop`, the install command, `seedeep start` |
 | a version *ahead* of npm's | that is a build of your own, and installing would downgrade it |
 
-Inside Claude Code, `/seedeep self-update` first reports what *would* happen —
-version, channel, and whether it can run at all — and Claude then runs the single
+Inside Claude Code, `/seedeep self-update` first reports what *would* happen, meaning
+version, channel, and whether it can run at all, and Claude then runs the single
 `seedeep self-update` command, which the command file already allows. The package
 manager is never invoked by Claude directly, and `/seedeep update` still only
 reports: the word that tells and the word that acts stay separate.
 
 ## The macOS permission the server asks for
 
-**"seedeep would like to access files in your Documents folder"** — asked by the
-**server**, not the tray, and only if your projects live there (or in Desktop or
+"seedeep would like to access files in your Documents folder", asked by the
+**server** rather than the tray, and only if your projects live there (or in Desktop or
 Downloads, which macOS gates the same way).
 
 seedeep reads `~/.claude/projects` and nothing else, with one exception: it runs
-**read-only git** in the working directory of a session — `rev-parse`, `log`,
-`diff-tree`, `remote get-url`, `rev-list`, every one with `--no-optional-locks` so
+**read-only git** in the working directory of a session (`rev-parse`, `log`,
+`diff-tree`, `remote get-url`, `rev-list`), every one with `--no-optional-locks` so
 that even a read cannot take `.git/index.lock` while you are committing. That is
 what fills the **Commits** and **Changed files** cards, and it runs when you open a
 session, not across your whole corpus. **Refuse and those two cards stay empty**;
 nothing else changes.
 
 Neither this prompt nor the tray's appears for the plain download, run from a
-terminal in a directory you already have access to. The tray's own permission — the
-local network — is in [`tray.md`](tray.md#the-one-permission-the-tray-asks-for).
+terminal in a directory you already have access to. The tray's own permission, the
+local network, is in [`tray.md`](tray.md#the-one-permission-the-tray-asks-for).
 
 ## Data flow
 
 Session data flows one way: the server pushes to the browser (Server-Sent Events)
-and the browser never sends any of it back — nothing seedeep reads is ever written.
+and the browser never sends any of it back. Nothing seedeep reads is ever written.
 
-**One exception, and it is off until you turn it on: the notification webhook.**
+One exception, and it is off until you turn it on: the notification webhook.
 It is the only thing in seedeep that sends your session data anywhere. Configured
 under `notifications.webhook` in `~/.seedeep/config.json`, it POSTs to whatever
-address you put there — your own ntfy, Pushover, a Telegram bot, a script on your
-LAN — when a session stops on you, breaks, or hands the turn back. What leaves the
+address you put there (your own ntfy, Pushover, a Telegram bot, a script on your
+LAN) when a session stops on you, breaks, or hands the turn back. What leaves the
 machine is what the banner says: the project name, the session's subject, and the
 tool and command a session is waiting on. Nothing else, and nothing at all while
 `url` is empty, which is how it ships. Emptying `url` turns it off again.
-The browser does POST two things, and both are seedeep's own state, never yours: the
-settings, and a restart. (The share card's PNG is drawn by the page itself — it
+The browser does POST two things, and both are seedeep's own state rather than yours: the
+settings, and a restart. (The share card's PNG is drawn by the page itself and
 never leaves your browser.)
 
 ## Remote access
@@ -320,7 +320,7 @@ SEEDEEP_TLS_CN=my-machine.local bun start -- --host 0.0.0.0
 ```
 
 Beyond loopback, HTTPS is mandatory and every `/api/*` request needs
-`Authorization: Bearer <token>` — a 32-byte token generated on first run and kept in
+`Authorization: Bearer <token>`, a 32-byte token generated on first run and kept in
 `~/.seedeep/config.json`. `seedeep` issues its own self-signed certificate, valid for
 the machine's current LAN address; the certificate's common name is required, which
 is what `SEEDEEP_TLS_CN` above provides. The startup URL carries the token, and the
@@ -328,43 +328,43 @@ page moves it into local storage and strips it from the address bar, so it never
 reaches your browser history.
 
 Its SHA-256 fingerprint is printed on **every** start, and shown in the settings
-panel with a Copy button — a browser waves a self-signed certificate through with one
+panel with a Copy button. A browser waves a self-signed certificate through with one
 click, but anything else has to pin it, and can only do that if you can read the
 value when you set that client up.
 
-The settings panel (the sliders icon in the header) edits all of it — port, host,
+The settings panel (the sliders icon in the header) edits all of it: port, host,
 token, the full access URL, and the certificate fingerprint, each with a Copy
-button — so nothing has to be edited by hand. It is an editor of `config.json`: the
+button, so nothing has to be edited by hand. It is an editor of `config.json`: the
 fields show what that file says (under any flag or environment variable that overrides
-it), so the two ways of configuring seedeep cannot undo each other — a save leaves
+it), so the two ways of configuring seedeep cannot undo each other, and a save leaves
 every field it did not mention exactly as your editor left it.
 
-**A running server keeps the port, host and certificate name it started with**, whichever
-way they changed — the panel or an editor. Until you restart it, the file says one thing
+A running server keeps the port, host and certificate name it started with, whichever
+way they changed, the panel or an editor. Until you restart it, the file says one thing
 and the process does another, which on this page means remote access that is configured
-and simply not listening. Every surface now says so rather than leaving it to be found
+and simply not listening. Every surface says so rather than leaving it to be found
 with `lsof`: an amber dot on the Settings button with the panel closed, a line above the
-tray's sessions, and a line in `seedeep status`. `seedeep restart` — or **Restart now** in
-the panel — applies it.
+tray's sessions, and a line in `seedeep status`. `seedeep restart`, or **Restart now** in
+the panel, applies it.
 
 A value a CLI flag or an environment variable sets is not reported, because a restart
 would not honour the file there either: `--port 9000` wins over `config.json` on every
 start, so there is nothing pending to announce.
 
-**The token is stored per ADDRESS, and the port is part of the address.** The
-browser keeps it in local storage, which is partitioned by origin — scheme, host
-*and* port — so a second `seedeep` on the same machine at another port is an address
+The token is stored per ADDRESS, and the port is part of the address. The
+browser keeps it in local storage, which is partitioned by origin (scheme, host
+*and* port), so a second `seedeep` on the same machine at another port is an address
 that has never been given the token, even though the certificate and the host are
 identical. Opening it bare then shows a red **`No token for this address`** in the
-header (hover it for the rest); the fix is to open the URL `seedeep` printed at
-startup once — the page stores the token and strips it from the address bar — or to
+header (hover it for the rest). The fix is to open the URL `seedeep` printed at
+startup once, so the page stores the token and strips it from the address bar, or to
 paste the token in the settings panel. **`Token refused`** is the other half of the
 same sentence: something IS stored and the server does not accept it, because it was
 regenerated or belongs to another `seedeep`.
 
 Neither is ever reported as a lost connection. A 401 is not a dropped stream and
-reconnecting cannot fix it, so the banner says which of the two it is instead of
-promising a recovery that will not come.
+reconnecting cannot fix it, so the banner names which of the two it is
+rather than showing a reconnection attempt.
 
 **`seedeep` ships no tunnel.** Reaching it from outside the local network is
 deliberately not its job: use an SSH port-forward
@@ -376,16 +376,16 @@ full is in [`configuration.md`](configuration.md#security-model).
 
 The menu-bar tray is a separate download, built by CI from a tag and attached to
 [the latest release](../../../releases/latest) beside the server: one universal
-`seedeep-tray_<version>_universal.dmg` for macOS — Apple Silicon and Intel in the
-same file, so there is nothing to choose — and one `-setup.exe` per architecture for
+`seedeep-tray_<version>_universal.dmg` for macOS, with Apple Silicon and Intel in the
+same file so there is nothing to choose, and one `-setup.exe` per architecture for
 Windows, `_arm64-` on a Snapdragon or any other Windows-on-ARM machine and `_x64-`
 on everything else, since Windows has no universal binary to hide the question. Until a
 release is listed there, `bun run tray:build` produces the same bundle locally,
 under the same name.
 
-**The tray is called `seedeep-tray`, the server is called `seedeep`**, and they are two
-programs, named apart on purpose. One name for both makes a system permission dialog impossible to
-read — it names the app that is asking, and both would be *"seedeep"* — and makes
+The tray is called `seedeep-tray`, the server is called `seedeep`, and they are two
+programs, named apart. One name for both makes a system permission dialog impossible to
+read, since it names the app that is asking and both would be *"seedeep"*, and makes
 `killall seedeep` reach the server rather than the app you meant.
 
 It is optional, and it is a **client**: it connects to a server, on this machine or
@@ -395,24 +395,24 @@ on another one. The server is what has to run where Claude Code runs.
 certificate behind these builds; that is the state `seedeep` ships in today, and each
 system says so in its own way:
 
-- **macOS** — the first double-click is refused. The way through is **System Settings →
+- **macOS:** the first double-click is refused. The way through is **System Settings →
   Privacy & Security → Security → Open Anyway**, then your login password. Apple
   offers that button for about an hour after the attempt that was refused, so open
   the app first and go to Settings second.
-- **Windows** — SmartScreen stops the installer. The way through is **More info → Run
+- **Windows:** SmartScreen stops the installer. The way through is **More info → Run
   anyway**. The installer installs for the current user only, so it never asks for
   Administrator rights.
 
-Both warnings are the honest cost of an unsigned build, not a sign that something
+Both warnings are the honest cost of an unsigned build rather than a sign that something
 went wrong. Signing becomes a real decision when there is a release worth signing.
 
-**Every tray update asks for its permissions again**, and that is the price of an
+Every tray update asks for its permissions again, and that is the price of an
 unsigned build rather than a bug: macOS attaches a permission to a code IDENTITY, and
-an unsigned app has none that survives a rebuild — `codesign -d -r-` on the installed
-app answers *"code object is not signed at all"*. The bundle identifier does not
+an unsigned app has none that survives a rebuild (`codesign -d -r-` on the installed
+app answers *"code object is not signed at all"*). The bundle identifier does not
 change, so your settings and stored connection carry over; the permission does not.
-The one that bites is notifications: **a tray that notified last week can go quiet
-after an upgrade**, and the fix is System Settings → Notifications → seedeep-tray.
+The one that bites is notifications: a tray that notified last week can go quiet
+after an upgrade, and the fix is System Settings → Notifications → seedeep-tray.
 What each banner says, and which ones ship on, is in
 [`tray.md`](tray.md#notifications).
 
@@ -425,13 +425,13 @@ ran `seedeep install-command`, there is a third: `~/.claude/commands/seedeep.md`
 
 The **tray** is a different program, and removing the server does not touch it:
 
-- **macOS** — quit it from the menu bar, then drag **seedeep-tray** out of
-  Applications. There is no uninstaller to run: the download is a `.dmg`, and a DMG
+- **macOS:** quit it from the menu bar, then drag **seedeep-tray** out of
+  Applications. There is no uninstaller to run, because the download is a `.dmg` and a DMG
   *is* the drag, in both directions. What that leaves behind is one folder,
-  `~/Library/Application Support/app.seedeep.tray/` — the server you connected to and
-  the notification switches, nothing else. Delete it to leave nothing; keep it and a
+  `~/Library/Application Support/app.seedeep.tray/`, holding the server you connected to and
+  the notification switches. Delete it to leave nothing; keep it and a
   reinstall picks up where you left off.
-- **Windows** — Settings → **Installed apps** → **seedeep-tray** → Uninstall. The
+- **Windows:** Settings → **Installed apps** → **seedeep-tray** → Uninstall. The
   uninstaller draws a **Delete app data** checkbox on the way, and it starts
   **unchecked**: leave it and `%APPDATA%\app.seedeep.tray` survives for the next
   install, tick it and it goes with the app.

--- a/docs/search.md
+++ b/docs/search.md
@@ -10,25 +10,24 @@ the route in `apps/server/src/server/server.ts`.
 
 ## What is searched: the dialogue, not the transcript
 
-The corpus is what was **said**:
+The corpus is what was said:
 
-- **your prompts** — typed text, and a slash command's **arguments** (never its `<command-name>`
-  wrapper). Both shapes of a command count: the expanded one and the one Claude Code writes as the
-  plain text you typed (`/code-review del diff`) — an argument-less command indexes as its own name
+- your prompts: typed text, and a slash command's arguments (never its `<command-name>`
+  wrapper). Both shapes of a command count, the expanded one and the one Claude Code writes as the
+  plain text you typed (`/code-review del diff`). An argument-less command indexes as its own name
   (`/compact`), which is what the user sent;
-- **Claude's text blocks** — its prose answers.
+- Claude's text blocks, its prose answers.
 
 Everything else in a transcript is excluded: tool results, tool inputs, file contents, injected
-instructions, system reminders, task notifications, compaction preambles. That is not a
-simplification, it is the point — the surplus a raw-jsonl scan matches is text the session never
-said.
+instructions, system reminders, task notifications, compaction preambles. The surplus a raw-jsonl scan matches is text the
+session never said, which is why none of it is indexed.
 
 Extraction goes through the REAL parser (`userLineIntent` + `CONTROL_COMMANDS` in `parser.ts`),
 never a second reader of the same lines. What that rule drops is `<task-notification>` lines,
-compaction preambles and probe artefacts — **not one human prompt**.
+compaction preambles and probe artefacts, and no human prompt.
 
 **LIMIT:** subagent transcripts are not indexed. They are a separate file per subagent
-(`<uuid>/subagents/`), and their dialogue is machine-to-machine — an agent prompt written by Claude,
+(`<uuid>/subagents/`), and their dialogue is machine-to-machine: an agent prompt written by Claude,
 not by you.
 
 ## A commit hash also asks git
@@ -38,13 +37,13 @@ place to look for one: the hash of a commit normally appears only in the output 
 that made it, which this index excludes by design. So a hash query ALSO asks git who produced that
 commit, by the attribution in [`session-output.md`](session-output.md#attribution-proof-first-testimony-second-otherwise-nothing), and merges those sessions into the same rows.
 
-Nothing else changes: same row shape, same ordering, no extra section — only the set of sessions
-grows. A text query is untouched: one regex decides, and a query that is not a hash never asks git.
+Nothing else changes: same row shape, same ordering, no extra section, only a larger set of
+sessions. A text query is untouched, since one regex decides and a query that is not a hash never
+asks git.
 
-A session found this way carries **`hits: 0` and no snippet** — there is no passage to quote,
-because it never said the hash. It therefore reads `0 per 1k` and sorts last under the default
-density order. That is deliberate: the alternative was to invent an occurrence count the dialogue
-does not contain.
+A session found this way carries `hits: 0` and no snippet, because there is no passage to quote:
+it never said the hash. It therefore reads `0 per 1k` and sorts last under the default
+density order. The alternative was to invent an occurrence count the dialogue does not contain.
 
 An unknown hash adds nothing, and a hash in a repository seedeep cannot reach (renamed or moved
 directory) is simply not found.
@@ -52,14 +51,14 @@ directory) is simply not found.
 ## A tracker id also asks the sessions' tool calls
 
 The same reasoning, for the other identifier a user types into a search box. `ABC-12` or `#42` also
-returns the sessions that ACTED on that card — read from their tool calls, by the rules in
+returns the sessions that ACTED on that card, read from their tool calls, by the rules in
 [`session-output.md`](session-output.md#tracker-cards). The dialogue index cannot see those: the id lives in a call's id field, and a
 session that worked a card for an hour may never have typed its key.
 
-Same row shape, same ordering, same honest `hits: 0` as a hash match: a hash is answered by git, a
+Same row shape, same ordering, same honest `hits: 0` as a hash match. A hash is answered by git, a
 card id by its own persisted index (`cards-index.jsonl`). That index is touched ONLY when the query
 is shaped like a card id, so a text search pays nothing for it. See [`session-output.md`](session-output.md#tracker-cards). The shape test
-is deliberately permissive — `GPT-4` and `UTF-8` pass it and simply match nothing, since the answer
+is deliberately permissive: `GPT-4` and `UTF-8` pass it and simply match nothing, since the answer
 comes from ids observed in tool calls, never from text.
 
 ## Matching: every word is an AND term
@@ -71,13 +70,13 @@ result. Adding a word can only narrow the set, never widen it.
 
 Rows are split with the same predicate the picker uses (`isAutomated`: `entrypoint` starting with
 `sdk`). Your own sessions are listed; the automated runs (a docs gate, a `claude -p` script) sit
-behind a `+ N automated runs … — show` control that **states its own count**. Nothing is dropped in
+behind a `+ N automated runs … show` control that states its own count. Nothing is dropped in
 silence, and nothing is truncated: there is no top-N cut.
 
 ## Ordering: density by default
 
-Three orders, selectable; each sorts by **the number the row prints** — a list ranked on something
-else is a leaderboard nobody can check. The score box therefore changes with the key: it names the
+Three orders, selectable. Each sorts by the number the row prints, so that the ranking can be
+checked against what is on screen. The score box therefore changes with the key: it names the
 quantity it is showing (`per 1k`, `times`, `last run`), and the readout table in `search-view.ts`
 (`SCORE`) is keyed by the sort key itself, so a key added without its readout does not compile.
 
@@ -85,13 +84,13 @@ quantity it is showing (`per 1k`, `times`, `last run`), and the readout table in
 |---|---|---|
 | **density** (default) | occurrences per 1k characters of dialogue | `2.6 per 1k` |
 | occurrences | total occurrences of every term | `24 times` |
-| recent | last activity | `16d` / `today` — *last run* |
+| recent | last activity | `16d` / `today`, *last run* |
 
-Density is the default because **ordering by raw occurrences ranks session LENGTH**.
+Density is the default because ordering by raw occurrences ranks session LENGTH.
 
-The denominator is the dialogue **itself** — the characters that were said. The separators the
+The denominator is the dialogue itself, the characters that were said. The separators the
 matcher joins utterances with are not part of it: charging them would inflate exactly the shortest
-sessions, which is precisely where density decides anything.
+sessions, which is where density decides anything.
 
 **LIMIT:** a very short session that mentions a term once can top the density order on that one
 mention. The row prints its own numbers (`1× · 0k`), so the order stays explainable, and no
@@ -99,14 +98,14 @@ arbitrary minimum-length constant is invented to hide it.
 
 ## Snippets
 
-Up to two passages per session: for each utterance, the window where the **most distinct terms**
-cluster; the best two, most-terms-first. Distinct terms, not occurrences — a passage carrying both
-words you typed is the one that proves the session is the right one; a passage repeating the first
-one ten times is not.
+Up to two passages per session: for each utterance, the window where the most distinct terms
+cluster; the best two, most-terms-first. Distinct terms, not occurrences: a passage carrying both
+words you typed is the one that proves the session is the right one, while a passage repeating the
+first one ten times proves nothing.
 
 Where two terms match at the same spot because one contains the other (`toast` and `toasting`), the
-**longer** one is highlighted: the word that brought the session up has to read as a match, not be
-cut short by its own prefix.
+longer one is highlighted, so that the word which brought the session up reads as a match rather
+than being cut short by its own prefix.
 
 Every snippet is attributed (**you** / **claude**) and the terms are highlighted with `<mark>`
 element nodes built from indices. Never an HTML string: the text is a real prompt, and markup inside
@@ -114,13 +113,13 @@ it must be impossible to execute.
 
 ## The session id
 
-The id chip copies the **full uuid** on click. What it DISPLAYS depends on the room the surface has:
+The id chip copies the full uuid on click. What it DISPLAYS depends on the room the surface has:
 
-- **Search row** — the whole uuid, on the meta line. This is the surface you reach for when the next
-  thing you do is `claude --resume <id>`, and a prefix you must click to complete is not that. It
-  sits on the meta line (mono, ~230px available) rather than in the actions column, which would take
-  that width from the snippets.
-- **Picker row** — the 8-character prefix seedeep has always printed: the row is narrow, and there
+- **Search row:** the whole uuid, on the meta line. This is the surface you reach for when the next
+  thing you do is `claude --resume <id>`, and a prefix you must click to complete does not serve
+  that. It sits on the meta line (mono, ~230px available) rather than in the actions column, which
+  would take that width from the snippets.
+- **Picker row:** the 8-character prefix seedeep has always printed. The row is narrow, and there
   the id only has to tell two sessions apart.
 
 It is the same component in both (`id-chip.ts`), so the id is never a copy button on one surface and
@@ -129,7 +128,7 @@ unchanged rather than claiming one.
 
 ## The index
 
-`~/.seedeep/search-index.jsonl` — seedeep's own file, never a session file (`SEEDEEP_HOME` moves it
+`~/.seedeep/search-index.jsonl`, seedeep's own file and never a session file (`SEEDEEP_HOME` moves it
 with the rest of seedeep's state: [`configuration.md`](configuration.md#moving-it-seedeep_home)).
 One JSON line per
 session (`path`, staleness stamp, dialogue segments) behind a version header; a missing, corrupt or
@@ -137,28 +136,28 @@ older-version file is treated as empty and rebuilt.
 
 - **Incremental** on `(size, mtime)`, atomic on write (temp + rename), refreshes serialized.
 - **Shape-checked on load.** An entry whose segments do not carry the current fields is discarded and
-  the session re-read, and a field added to the segment type without being listed fails the BUILD —
+  the session re-read, and a field added to the segment type without being listed fails the BUILD,
   the same forcing function `aggregate-cache.ts` uses.
 - **Refreshed on demand**, when a search runs: it costs nothing until you use the tab, and a session
   being written right now enters the results as of the query.
 - **Its own file, deliberately.** `aggregates.json` (the retrospective/Compare cache) is rewritten
   whole on every refresh, and the dialogue is bulk prose that cache never reads. Sharing them
-  would also mean bumping `CACHE_VERSION` — re-parsing the whole corpus — to add text the
+  would also mean bumping `CACHE_VERSION`, re-parsing the whole corpus, to add text the
   retrospective does not look at.
 
-The lowercased text a query is matched against is **derived, never stored**, and it is keyed on the
+The lowercased text a query is matched against is derived, never stored, and it is keyed on the
 ENTRY rather than on its path. That is the whole invalidation strategy: an entry's text cannot
-change — a changed file becomes a new entry — so a stale derivation is unreachable, and nothing has
-to be invalidated by hand from inside the refresh loop.
+change, since a changed file becomes a new entry, so a stale derivation is unreachable and nothing
+has to be invalidated by hand from inside the refresh loop.
 
 The query is a substring scan per term. **Do not** add an inverted or trigram index: nothing
 measured asks for one, and the measurement that says so is kept next to the code it constrains
-(`search-index.ts`, above `createSearchIndex`) — where a change to the index has to read it.
+(`search-index.ts`, above `createSearchIndex`), where a change to the index has to read it.
 
 ## Privacy
 
 The index holds your own prompts verbatim, in your home directory, derived from transcripts already
-on disk. `/api/search` is auth-gated like every other `/api/*` route — it is the endpoint where a
-leak *is* the content. Any public screenshot of this tab must come from a **synthetic** corpus.
+on disk. `/api/search` is auth-gated like every other `/api/*` route, and it is the endpoint where a
+leak *is* the content. Any public screenshot of this tab must come from a synthetic corpus.
 
-**Endpoint:** `GET /api/search` — its full contract is in [`api.md`](api.md#get-apisearch).
+**Endpoint:** `GET /api/search`, with its full contract in [`api.md`](api.md#get-apisearch).

--- a/docs/session-output.md
+++ b/docs/session-output.md
@@ -16,23 +16,23 @@ Code: `apps/server/src/server/transcript-scan.ts` (the single pass every join co
 ## What the three have in common
 
 **One pass over the transcript, cached.** `transcript-scan.ts` reads a session once, keyed on its
-size and mtime, and all three joins consume that reading — so a session that has already rendered
+size and mtime, and all three joins consume that reading, so a session that has already rendered
 its Commits card pays nothing to render the other two. Subagent sidecars are included: a subagent's
 commit, file or card is its parent session's.
 
-**The repository is only ever read**, through `rev-parse`, `log`, `remote get-url`, `rev-list` and
+The repository is only ever read, through `rev-parse`, `log`, `remote get-url`, `rev-list` and
 `diff-tree`. No index is taken, and that is enforced rather than assumed: every call carries
 `--no-optional-locks`. Some porcelain refreshes the index as a side effect and takes
 `.git/index.lock` to do it, and seedeep polls the repository of a session that may be committing
-right now — taking that lock even for a millisecond can fail the user's own `git add`.
+right now, and taking that lock even for a millisecond can fail the user's own `git add`.
 
-**A repository is identified differently by the two features that need one, on purpose.** Commits
+A repository is identified differently by the two features that need one. Commits
 key it by `git rev-parse --git-common-dir`: two worktrees report different toplevels and the same
 common dir, and `git log --all` from either sees both their commits, so parallel worktree sessions
 collapse to one reader. Files key it by TOPLEVEL instead: there the path matters as much as the
 history, because a file of a commit made in worktree B lives under B's toplevel.
 
-**Nothing here asks a network anything** — not a forge, not a tracker. Every link is built offline
+Nothing here asks a network anything: not a forge, not a tracker. Every link is built offline
 from what the transcript and the repository already hold.
 
 ## Commits
@@ -46,14 +46,14 @@ Two sources answer two different questions, and neither can answer the other's:
 | The session transcript (`~/.claude/projects/**.jsonl`) | **who** ran a commit, and what its command printed |
 | The repository, read with `git` | **what exists**: the surviving hash, its real subject, date and branch |
 
-There is **no forge API call** — see *The forge link* below.
+There is **no forge API call**; see *The forge link* below.
 
 ### The forge link
 
 Built offline from `origin`, in three steps (`remoteBase` + `commitUrl` in `apps/server/src/server/git.ts`):
 
 1. `git remote get-url origin`.
-2. Normalise to https — git stores three shapes: the scp one (`…@host:owner/repo.git`, the user
+2. Normalise to https. Git stores three shapes: the scp one (`…@host:owner/repo.git`, the user
    being `git`), `ssh://…@host/owner/repo.git`, and `https://host/owner/repo.git`. The `.git`
    suffix and any trailing slashes go.
 3. Append `/commit/<hash>`, or `/-/commit/<hash>` when the host contains `gitlab.`.
@@ -61,17 +61,17 @@ Built offline from `origin`, in three steps (`remoteBase` + `commitUrl` in `apps
 | Remote | Link |
 |---|---|
 | scp form on `github.com`, `owner/repo` | `https://github.com/owner/repo/commit/<sha>` |
-| scp form on `gitlab.com`, `group/subgroup/repo` | `…/group/subgroup/repo/-/commit/<sha>` — GitLab subgroups work, the path is copied whole |
+| scp form on `gitlab.com`, `group/subgroup/repo` | `…/group/subgroup/repo/-/commit/<sha>`; GitLab subgroups work, the path is copied whole |
 | `https://gitlab.example.com/group/repo.git` | `…/-/commit/<sha>` |
-| scp form on a self-hosted GitLab (`git.company.it`) | `…/commit/<sha>` — no `/-/`, and still correct: see below |
+| scp form on a self-hosted GitLab (`git.company.it`) | `…/commit/<sha>`, no `/-/`, and still correct: see below |
 
-**A self-hosted GitLab on an arbitrary domain still works.** The host test is a heuristic and it
-misses `git.company.it`, so that repo gets the plain path — which GitLab redirects to
+A self-hosted GitLab on an arbitrary domain still works. The host test is a heuristic and it
+misses `git.company.it`, so that repo gets the plain path, which GitLab redirects to
 `/-/commit/<sha>`. The heuristic only saves a redirect; it is not what makes GitLab work. GitHub,
 Gitea and Codeberg take the plain path natively.
 
 LIMIT: **Bitbucket** serves commits at `/commits/<hash>` (plural). seedeep produces `/commit/`,
-and whether Bitbucket redirects it has NOT been verified — treat Bitbucket as unsupported until
+and whether Bitbucket redirects it has NOT been verified. Treat Bitbucket as unsupported until
 someone measures it.
 
 LIMIT: **Azure DevOps** uses a different shape entirely (`…/_git/<repo>/commit/<hash>`), and a
@@ -84,28 +84,28 @@ hostname heuristic.
 
 | Level | Rule |
 |---|---|
-| **Proof** | The commit's hash appears in the output of that session's own `git commit` call — the same `tool_use`/`tool_result` pair. No text matching. The only bounds are ordering ones: the commit must be authored after that session's previous commit call and no later than this one (plus a 120 s tolerance, since the call's timestamp is when it returned). |
-| **Testimony** | No hash came back (`-q`, or a proxy that swallowed the output). The commit's subject must then appear in a `git commit` command run within ±120 s — its first 32 characters, which is long enough to be unique and short enough to survive a message the shell reflowed — and exactly ONE session of the repo may claim it. |
+| **Proof** | The commit's hash appears in the output of that session's own `git commit` call, the same `tool_use`/`tool_result` pair. No text matching. The only bounds are ordering ones: the commit must be authored after that session's previous commit call and no later than this one (plus a 120 s tolerance, since the call's timestamp is when it returned). |
+| **Testimony** | No hash came back (`-q`, or a proxy that swallowed the output). The commit's subject must then appear in a `git commit` command run within ±120 s, using its first 32 characters, which is long enough to be unique and short enough to survive a message the shell reflowed, and exactly ONE session of the repo may claim it. |
 | **Unattributed** | Anything else, including two claimants. The commit is simply not listed. |
 
 A commit is **never** handed to the nearest session in time. With two sessions on one repo that
-would be a guess, and a wrong commit under a session is worse than a missing one.
+would be a guess, and the cost of guessing wrong is a commit filed under the wrong session.
 
 Rules that follow from how the data really behaves:
 
-- **A call proves only what it made, not what it printed.** `git commit && git log --oneline -5`
+- A call proves only what it made, not what it printed. `git commit && git log --oneline -5`
   names four older commits, possibly another session's. A named hash counts only when the commit
   was authored after that session's previous commit call.
-- **The repo's identity is `git rev-parse --git-common-dir`, not the toplevel.** Two worktrees
+- The repo's identity is `git rev-parse --git-common-dir`, not the toplevel. Two worktrees
   report different toplevels and the same common dir, and `git log --all` from either sees both
-  their commits — so parallel worktree sessions collapse to one reader.
-- **`git -C <path> commit` does not contain the string `git commit`.** The command test tolerates
-  options between the two words — a flag may carry a value, and that value may not itself begin with
+  their commits, so parallel worktree sessions collapse to one reader.
+- `git -C <path> commit` does not contain the string `git commit`. The command test tolerates
+  options between the two words, because a flag may carry a value and that value may not itself begin with
   `-`. The restriction is what keeps the match linear on a command that never reaches `commit`, and
   it costs nothing: a `-`-leading token is read as the next flag and still matches.
 - **Subagents commit too.** Their sidecar transcripts (`<slug>/<uuid>/subagents/agent-*.jsonl`) are
   scanned with the parent's, and their commits are the parent session's.
-- **Attribution is exclusive across sessions**, computed once per repo over every session whose
+- Attribution is exclusive across sessions, computed once per repo over every session whose
   window overlaps. Computing it per session in isolation would put one commit in several lists.
 - **Author date, not committer date.** A rebase moves the committer date; `--since/--until` filter
   on it, so the range asked of git is padded by a day and the author date is filtered in memory.
@@ -113,17 +113,17 @@ Rules that follow from how the data really behaves:
 ### Finding the repository
 
 From the session's `cwd` (present on every transcript line), walking up via `rev-parse`. When the
-cwd is not inside a repo — a session run one directory above its workspace — the repo is taken
+cwd is not inside a repo, as with a session run one directory above its workspace, the repo is taken
 from the paths the commands name: `git -C <path>` and `cd <path>`, absolute or relative to that
 line's cwd.
 
 LIMIT: if the project directory has since been renamed or moved, the path the session recorded no
 longer resolves and the session lists no commits. seedeep cannot know where the directory went.
 
-**A directory that cannot be ENTERED is not a directory without commits**, and the answer says
+A directory that cannot be ENTERED is not a directory without commits, and the answer says
 which. When no repository is found for a session that did run `git commit`, each of its `cwd`s is
 put to one `access` check (`whyNoRepo`, `apps/server/src/server/git.ts`) and `SessionCommits` comes back with
-**`denied: true`** if any of them exists but refuses entry. Only then — the ordinary path, where a
+**`denied: true`** if any of them exists but refuses entry. Only then: the ordinary path, where a
 repository resolved, costs nothing.
 
 The codes: `EACCES` for a directory whose mode forbids entry, `ENOENT` for one that is not
@@ -141,23 +141,23 @@ its commit could be claimed here by testimony (never by proof).
   and the one with the most to read takes the position the eye reaches first.
   Commits is a quarter of the row, Cards the last quarter. It carries the count, the four newest commits (short hash + subject) and
   `+ N more →` into the drawer. At that width a typical subject fits whole.
-- **The short hash is cyan** (`--agent`).
-- **The card is ALWAYS there, empty or not**: a missing widget cannot
+- The short hash is cyan (`--agent`).
+- The card is ALWAYS there, empty or not: a missing widget cannot
   distinguish "this session shipped nothing" from "seedeep did not look". Empty, it says
-  `No commits in scope yet.` and its **Expand all is hidden** — the drawer is built from the rows,
+  `No commits in scope yet.` and its **Expand all is hidden**, because the drawer is built from the rows,
   so on an empty card that button would do nothing.
-- **Unless it was REFUSED the folder**, in which case it says so instead: *"Cannot read this
+- Unless it was REFUSED the folder, in which case it says so instead: *"Cannot read this
   session's folder, so its commits are unknown"*, with the gesture that fixes it. Same distinction
-  as the bullet above, one level deeper — only one of the two states is the user's to act on. On
+  as the bullet above, one level deeper: only one of the two states is the user's to act on. On
   macOS the second is ordinary rather than exotic: `~/Documents`, `~/Desktop` and `~/Downloads` are
   gated, and a session working in one of them is invisible until a system dialog is answered.
 - **The drawer** lists every commit, oldest first, with subjects wrapped rather than clipped.
 - **A row without a link** is a commit that is not pushed (or a repo with no `origin`). It carries
-  a `local` chip, its hash goes quiet and it does not open anything — a link would 404. The chip
+  a `local` chip, its hash goes quiet and it does not open anything, because a link would 404. The chip
   is on the row, not only in a tooltip: a row that does nothing when clicked otherwise reads as
   broken.
-- **The description states what the card can do.** With something pushed it invites the click;
-  with everything local it says so instead — a card that promises an action it cannot perform is
+- The description states what the card can do. With something pushed it invites the click;
+  with everything local it says so instead, since a card that promises an action it cannot perform is
   the card lying about itself.
 - **Freshness**: fetched once when the replay hands off, then every 60 s while the session is live,
   and once more when it ends.
@@ -170,27 +170,27 @@ Claude Code's rewind ledger (`file-history-delta`) records only what CC's own fi
 wrote. A file written by a `python3` heredoc, a `cat >>` or the build leaves no delta at all, so a
 card fed by the ledger undercounts what the commit actually carried.
 
-The missing half cannot be recovered by inference either. **Which session wrote a file by shell is
-recorded nowhere on disk** — with two sessions working the same repository no source tells them
-apart, and any rule based on timing is a guess. A count that is a guess is worse than no count.
+The missing half cannot be recovered by inference either. Which session wrote a file by shell is
+recorded nowhere on disk: with two sessions working the same repository no source tells them
+apart, and any rule based on timing is a guess. So no count is produced from that half at all.
 
 So the card counts the files of the commits attributed to the session (*Commits*, above), which is
-both complete — a commit carries what changed, not how it was written — and provably that session's.
+both complete (a commit carries what changed, not how it was written) and provably that session's.
 The number is reproducible: `git show --stat <hash>` for each commit the drawer names.
 
-**The working tree is NOT a second source.** `git status` describes the repository now, not what one
+The working tree is NOT a second source. `git status` describes the repository now, not what one
 session did: two live sessions in one repo would each claim the whole dirty tree, and changes made
 before a session started would be credited to it. That is the same
 inference this feature refuses everywhere else. The cost is stated plainly: while a session is
 working and has not committed, the card has nothing to show and says so.
 
-A path delivered by several commits counts ONCE, keeping the latest — the commit a reader would open
-to see its current state — so the hero can never exceed the distinct files the commits carry.
+A path delivered by several commits counts ONCE, keeping the latest, meaning the commit a reader would open
+to see its current state, so the hero can never exceed the distinct files the commits carry.
 
 ### One number, and a description that names its source
 
 The hero is the file count. The card's DESCRIPTION doubles as its caption, so the widget needs no
-trailing line for it — one line, rewritten per render:
+trailing line for it. One line, rewritten per render:
 
 | State | Description |
 |---|---|
@@ -208,37 +208,37 @@ card asserting something it never learned.
 The description carries **no second count**: two numbers on one card invite a subtraction, and the
 first time they fail to add up the card reads as broken. At session scope the commit count is the
 server's; with a turn selected it is the distinct commits among the rows on screen, counted by
-HASH — deriving it from timestamps would
+HASH, since deriving it from timestamps would
 merge two commits made in the same second, since git author dates are whole seconds.
 
 A session that committed work started by earlier sessions shows all of that commit's files. That is
 true and verifiable ("this session delivered 23 files"), and it is not the same claim as "this
-session wrote 23 files" — which no source can support.
+session wrote 23 files", which no source can support.
 
 ### The scratchpad row
 
 Claude Code's per-session scratchpad lives outside the repository, so no commit can carry it. This
 is the one thing the ledger alone knows, and the only reason it is still read: scratchpad paths get
 their own row under the bars (`+N scratchpad files`), never the hero. Everything else the ledger
-holds — including CC's own memory notes — is dropped: it is not work on the project.
+holds, including CC's own memory notes, is dropped: it is not work on the project.
 
 `isScratchPath` classifies on the `~scratch` token `anon` produces, so a ledger path is anonymized
-BEFORE it is tested — the scratchpad root is spelled three ways across platforms, and the raw path
+BEFORE it is tested: the scratchpad root is spelled three ways across platforms, and the raw path
 does not identify it.
 
 **`trackingPath` has two shapes**: absolute, or relative to the session's cwd. `ledgerPath` resolves
 relative → absolute (`backup.realParentDir` first, then the last cwd seen in the file). With
-neither, the path is left exactly as CC wrote it — never guessed.
+neither, the path is left exactly as CC wrote it, never guessed.
 
 ### Reading a commit's file list
 
 `readCommitFiles` passes `-z`: `--name-only` C-quotes any path outside ASCII (`core.quotePath`
-defaults to true), so `src/café.ts` would come back as a `"src/caf\303\251.ts"` literal — a string
+defaults to true), so `src/café.ts` would come back as a `"src/caf\303\251.ts"` literal: a string
 that matches no other spelling of the file, defeats the root-prefix strip, and shows a reader an
 escape blob. A commit's file list never changes, so it is memoised per `(repo, hash)`.
 
 Every repo root a session touched is sent to the client, and a row is shortened against the longest
-one that matches — a session moving between two repos would otherwise show one set of rows relative
+one that matches, since a session moving between two repos would otherwise show one set of rows relative
 and the other absolute.
 
 ### The published-artifacts row
@@ -251,33 +251,33 @@ It gets its own row under the bars (`+N published artifacts`), never the hero, f
 the scratchpad row does: a page put online is not a file this session changed. The drawer then lists
 each page as a real link, under its own heading, with a third KPI tile.
 
-**The row counts PAGES, not publishes.** A redeploy passes the page's own `url` and overwrites it, so
+The row counts PAGES, not publishes. A redeploy passes the page's own `url` and overwrites it, so
 a count of publishes would be a number the reader can find nowhere. The last publish to a URL wins,
 so the label is the description that matches what is online now. Same rule as a path delivered by
 several commits.
 
-**A publish is recognised by its `file_path` first, and only then by the URL its result names.** The
-reading form (`action: "list"`) returns a result FULL of artifact URLs — one per page the user owns —
+A publish is recognised by its `file_path` first, and only then by the URL its result names. The
+reading form (`action: "list"`) returns a result FULL of artifact URLs, one per page the user owns,
 so the URL alone would turn one listing into a dozen rows claiming this session had published them
 all. A publish whose result names no page (it failed) leaves no row: only the server can say a page
 exists.
 
-Both this row and the scratchpad one come from the transcript, so a session **outside a repository
-still shows them**: git having nothing to say is not the same as the session having delivered
+Both this row and the scratchpad one come from the transcript, so a session outside a repository
+still shows them: git having nothing to say is not the same as the session having delivered
 nothing.
 
 ### Scope
 
 Session scope shows everything. With a turn selected, files are filtered by TIME: a file falls in
 the turn whose `[start, next start)` contains the instant of the commit that delivered it. A
-published page follows the same rule, on the instant of its publish — a row that ignored the turn
+published page follows the same rule, on the instant of its publish, since a row that ignored the turn
 would contradict its neighbours. The description follows the selection, counting the commits
 actually on screen.
 
 ### Refresh
 
 `GET /api/files`, on the same 60 s beat as Commits, plus a debounced refetch (1.5 s) whenever the
-ledger grows — a delta is the only on-transcript signal that files are moving; a commit announces
+ledger grows, because a delta is the only on-transcript signal that files are moving while a commit announces
 nothing. The debounce is registered through `later()`, so it dies with the tab: a stray timer would
 re-render a torn-down graph and restart its 1 s ticker forever. The answer repaints through
 `scheduleRender`, never a direct `render()`, which would bypass the `live` guard and draw the whole
@@ -292,19 +292,19 @@ says `No files match the filters.` only when a filter really is set.
 ### Limits
 
 - A **merge commit** lists no files (git would need `-m`, which reports each file once per parent).
-- A session that has **not committed** shows no number, however much it wrote — including every live
+- A session that has **not committed** shows no number, however much it wrote, including every live
   session before its first commit. Work a later session commits appears on that session's card.
 - A session **outside a repo** has no count at all (it can still carry the two secondary rows).
 - The card says what was **delivered**, not who typed it (see the note on shared commits above).
 - A published page is listed from the transcript, so seedeep says it EXISTED, never that it is still
-  online — nothing here asks claude.ai anything, and a page the owner deleted would still be listed.
+  online: nothing here asks claude.ai anything, and a page the owner deleted would still be listed.
 
 ## Tracker cards
 
 ### The signal is an ACTION, never a mention
 
 A tracker key typed in a prompt is the widest signal and the weakest evidence: most of what looks
-like one names no tracker at all — `GPT-4`, `RSA-2048`, `UTF-8`, `CVE-…`, `ISO-8601`.
+like one names no tracker at all: `GPT-4`, `RSA-2048`, `UTF-8`, `CVE-…`, `ISO-8601`.
 
 So no text is read. A card is attributed only when a **tool call named it**, and the id comes from
 the call's own id FIELD (`input.id`, `input.issueId`), never from its body:
@@ -314,23 +314,23 @@ the call's own id FIELD (`input.id`, `input.issueId`), never from its body:
 | `wrote` | the session CHANGED the card | `save_…`, `create_…`, `update_…`, `delete_…`, `add_…`, `remove_…`, `assign_…`, `move_…`, `archive_…`, `comment_…` MCP verbs; a `gh issue close/comment/edit/reopen/create/…`; a closing keyword in a commit message |
 | `read` | it only looked | any tracker call that is not one of those write verbs (`get_…`, `list_…`, …); `gh issue view` |
 
-Merged per card, a write anywhere wins: a session that edits a card also read it, and the edit is
-what makes the link real.
+Merged per card, a write anywhere wins: a session that edits a card also read it, and the
+write is the stronger of the two claims.
 
-Unlike a commit, the relation is **many-to-many** — one card can be touched by several sessions.
+Unlike a commit, the relation is **many-to-many**, and one card can be touched by several sessions.
 Nothing here claims exclusivity, and the card never says "the" session.
 
 ### Title and link come back for free, offline
 
 Both are read out of the tool_result of the call that touched the card. A single call may carry
-neither — a comment does not — but merged per card, the read or write beside it supplies both. A
+neither, since a comment does not, but merged per card, the read or write beside it supplies both. A
 card with no title renders as its bare id, which is a true row, not a broken one.
 
 The MCP link is **never constructed**: it is the `url` the tracker itself returned, accepted only
 when it names that same card (a description can hold any number of links). So no tracker host is
 hardcoded anywhere, and a self-hosted tracker links correctly without a line of code.
 
-No network call is made at read time — for the tracker or for the forge.
+No network call is made at read time, for the tracker or for the forge.
 
 ### Which trackers work
 
@@ -338,7 +338,7 @@ Recognition is by SHAPE, not by vendor: any MCP tool whose name carries `issue` 
 whose id field looks like `ABC-12`, qualifies. Linear and Jira share that key shape, so both work;
 so does a self-hosted tracker exposing the same verbs. The `mcp__` prefix keeps ordinary tools out.
 
-**Without an MCP tracker, this card stays empty** unless the session uses `gh issue` or closing
+Without an MCP tracker, this card stays empty unless the session uses `gh issue` or closing
 keywords. That is deliberate: the commit-message signal alone (a bare key in free text) reopens
 exactly the class of false positives the id-field rule removes.
 
@@ -348,7 +348,7 @@ exactly the class of false positives the id-field rule removes.
 it needs nothing new: the repository comes from the session's cwd through the same `resolveRepo` +
 `origin` path the commit link uses, and `#42` is keyed by repository (`host/owner/repo#42`) because
 a number is unique only there. That identity has ONE definition (`repoSlug`), so an issue reached
-both from the cwd and from `--repo` is one row, not two. `-R/--repo owner/repo` overrides the cwd —
+both from the cwd and from `--repo` is one row, not two. `-R/--repo owner/repo` overrides the cwd, because
 most reads in a real corpus are OTHER projects' issues, read as documentation, and scoping them to
 the session's own repo would key them wrongly and link to a page that does not exist.
 
@@ -362,15 +362,15 @@ record `GH_HOST`. The key is right either way; only the link would point at the 
 
 The title of a forge issue is read from whatever the command printed, in four observed shapes:
 `--json` output; `title:<tab>…` from `gh issue view` with no tty; `✓ Closed issue owner/repo#2 (The
-title)`, gh's own confirmation — so an action that never asked for the title still yields one; and
+title)`, gh's own confirmation, so an action that never asked for the title still yields one; and
 `[open] Issue #2: The title`, the shape a wrapper that reformats gh's output prints. A shape none of
 them matches costs the row only its title: the id, the link and the evidence come from the command
 itself.
 
 ### What the Cards card shows
 
-The output row reads left to right as **Main tools · Commits · Cards** — what the session ran, what
-it shipped, what it was working on — at a fixed **50 / 25 / 25**. Main tools leads because it is the
+The output row reads left to right as **Main tools · Commits · Cards**, meaning what the session ran, what
+it shipped and what it was working on, at a fixed **50 / 25 / 25**. Main tools leads because it is the
 widest card and the one most read. All three are always
 drawn: a widget that appears only once it has content cannot report that there is none,
 and its absence is indistinguishable from seedeep not looking. Empty, this card says `No tracker
@@ -379,13 +379,13 @@ card in scope yet.` and hides its **Expand all**, which would open an empty draw
 Each row: the id, a `read` chip when the session only looked, the title, and a click that opens the
 card on its tracker. A row with no link says so instead of doing nothing. The card shows the newest
 4 and defers the rest to the drawer, where every card is listed with how many calls named it
-(`4 tool calls`) — spelled out, since a bare `×4` reads as a count of cards, and
+(`4 tool calls`), spelled out because a bare `×4` reads as a count of cards, and
 named `tool calls` because everywhere else on the page a bare `calls` now means a call to the model.
 
 The lookup is answered from an **index**, not by reading the corpus. The commit-hash inverse can
 skip one: git is an index that already exists, so it asks which repository holds the object and
 opens only the sessions bracketing it. Nothing indexes a tracker id, so reading every transcript on
-every query is the only alternative — and a cache the query cannot use is not a cache.
+every query is the only alternative, and a cache the query cannot use is not a cache.
 
 `apps/server/src/server/cards-index.ts` is that index: same shape as session search's
 (`search-index.ts`), its own file (`~/.seedeep/cards-index.jsonl`), a header plus one line per
@@ -400,14 +400,14 @@ result, so it moves too.
 
 Search answers the other direction too, for the two identifiers a user actually types
 ([`search.md`](search.md)). Both arrive with no session attached, and both return ordinary result
-rows with zero hits — there is no passage to quote, because the session never said the identifier.
+rows with zero hits, because there is no passage to quote, because the session never said the identifier.
 
 - **A commit hash** asks git which session produced it. The hash carries no repository, so every
   repo the corpus knows is asked whether it holds that object, and only the sessions whose activity
   brackets the commit are then read.
-- **A tracker id** (`ABC-12`, `#42`) returns the sessions that ACTED on that card — the ones the
+- **A tracker id** (`ABC-12`, `#42`) returns the sessions that ACTED on that card, the ones the
   dialogue index cannot see, because the id lives in a tool call and often nowhere in what was said.
-  The query test is permissive on purpose: `GPT-4` reaches the lookup and finds nothing, since the
+  The query test is permissive: `GPT-4` reaches the lookup and finds nothing, since the
   answer comes from ids observed in tool calls, never from text.
 
 ## Endpoints

--- a/docs/trace.md
+++ b/docs/trace.md
@@ -2,7 +2,7 @@
 
 A near-fullscreen modal showing a session as **a scrolling document of turns**:
 one full-width row per turn, each expandable in place into the horizontal strip
-of what actually happened — API calls, tools, subagent spawns — down to any
+of what actually happened (API calls, tools, subagent spawns) down to any
 single step's drawer. Opened from the **Trace** button on the Live activity
 card; scope-aware (whole session, or only the selected turn).
 
@@ -20,13 +20,13 @@ This is the reference for its rules and invariants. Deltas live in
 
 ## The spine
 
-The spine is an `overflow-y:auto` document — one turn row per line, each open
-turn's strip below its own header — so the scrollbar, the wheel, the keyboard and
+The spine is an `overflow-y:auto` document: one turn row per line, each open
+turn's strip below its own header, so the scrollbar, the wheel, the keyboard and
 the browser's own find all work natively.
 
 `openBlock` is shared with the Live activity card's all-activity list, which passes it
-a `BackEntry` so a drill-down leaves a breadcrumb. The Trace deliberately passes none —
-its `onBlock` takes only a handle — because the modal stays open behind the drawer and
+a `BackEntry` so a drill-down leaves a breadcrumb. The Trace passes none,
+its `onBlock` taking only a handle, because the modal stays open behind the drawer and
 is still there to return to. A crumb here would offer to "go back" to something that
 never went away.
 
@@ -37,26 +37,26 @@ including live event ordering), `apps/server/tests/trace-render.test.ts` (fake-d
 ## Why the strip is grouped
 
 A turn can hold hundreds of steps, and at one 172px block each even an ordinary
-turn overflows the stage — zooming out cannot fix it, because text dies before
+turn overflows the stage, and zooming out cannot fix it, because text dies before
 the strip fits. So the strip renders a **group tree** with in-place expansion
 instead of one block per step.
 
 ## The grouping rule (hybrid)
 
-- **Round** — one `api` span plus the tool spans it triggered (the literal
+- **Round:** one `api` span plus the tool spans it triggered (the literal
   transcript structure). Tools before any api form a leading, api-less round.
-- **Landmark** — `prompt`, `spawn`, `result` spans, and tool spans named
+- **Landmark:** `prompt`, `spawn`, `result` spans, and tool spans named
   `Skill`, `AskUserQuestion`, `ReportFindings`. Landmarks always render
   top-level, never inside a group.
-- **Chapter** — a run of consecutive completed rounds folds into one block,
+- **Chapter:** a run of consecutive completed rounds folds into one block,
   capped at **10 rounds** and broken early by any landmark. A run of exactly
   one round stays a lone round block (never wrapped).
-- **Parallel spawns** — a run of spawn steps ADJACENT in the strip (nothing
+- **Parallel spawns:** a run of spawn steps ADJACENT in the strip (nothing
   between them) collapses into one `parallel` item, because drawing them
-  left-to-right with arrows asserts a sequence that never happened. **Adjacency
-  is the criterion, never time**: spawns that overlap while work sits between
+  left-to-right with arrows asserts a sequence that never happened. Adjacency
+  is the criterion, never time: spawns that overlap while work sits between
   them are separate launches and must not merge, and no threshold could tell the
-  two apart anyway — a `tool_use` line lands only when the streaming response
+  two apart anyway, since a `tool_use` line lands only when the streaming response
   reaches it, so spawns fired together are written seconds apart. A run of one
   stays a plain spawn block.
 - Group ids are stable (`r<n>`, `ch<startRound>`): a live turn's trailing
@@ -65,24 +65,24 @@ instead of one block per step.
 
 ## What a group block is CALLED
 
-A round's name is the **intent its own API call stated** — the mid-turn text block
+A round's name is the **intent its own API call stated**: the mid-turn text block
 of that call, i.e. the model saying what it is about to do. Round = api + its
 tools, and the intent belongs to that same api, so the join is the call id
 (`message.id`), never "the last api span": one response is written as several
 jsonl lines (thinking, then text, then each `tool_use`), so a slow line would
 otherwise name whatever round happened to be open. The api span is always there
-when the intent arrives, because the call's FIRST line created it — that is the
+when the intent arrives, because the call's FIRST line created it. That is the
 intent's own line when the text block leads (a line emits `usage` before its
 content blocks) and an earlier `thinking` line otherwise. No parking is needed.
 
-- **The number stays the fallback, and that is the common case** — most rounds
+- The number stays the fallback, and that is the common case. Most rounds
   state no intent at all and keep `#7 round`; a named round moves its number to
   the sub-line, where it weighs the same as `2 steps`.
 - **Two clamped lines, not the sentence.** A 172px block shows a few dozen
   characters of an intent that runs to hundreds, so the block carries the opening
   and `title` carries the whole text. The clamp is a class (`gnamed`), so CSS
   decides how much shows, not the renderer.
-- **A chapter counts intents; it is never named by one.** Naming a chapter after
+- A chapter counts intents; it is never named by one. Naming a chapter after
   the first intent it folds describes one round out of up to ten as if it
   described all ten. It keeps its range (`R1–10`) and prints `3 intents` in the
   sub-line, dropping `steps` to make room (with all four facts the sub-line wraps
@@ -93,13 +93,13 @@ content blocks) and an earlier `thinking` line otherwise. No parking is needed.
   (its own span), and naming the last round with it would put the conclusion on
   the block that led to it.
 - The reducer keeps only the LATEST narration (the live NOW panel's datum, by
-  design). The Trace needs the history, so it lives on the spans — one intent per
-  `api` span — and the two never compete.
-- **The whole text lives in the api block's drawer**, as its own `Intent` block
-  above `Input`, fetched with the rest of the call from `/api/call-io` — never
+  design). The Trace needs the history, so it lives on the spans, one intent per
+  `api` span, and the two never compete.
+- The whole text lives in the api block's drawer, as its own `Intent` block
+  above `Input`, fetched with the rest of the call from `/api/call-io`, never
   inside `Output`, which a call with tools renders verbatim because its args are
   code. The block is hidden, not omitted, when the call said nothing.
-- **The span DOES hold the text, and that is deliberate** — unlike the turn's own
+- The span DOES hold the text, and that is deliberate, unlike the turn's own
   text, whose handle carries only an index. A round's label has to be drawn on
   every rebuild, including offline replay, so making it wait on a fetch would
   leave the strip unnamed until the network answered. What the span holds is the
@@ -110,45 +110,45 @@ content blocks) and an earlier `thinking` line otherwise. No parking is needed.
 Group blocks show label (`#7 round` / `R1–10` / the round's intent), counts +
 duration, and a type-dot preview. Click expands **in place** (dashed frame, sideways fold cap);
 nesting is chapter → rounds → steps. Each turn header carries
-`expand` / `collapse` (expand iterates to a fixpoint — one click opens every
+`expand` / `collapse` (expand iterates to a fixpoint, so one click opens every
 level). They act on this turn's GROUPS; the header's `Close turns` acts on turns.
 Expanded groups are **pinned** by namespaced key
-(`<turn>:<ns><id>` — the main strip and each subagent lane have distinct key
+(`<turn>:<ns><id>`, since the main strip and each subagent lane have distinct key
 spaces) and survive live re-renders; `open()` resets them, together with the
-failure cursor and the jump marker — those are keyed by MODEL index, which names
+failure cursor and the jump marker, which are keyed by MODEL index and so name
 a different turn after a re-open (a scoped open makes index 0 some other turn).
 
 ## The turn row
 
-One row per turn, with fixed-width slots that are emitted even when empty — on a
+One row per turn, with fixed-width slots that are emitted even when empty: on a
 long session the metrics have to line up in columns, or comparing two rows means
 re-reading both. Left to right: `T<n> · kind`, title, sparkline,
 subagent count, failure badge, duration.
 
-- **The sparkline is the turn's SHAPE**, not its volume: a count says how much a
+- The sparkline is the turn's SHAPE, not its volume: a count says how much a
   turn did and never what it looked like, so a long tool burst and alternating
   api/tool cycles would read identically. The turn's steps are binned in order
-  into at most `SPARK_BINS` (30) slots — the cap is what keeps the bar bounded on
+  into at most `SPARK_BINS` (30) slots, and the cap is what keeps the bar bounded on
   a turn of hundreds of steps. The total stays beside it as a number.
-- **A bin STACKS the types it holds, proportionally** (order: `SPARK_RANK`), and
+- A bin STACKS the types it holds, proportionally (order: `SPARK_RANK`), and
   never picks a winner: one colour per bin cannot describe a mixture, and every
   way of picking one paints a wall of the type that wins almost every bin. A
   failing bin's red band never scales below a third of the bin: one bad step
   among six must still be visible.
-- **The bands of a bin sum to 1, and that is a contract** (`binComposition`, a pure
+- The bands of a bin sum to 1, and that is a contract (`binComposition`, a pure
   function, asserted in `trace-render.test.ts`). A `linear-gradient` holds its last
   colour past its last stop, so a composition that closes early is not a shorter
-  bar — it is the LAST type silently taking the remainder, on the row that exists
+  bar: it is the LAST type silently taking the remainder, on the row that exists
   to state the shape.
 
-- **The left rule is the turn's STATE**, not its index: neutral, red when the
+- The left rule is the turn's STATE, not its index: neutral, red when the
   turn holds a failure, amber while it is live. A per-turn hue would say nothing
   `T7` does not already say, and would land on the error colour.
-- **A row is named by the command AND its arguments**, since a command's
-  arguments ARE its prompt — dropping them titles a `/code-review del diff` round
+- A row is named by the command AND its arguments, since a command's
+  arguments ARE its prompt, and dropping them titles a `/code-review del diff` round
   `del diff`. One rule (`entryText`, `core/tree-format.ts`), shared with the
   Graph's `entryLabel`.
-- **Nothing is FINAL while a turn is live — unless the session is over.** The
+- Nothing is FINAL while a turn is live, unless the session is over. The
   `▲ FINAL RESULT` cap and its block are omitted whenever any round is still
   working AND the session is open (`open`/`update` take `ended`): the last answer
   on record then belongs to a PREVIOUS round, and showing it under that cap says
@@ -156,7 +156,7 @@ subagent count, failure badge, duration.
   finished session from hiding its answer, since a round killed mid-flight keeps
   `state: 'live'` for good. It returns as soon as the live round produces its own
   answer.
-- **A round that DELEGATED is never an idle one-liner.** Only a control command
+- A round that DELEGATED is never an idle one-liner. Only a control command
   with nothing behind it (`/model`, `/clear`) collapses to a single line. A
   forked skill (`/code-review`) makes no API call and runs no tool on the main
   thread, so on those two counts alone it would collapse exactly like a `/model`
@@ -165,7 +165,7 @@ subagent count, failure badge, duration.
   tool_use, so `span-store` registers the spawn block from that event and keys it
   by the AGENT id (the only name the launch gives it); the sidecar, which carries
   no `toolUseId` either, resolves through the same key. The round's `kind` becomes
-  `work` at that launch — delegating IS running the model, the same call the
+  `work` at that launch, because delegating IS running the model, the same call the
   reducer's `kindOf` makes, so the two surfaces cannot label one round two ways.
   The kind is a GUESS when the turn opens (a `user-turn` carries only its command
   name); the launch is the moment that guess is answered. `isIdle` also requires
@@ -177,37 +177,37 @@ subagent count, failure badge, duration.
   The spawn span carries `handle.toolUseId` set to that same agent id: the render
   links a span to its block through THAT field alone, so a handle without it
   draws the block with `no child events` while its lane sits in the store. Its
-  span is closed by `agent-end` — a forked skill emits no `tool-end`, so nothing
+  span is closed by `agent-end`: a forked skill emits no `tool-end`, so nothing
   else can.
-- **A collapsed turn declares its failures, and says how many.** The count is
+- A collapsed turn declares its failures, and says how many. The count is
   computed in `adaptSnapshot` over the main spans AND every child lane, so a
   failure that exists only inside a subagent still reaches the shut row. The
   badge reads `N failed steps`, never a bare "failed": the turn carried on and N
   of its steps did not. Its `title` says so outright.
-- **The badge is a BUTTON, and it goes there.** A count the user wants to click
+- The badge is a BUTTON, and it goes there. A count the user wants to click
   and cannot is a dead end, and reaching a failure by hand means opening the turn
   and every group above it, once per failure. Clicking pins the containing groups
-  (`groupPathToSpan`) BEFORE the rebuild — `pinnedGroups` is what survives one —
+  (`groupPathToSpan`) BEFORE the rebuild, since `pinnedGroups` is what survives one,
   unfolds the lane when the failure is inside a subagent, rebuilds, then scrolls
   the block into view and marks it. Repeated clicks cycle the turn's failures
   and wrap. Four rules make the jump hold:
   - **It releases auto-follow.** Jumping is navigation, as deliberate as a
-    scroll, and a scroll releases follow — otherwise the next live event scrolls
+    scroll, and a scroll releases follow, or the next live event would scroll
     the failure straight off screen.
-  - **The marker is STATE (`_hitSpanId`), not a class written once.** Every path
+  - The marker is STATE (`_hitSpanId`), not a class written once. Every path
     that redraws a block re-derives it (`applyHit`, called from `renderLanes`), so
     a live rebuild, a turn re-opened by hand or a lane folded and unfolded all keep
     it.
-  - **It opens a merged parallel run whole**, because the run is one block on
+  - It opens a merged parallel run whole, because the run is one block on
     screen: unfolding a single spawn of it would leave the lane under a block
     still reading `▸ expand flow`.
   - Inside a `Workflow` the lane draws a **tile**, not a strip, so the tile is what
-    the jump lands on and marks — the spans of a Workflow lane have no block of
+    the jump lands on and marks: the spans of a Workflow lane have no block of
     their own.
-- **A live turn must also hold work.** A finished session still reports
+- A live turn must also hold work. A finished session still reports
   `state === 'live'` on every turn it never closed, and those turns are empty, so
   the amber rule requires api or tool spans.
-- **Duration is a bar, not only a number** — each turn against the longest turn,
+- Duration is a bar, not only a number: each turn against the longest turn,
   each block against the widest block in its strip (linear: a 96ms Skill beside
   a 5m chapter *should* read as nothing). The row's bar has no axis and no label,
   so it carries a `title` stating what it measures, and it stays **neutral in
@@ -215,66 +215,66 @@ subagent count, failure badge, duration.
   sparkline already carry. The duration number sits in a fixed-width cell so the
   bars line up down the session; sized to their text ("60s" vs "76m 4s") every
   bar slides.
-- **A control command that ran nothing is one dim line** (`/clear`, `/model`). A
-  `work` turn with no api/tool was interrupted with Esc and keeps a full row —
+- A control command that ran nothing is one dim line (`/clear`, `/model`). A
+  `work` turn with no api/tool was interrupted with Esc and keeps a full row,
   that is information, not noise.
-- **The session subject is the first turn that did work.** `turns[0].title` is
+- The session subject is the first turn that did work. `turns[0].title` is
   usually a control command, which would head the view `/clear` while the picker
   shows the real subject.
 
 ## Live behavior
 
-- On a turn with `state === 'live'`, the **tail round stays raw** — open step
-  blocks, never folded — and the newest block glows. Finished rounds fold as
+- On a turn with `state === 'live'`, the **tail round stays raw**, with open step
+  blocks and never folded, and the newest block glows. Finished rounds fold as
   the next api arrives; chapters close at the cap or at a landmark.
 - **Auto-follow** (whole-session open): the view tracks the newest work by
   scrolling the last turn's header ≈20% down the stage; a live turn also scrolls
   its own strip fully right, because the strip grows rightward. A manual scroll
   releases follow; the header's `follow` button re-engages it.
-- **Ours-or-theirs is decided by POSITION, not by a time window.** The controller
+- Ours-or-theirs is decided by POSITION, not by a time window. The controller
   records the `scrollTop` it just set (`_expectedTop`, read back so the browser's
   clamping is included) and the listener ignores an event landing within 2px of
   it. A flag cleared on the next frame is not equivalent: on a busy live session
   `focusLastTurn` runs on every event, so it would be up whenever the user
   happened to scroll, and their scroll would be swallowed as ours.
-- **`follow` is hidden unless the session is WORKING.** Auto-follow acts only
+- `follow` is hidden unless the session is WORKING. Auto-follow acts only
   through `update()`, which a finished session never calls, so there the button
-  would merely jump to the last turn — `Last turn`'s job, which also opens it. A
+  would merely jump to the last turn, which is `Last turn`'s job and also opens it. A
   control doing another control's job is worse than an absent one. Liveness needs
   real work, not just `state === 'live'` (see the turn-row rules above).
 - `update()` restores `scrollTop` after the rebuild, so a live event cannot
-  throw a user reading turn 12 back to the top — **and each open turn's strip
+  throw a user reading turn 12 back to the top, **and each open turn's strip
   `scrollLeft` with it**. The strip is a SEPARATE scroller: restoring only the
   stage sends a reader back to the strip's first block once a second. The live
-  turn is the exception, because `focusLastTurn` deliberately scrolls it fully
+  turn is the exception, because `focusLastTurn` scrolls it fully
   right afterwards.
 - Blocks appear seconds after the console shows the same activity: a spawn's
   `tool_use` line is written to the jsonl only when the **streaming response
-  reaches it**. seedeep reads the file — this floor is inherent to the read-only
+  reaches it**. seedeep reads the file, so this floor is inherent to the read-only
   architecture.
 
 ## Class scoping
 
 Every class the renderer writes must be scoped under `.trace-modal`, or a global
-rule reaches it — a single-class name like `live` is also the Live-activity
+rule reaches it: a single-class name like `live` is also the Live-activity
 badge's, and it lands on every Trace node carrying it.
 `apps/server/tests/trace-css-scope.test.ts` reads the stylesheet
 and the renderer as TEXT and fails on any Trace class that a single-class global
 rule also targets; a fake-dom test cannot catch this, because it does no layout.
-`hidden` is the one allowed collision — a shared utility whose effect is wanted.
+`hidden` is the one allowed collision, a shared utility whose effect is wanted.
 
 The guard only sees what it can extract: `classList?.add('hit')` is invisible to
 a regex demanding `classList.`, and a name BUILT at runtime (`'t-' + type`, the
-sparkline bins) never appears as a literal at all. Both are covered — the second
+sparkline bins) never appears as a literal at all. Both are covered, the second
 by asserting that no global rule falls inside a runtime-built prefix family.
 Adding a new way to write a class name means teaching the extractor about it in
 the same commit.
 
 ## Subagents
 
-- **The spawn block IS the subagent.** Label = the launch intent
+- The spawn block IS the subagent. Label = the launch intent
   (`description` → first line of the prompt → agent type); sub-line = agent
-  type (model) · tool count · the lane's real duration — never the spawn-call
+  type (model) · tool count · the lane's real duration, never the spawn-call
   ms, which is only a launch receipt. A fan-out spawn aggregates
   (`3 subagents · 12 tools · 5m`).
 - **Click the block → the child's flow unfolds** as a parallel lane below,
@@ -287,25 +287,25 @@ the same commit.
   bundle grid instead. A lane with no child events says so
   (background agents may write no child transcript).
 - **ⓘ on the block → the drawer**: the subagent drawer when the agent is in
-  the snapshot, else the spawn TOOL drawer (launch prompt, timing) — a click
+  the snapshot, else the spawn TOOL drawer (launch prompt, timing), so a click
   is never a silent no-op.
 - **Live event ordering** (the invariant that makes lanes fill while agents
   run): the watcher reads a child's `meta.json` and transcript as soon as the
-  agent starts writing — BEFORE the parent's assistant line exists. The span
+  agent starts writing, BEFORE the parent's assistant line exists. The span
   store parks an early `subagent-meta` until its spawn arrives, then applies
   it and flushes the child events buffered meanwhile. Covered by the
   live-ordering test in `apps/server/tests/span-store.test.ts`.
-- **A lane is anchored by its spawn, and a resumed agent still finds it.** The
+- A lane is anchored by its spawn, and a resumed agent still finds it. The
   completion notification normally carries the spawn's `tool-use-id`, but after
   a `SendMessage` resume Claude Code carries the RESUME call's id, which anchors
-  no lane — so the store falls back to `<task-id>` (the child's agentId) through
+  no lane, so the store falls back to `<task-id>` (the child's agentId) through
   the same `agentId → spawn` map. Without it a resumed lane keeps its
   pre-resume status forever. The map is written back with the spawn's id, never
   the notification's.
 
 ## The turn's own text
 
-The first and last block of a turn ARE the conversation — what was asked, and what
+The first and last block of a turn ARE the conversation: what was asked, and what
 came back. Both carry a `turn-text` handle (`{turnIndex, which}`) and open the
 shared output drawer through `openBlock`, exactly like a tool or an API call.
 
@@ -313,8 +313,8 @@ The handle carries **only the index**: the text lives on the reducer's `TurnNode
 (`prompt`, `result`), and the router reads it there at click time rather than the
 span store keeping a second copy of it.
 
-**A mid-turn `reply` opens nothing.** The reducer stores the turn's result as
-"last wins", so an earlier answer's text is no longer available — opening it would
+A mid-turn `reply` opens nothing. The reducer stores the turn's result as
+"last wins", so an earlier answer's text is no longer available, and opening it would
 show a *later* answer than the block claims. Rather than showing the wrong text,
 that one block stays inert (`cursor:default`, no hover).
 
@@ -326,19 +326,19 @@ the end block the session's conclusion would live only at the far right of an
 expanded turn's strip, past a horizontal scroll.
 
 The end cap labels a **full-width final-result block**: the turn id, and the
-answer's first line stripped to plain (like the NOW panel's inline line — this
+answer's first line stripped to plain (like the NOW panel's inline line; this
 block renders prose, not a step label, so raw `**` and backticks read as noise;
 code inside a fence is quoted as it is, since there the markers are the code).
 Clicking it opens the same drawer as that turn's `done` block. An answer that
-strips to nothing at all — markers and no words — reads `(no text)`, the same
+strips to nothing at all, markers and no words, reads `(no text)`, the same
 words the NOW panel uses for the same nothing.
 
-- **It reads the LAST `result` span of the last turn that holds one**, and reuses
-  that span's `turn-text` handle — so the block and the `done` block can never
+- It reads the LAST `result` span of the last turn that holds one, and reuses
+  that span's `turn-text` handle, so the block and the `done` block can never
   disagree, and no second copy of the text exists (see *The turn's own text*).
   That span is always the latest answer, which is exactly what the reducer's
   `TurnNode.result` holds, so the mid-`reply` hazard does not apply here.
-- **It names its turn (`T6`).** On a live session the last turn may still be
+- It names its turn (`T6`). On a live session the last turn may still be
   working while the answer on screen belongs to the one before it; unnamed, a
   block in that position would lie by position alone.
 - **No answer yet → the empty state, not a missing block** (`No final answer yet`,
@@ -353,16 +353,16 @@ text). A turn can hold several: the model closes, then is re-woken without a
 new user prompt (e.g. a background task notification). A result with spans
 AFTER it renders as a dashed, dimmed **reply**; only the last one is **done**.
 Live, the tail result reads `done` and demotes itself automatically if more
-work arrives — same rule, position-derived.
+work arrives: same rule, position-derived.
 
 ## Block colors
 
 Steps carry their span-type color (`--sp-*`: prompt violet, api blue, tool
 green, skill mint, result amber); spawn blocks are cyan with a gradient fill;
-**rounds are teal (`--sp-round`) and chapters indigo (`--sp-chapter`)** so the
-three families — steps, rounds, chapters — read apart at a glance.
+rounds are teal (`--sp-round`) and chapters indigo (`--sp-chapter`) so the
+three families (steps, rounds, chapters) read apart at a glance.
 
-**No successful category may sit near the error hue.** A step that worked must
+No successful category may sit near the error hue. A step that worked must
 never read as one that failed. The hues, and their distance from
 `--sp-error` (351°):
 
@@ -375,29 +375,29 @@ never read as one that failed. The hues, and their distance from
 | `--sp-prompt` `#a78bfa` | 255 | 96° |
 | `--sp-result` `#fbbf24` | 43 | 52° |
 
-`tool` is the most frequent category of all, so it takes hue 99 — the furthest a
+`tool` is the most frequent category of all, so it takes hue 99, the furthest a
 free hue can sit from every other token (56° from its nearest neighbour). `result`
 stays amber at 52°: it appears once per turn and carries the word "done", and
 frequency is what makes a collision dangerous. All these tokens are Trace-only.
 
-`--sp-api` (213) and `--sp-spawn` (199) sit 14° apart. Left alone deliberately:
-a spawn block is a different shape — cyan gradient fill, stacked edges when
-merged — and the two never appear as adjacent bare dots.
+`--sp-api` (213) and `--sp-spawn` (199) sit 14° apart. Left alone:
+a spawn block is a different shape (cyan gradient fill, stacked edges when
+merged) and the two never appear as adjacent bare dots.
 
 A span whose `status === 'error'` (a tool that **failed**, or an API call
 Claude Code flagged `isApiErrorMessage`) takes a red border (`--sp-error`),
-in the main strip and inside subagent lanes alike — most real failures happen
+in the main strip and inside subagent lanes alike, since most real failures happen
 inside a subagent. A tool the **user refused** (Esc on the permission prompt,
 or a deny rule) is not a failure and is never reddened; the parser draws that
 line (`apps/server/src/server/failure.ts`, `toolOutcome`), not the Trace.
 
-**A background command fails LATER than its span.** A `Bash` launched in the
-background returns a receipt in ~100ms — the call's work was starting the
+A background command fails LATER than its span. A `Bash` launched in the
+background returns a receipt in ~100ms: the call's work was starting the
 command, so the span closes there and its duration stays the launch's, never
 the command's lifetime. (A foreground command *promoted* to the background when
 it outlives its call's own timeout is the same case with a different number: its
-span is the timeout it ran for — the `timeout` the call asked for, two minutes
-when it asked for none — so a promoted span is minutes long, not 100ms.) The
+span is the timeout it ran for, meaning the `timeout` the call asked for, two minutes
+when it asked for none, so a promoted span is minutes long, not 100ms.) The
 outcome arrives minutes or hours afterwards, on
 a `queue-operation` line, and is the only place the exit code exists. The span
 store keeps those spans and, when a non-clean status lands, reddens the span and
@@ -406,23 +406,23 @@ on the row.
 
 The gate is the RECEIPT, never the notification's id shape: a resumed subagent's
 `SendMessage` is named by a `b…` notification too, and keying on that would redden
-a call that launched nothing. Two receipt shapes pass it — a `Bash`'s
+a call that launched nothing. Two receipt shapes pass it: a `Bash`'s
 `backgroundTaskId`, and a `Monitor`'s `taskId` + `timeoutMs`, which is the same
 kind of launch under a different field name. A `Monitor` therefore behaves here
 exactly like a background `Bash`: a launch span that keeps its receipt's duration,
 a `bg` chip, and an outcome that lands when its stream ends.
 
-**A ⚑ means a hook had something to say about this call.** Claude Code writes a hook's
-note as an `attachment` line naming the call's id — a security plugin objecting to what
-was just written, most often — and the block carries the mark while the drawer carries
+A ⚑ means a hook had something to say about this call. Claude Code writes a hook's
+note as an `attachment` line naming the call's id, most often a security plugin objecting to what
+was just written, and the block carries the mark while the drawer carries
 the text. Only the mark: a note can be a paragraph, and a block is one line. Amber, not
 red, and independent of the span's status: a call somebody warned about is not a call
 that failed, and both can be true at once. The note arrives AFTER the call closed, so
 the store looks the span up by handle (newest turn first) rather than keeping every
-closed span to catch it — an index that would grow with the session to serve a handful
+closed span to catch it, an index that would grow with the session to serve a handful
 of notes.
 
-**The block says it was a background launch, in every state.** A `bg` chip sits
+The block says it was a background launch, in every state. A `bg` chip sits
 beside the label, from the launch onwards: without it the row is an ordinary
 100ms `Bash`, and its sub-line changes identity when the outcome lands (the
 command is replaced by CC's sentence, which names the command by its
@@ -430,10 +430,10 @@ command is replaced by CC's sentence, which names the command by its
 as the command's, and for a launch that is never notified at all it is the only
 thing on the row that stays true.
 
-**The drawer states the fate, and the strip's numbers are named for what they
-measure.** Opening a background block shows a `background` chip beside the kind,
+The drawer states the fate, and the strip's numbers are named for what they
+measure. Opening a background block shows a `background` chip beside the kind,
 an `Outcome` block carrying CC's sentence (or `still running` before it lands),
-and a `Launch` tile where every other tool has `Duration` — never the launch
+and a `Launch` tile where every other tool has `Duration`, never the launch
 receipt alone («Command running in background… you will be notified»), which
 says less than the row it was opened from.
 
@@ -441,12 +441,12 @@ The words are CC's; only their ORDER is seedeep's. `outcomeLine`
 (`core/activity-line.ts`) rewrites `Background command "Start seedeep server"
 failed with exit code 144` into `failed with exit code 144 · Background command
 "Start seedeep server"`, because the column truncates on the right and the fate
-— the one thing the row cannot deduce, and the only place the exit code exists
-— is the tail of CC's sentence. The regex anchors on the FATE, never on the
+(the one thing the row cannot deduce, and the only place the exit code exists)
+is the tail of CC's sentence. The regex anchors on the FATE, never on the
 name: a launch with no `description` is named by CC after the command itself,
 which brings its own quotes and newlines. CC also HTML-escapes what
 it quotes (`&amp;&amp;`, `&lt;&lt;`), and these lines are printed as text, so
-the entities are decoded after the split — never before, or a `&quot;` would
+the entities are decoded after the split, never before, or a `&quot;` would
 become a quote the split could land on. A summary that does not match the known
 shape still passes through whole: CC owns this text and may reword it, and a
 stale regex must degrade to showing everything, never to mangling it.
@@ -456,11 +456,11 @@ seedeep reports what Claude Code reported: exit 144 is what a deliberately
 semantics the logs do not carry.
 
 **A failure survives folding.** Because the tools that fail most (Bash, Edit,
-Read) are non-landmark, they fold into rounds/chapters — so a red leaf alone
+Read) are non-landmark, they fold into rounds/chapters, so a red leaf alone
 would be invisible in the collapsed strip. `groupTurnSpans` therefore carries
 `hasError` up the group tree (a group has it iff any leaf failed), and a
 flagged round/chapter block takes the red left rule while its type-dot preview
-paints the failing leaves' dots red — the failure is legible without opening
+paints the failing leaves' dots red, so the failure is legible without opening
 the block. Covered by `trace-group.test.ts` (propagation) and
 `trace-render.test.ts` (both faces + the preview dot).
 
@@ -469,14 +469,14 @@ the block. Covered by `trace-group.test.ts` (propagation) and
 | Click | Effect |
 |---|---|
 | turn header | expand/collapse the turn in place |
-| `N failed steps` badge | jump to the next failed step: opens the turn, the groups hiding it and its lane (a merged run whole), releases auto-follow, then scrolls to it and marks it — the marker survives every later rebuild |
+| `N failed steps` badge | jump to the next failed step: opens the turn, the groups hiding it and its lane (a merged run whole), releases auto-follow, then scrolls to it and marks it; the marker survives every later rebuild |
 | group block / fold cap | expand/collapse the group in place (pinned) |
 | step block (api/tool) | opens the existing drawer for that call/tool |
 | first block (prompt) | opens the turn's prompt, rendered as markdown |
 | last block (`done`) | opens the turn's final answer, rendered as markdown |
-| mid-turn `reply` | nothing — see below |
+| mid-turn `reply` | nothing; see below |
 | spawn block | unfolds/folds the child lane(s) below |
-| parallel block (`N in parallel`) | unfolds/folds EVERY lane of the run at once — it is drawn as one block, so it opens as one; each lane is named by its launch intent |
+| parallel block (`N in parallel`) | unfolds/folds EVERY lane of the run at once: it is drawn as one block, so it opens as one; each lane is named by its launch intent |
 | spawn ⓘ / lane name / workflow mini | drawer (subagent, or spawn tool as fallback) |
 | wheel / scrollbar / `PageDown` `Home` `End` | scroll the spine (native) |
 | wheel over an open strip | scroll that strip horizontally (native) |

--- a/docs/tray.md
+++ b/docs/tray.md
@@ -2,14 +2,13 @@
 
 A menu-bar app that shows, at a glance, which of your sessions need you. It is the second
 frontend after the browser GUI, and it is **a pure HTTP client**: it links no seedeep code,
-parses no session file, and reads one endpoint on its clock — `GET /api/digest`, where the server
+parses no session file, and reads one endpoint on its clock: `GET /api/digest`, where the server
 has already done the reduction (see [`api.md`](api.md#get-apidigest)).
 Everything the tray knows, it was told. The one exception is a server on the SAME machine, whose
-process it can start and stop — see [Starting and stopping the server](#starting-and-stopping-the-server).
+process it can start and stop; see [Starting and stopping the server](#starting-and-stopping-the-server).
 
-That is the whole architectural rule, and it is what keeps a second frontend from becoming a
-second implementation: a change to `apps/server/src/core/` cannot break the tray unless it
-changes the endpoint.
+That is the whole architectural rule: a change to `apps/server/src/core/` cannot break the tray
+unless it changes the endpoint.
 
 Downloading and installing it, the first-launch warnings, and removing it again are in
 [`install.md`](install.md#installing-the-tray).
@@ -18,7 +17,7 @@ Downloading and installing it, the first-launch warnings, and removing it again 
 
 ```text
 apps/tray/
-├── ui/                    the popover's HTML/CSS/TS — bundled by Bun into ui/dist/
+├── ui/                    the popover's HTML/CSS/TS, bundled by Bun into ui/dist/
 │   ├── panel.ts           the entry point: render what Rust reports, send back what a user does
 │   ├── bands.ts           the four bands, free of Tauri so it can be tested
 │   ├── settings.ts        the settings view, same rule
@@ -36,12 +35,12 @@ apps/tray/
     ├── src/update.rs      the release banner, and which versions this run has announced
     ├── src/store.rs       the private, atomic write
     ├── tests/fixtures/    a synthetic certificate, for hashing without a network
-    ├── icons/             the BUNDLE's icons (Finder, DMG, installer) — not the tray's
+    ├── icons/             the BUNDLE's icons (Finder, DMG, installer), not the tray's
     └── capabilities/      what the webview is allowed to call
 ```
 
 The two halves answer different questions. `ui/` is the panel a user looks at; `src-tauri/` is
-everything the panel cannot do from a webview — owning a menu-bar item, sending an OS
+everything the panel cannot do from a webview: owning a menu-bar item, sending an OS
 notification, and speaking HTTPS to a pinned self-signed certificate, which the webview's `fetch`
 cannot express at all.
 
@@ -55,7 +54,7 @@ live probes are contributor matters:
 
 The root `package.json` holds **the only version number in the repo**, and
 `apps/tray/src-tauri/tauri.conf.json` names that file as its `version` instead of carrying one
-of its own. So a tag ships the server and the tray at the same version by construction — not
+of its own. So a tag ships the server and the tray at the same version by construction, not
 by anyone remembering to update two files.
 
 The Rust crate's own `Cargo.toml` version is inert and stays at `0.0.0`; it is not what the
@@ -63,33 +62,33 @@ bundle reports.
 
 ## The menu-bar icon
 
-**The mark is a lens with no handle** — a thick ring of glass with a trace inside it: three spans
+The mark is a lens with no handle, a thick ring of glass with a trace inside it: three spans
 stepping to the right, the shape the Trace tab draws. It is **drawn, not shipped as image files**
 (`src/icon.rs`), because no test can say anything about a PNG. The geometry and the reasoning behind
 every constant live in that file, next to the code that has to obey them.
 
-**The icon is never absent.** An icon that disappears is indistinguishable from an app that
-crashed, so there is no state in which nothing is drawn — including "cannot reach the server",
+The icon is never absent. An icon that disappears is indistinguishable from an app that
+crashed, so there is no state in which nothing is drawn, including "cannot reach the server",
 which gets an icon of its own rather than silence.
 
 | State | Icon |
 | -- | -- |
-| **Unreachable** — nothing answering at the configured address | Grey glass, struck through, empty — nothing to read |
+| **Unreachable**, nothing answering at the configured address | Grey glass, struck through, empty: nothing to read |
 | **Nothing live** | Grey glass over the trace, still |
 | **Working, nobody waiting** | Blue glass with a **gap running round it**, a turn every two seconds. No count: a number that changes constantly is peripheral noise |
-| **≥1 waiting for you** | Amber glass, the same trace drawn **heavier** — 3 px bars instead of 2, run out as far as the circle allows — and **still**, plus a badge dot **only above one** |
-| **≥1 broken** | The plain mark **in red**, same badge rule — a session whose last model call FAILED. What keeps it off colour alone is that waiting thickens its bars and this does not |
+| **≥1 waiting for you** | Amber glass, the same trace drawn **heavier** (3 px bars instead of 2, run out as far as the circle allows) and **still**, plus a badge dot **only above one** |
+| **≥1 broken** | The plain mark **in red**, same badge rule: a session whose last model call FAILED. What keeps it off colour alone is that waiting thickens its bars and this does not |
 
 The state comes from the same reading the panel draws (see [The poll](#the-poll)), and it is
 repainted only when it changes. **Unreachable covers "nothing configured" as well as "configured and
 silent"**: both are the tray unable to see anything, and an idle icon it could not vouch for would be
-a guess. A digest that is not a list of sessions is Unreachable too — a schema change is this
+a guess. A digest that is not a list of sessions is Unreachable too, since a schema change is this
 client's one standing risk, and that state is the one that says so.
 
-**Working is the only state that moves, and the stillness of the others is half the message.** A
+Working is the only state that moves, and the stillness of the others is half the message. A
 turning gap means *something is running, there is nothing for you to do*; amber means *it is your
 turn*. So an approval STOPS the motion: with three sessions working and one stopped on you, the icon
-is amber and still, and that the other two are working is in the panel. Waiting outranks working —
+is amber and still, and that the other two are working is in the panel. Waiting outranks working,
 the icon says the thing you can act on.
 
 **Broken outranks all of it**, because a session stopped on an approval resumes the instant it is
@@ -98,29 +97,29 @@ event: set by a call flagged `isApiErrorMessage` and cleared only by the next ca
 model, never by time. `is_working` and `needs_you` are copies of the server's predicates, while this
 one is derived once by the reducer and carried in the digest's `error` field, so the icon, the panel
 and the portal's tab strip cannot disagree about whether a session is broken. A payload without the
-field reads as healthy — an older server must not paint every session red.
+field reads as healthy: an older server must not paint every session red.
 
-**The turn is 24 frames at 12 fps, one pass every two seconds.** A spinner is read out of the corner
+The turn is 24 frames at 12 fps, one pass every two seconds. A spinner is read out of the corner
 of the eye, so it is judged on whether the motion is smooth, and the frame COUNT is what buys that
 rather than the rate. The frames are rasterised ONCE at startup and cycled. The spin has its own
-loop — the poll's cadence is how often the server is asked, this one is how smooth a spinner looks —
+loop (the poll's cadence is how often the server is asked, this one is how smooth a spinner looks)
 and while no session is working that task holds on a `Notify` rather than leaving a 24 Hz timer
 ticking through an idle night. The two loops take turns with the icon under one lock, because the
 frame that matters is the one painted LAST.
 
 Three rules behind that table:
 
-- **The states differ by SHAPE, not only by colour** — struck through, empty glass, a turning gap,
-  heavier bars, plain — since colour alone would fail a colour-blind user and would vanish entirely
-  under a macOS template image. **The one exception is working-vs-waiting**, blue against amber: the
+- **The states differ by SHAPE, not only by colour**: struck through, empty glass, a turning gap,
+  heavier bars, plain. Colour alone would fail a colour-blind user and would vanish entirely
+  under a macOS template image. The one exception is working-vs-waiting, blue against amber: the
   pair that survives the common colour-vision deficiencies best. Waiting-vs-broken is the weakest
   shape difference the icon carries, and the test that guards it asserts the SHAPE and ignores the
   colour, demanding the difference be a large fraction of the ink rather than merely non-zero.
-- **The badge says THAT more than one is waiting, never how many.** The only way to give a numeral
+- The badge says THAT more than one is waiting, never how many. The only way to give a numeral
   room at this size is to shrink the mark until the primary signal is what suffers, and the exact
-  count is one click away in the panel — where the tray sends you for anything it cannot say at a
+  count is one click away in the panel, where the tray sends you for anything it cannot say at a
   glance.
-- **The mark is the same size in every state.** The badge RIDES the glass at the upper right, inside
+- The mark is the same size in every state. The badge RIDES the glass at the upper right, inside
   the circle rather than beside it, so it costs the mark no size at all; a mark that resizes as it
   changes meaning reads as a glitch, and a test asserts the height is identical across every state.
 
@@ -128,30 +127,30 @@ Three rules behind that table:
 
 A tray built from a checkout carries **a small dot on the glass, lower LEFT**, in every state. It
 says which build you are looking at, and nothing about the sessions. It rides the glass from the
-INSIDE — diagonally opposite the badge and deliberately **smaller** than it, so the two are told
+INSIDE, diagonally opposite the badge and **smaller** than it, so the two are told
 apart by size as well as by place: the badge changes while you watch, this one never changes at all.
 
-**The signal is `tauri::is_dev()`**, which is `!cfg!(feature = "custom-protocol")` — a feature
+**The signal is `tauri::is_dev()`**, which is `!cfg!(feature = "custom-protocol")`, a feature
 `tauri build` turns on and `tauri dev` does not, so it is a fact about how the binary was produced,
 decided at compile time and free at runtime. Deliberately NOT `SEEDEEP_HOME`: a user is entitled to
 move their state without their tray calling itself a development build.
 
 The portal has the same mark for the same reason, on its own signal
-([`configuration.md`](configuration.md#which-build-is-answering)) — the two seedeeps on a machine
+([`configuration.md`](configuration.md#which-build-is-answering)): the two seedeeps on a machine
 watch the *same* sessions, so nothing in the content ever tells them apart.
 
 ## The popover
 
-**It is rounded, and that costs a private API.** A hard rectangle hanging off the menu bar reads as
+It is rounded, and that costs a private API. A hard rectangle hanging off the menu bar reads as
 a window that lost its frame, not as a menu, so `.panel` carries a 12 px radius and clips its
 children. For the radius to be real the window is `transparent` and `body` paints nothing, which on
 macOS requires the `macos-private-api` feature (`app.macOSPrivateApi` in the config, and the matching
-feature on the `tauri` crate — the build script refuses to compile if the two disagree). **The
-documented consequence is that the app can never be accepted to the App Store**, which seedeep does
+feature on the `tauri` crate, and the build script refuses to compile if the two disagree). The
+documented consequence is that the app can never be accepted to the App Store, which seedeep does
 not ship through: the macOS deliverable is a DMG.
 
-**A tick never redraws a screen that has not changed** (`ui/surface.ts`). Every surface except the
-bands IS its status — nothing on a connection screen moves on the server's clock — so rebuilding one
+A tick never redraws a screen that has not changed (`ui/surface.ts`). Every surface except the
+bands IS its status, and nothing on a connection screen moves on the server's clock, so rebuilding one
 each second is not merely wasted work: it destroys what the DOM is holding for the user, a half-typed
 URL included. `Surface.put` draws unconditionally and forgets the key; `Surface.putIfChanged` draws
 only on a different key. The forgetting is load-bearing: "Connecting…" is drawn unkeyed, so without
@@ -160,11 +159,11 @@ it a connect that failed back to the same status would be skipped and the panel 
 
 Left-click **toggles** a chromeless window anchored on **the icon's actual rectangle**, which the
 OS reports with the click. A menu bar reorders itself as other apps come and go, so a remembered
-position would drift. It is centred on the icon, but **clamped to the work area of the monitor the
-icon is on**: the right-hand end of the menu bar is exactly where a tray icon sits, so a panel merely
+position would drift. It is centred on the icon, but clamped to the work area of the monitor the
+icon is on: the right-hand end of the menu bar is exactly where a tray icon sits, so a panel merely
 centred on it hangs off the edge of the screen.
 
-**Which way it opens is read off the icon, never off the platform.** If the icon's centre falls in
+Which way it opens is read off the icon, never off the platform. If the icon's centre falls in
 the lower half of that work area the panel grows **upward**, with its BOTTOM edge flush above the
 icon; otherwise it grows downward from just below it. A macOS menu bar is always the top strip, so
 the icon is always in the upper half and the direction there cannot change; on Windows the icon can
@@ -173,17 +172,17 @@ sit in the lower half, where anchoring below it puts the panel off-screen and co
 
 Two consequences worth naming. The anchored edge is the icon's, not the window's: growing downward
 the top never moves, while growing upward the panel has to move as well as grow. And the monitor is
-looked up from the ICON's point, never the window's — the window may be off the screen, which is the
+looked up from the ICON's point, never the window's, since the window may be off the screen, which is the
 state this repairs. `panel_geometry` is pure and carries the tests, including the two that hold the
 inverted range in each direction: `clamp` panics on one, and a tray that panics is a tray that
 disappears.
 
 It also closes when it loses focus. A window with no title bar has no close button, so clicking
-anywhere else *is* the dismissal — the way a menu behaves. **Both dismissals end the app's
-ACTIVATION, and the one from the icon has to do it by hand.** Clicking elsewhere ends it by
+anywhere else *is* the dismissal, the way a menu behaves. Both dismissals end the app's
+ACTIVATION, and the one from the icon has to do it by hand. Clicking elsewhere ends it by
 definition. Clicking the icon does not: an `Accessory` app owns no other window to fall back to, so
 hiding the popover leaves it the active app with nothing on screen, and macOS draws no banner for the
-active app ([Notifications](#notifications)) — so every real banner raised meanwhile would be dropped
+active app ([Notifications](#notifications)), so every real banner raised meanwhile would be dropped
 in silence. Dismissing from the icon therefore hides the APP, not only the window, and the next click
 on the icon unhides it before showing the panel.
 
@@ -193,7 +192,7 @@ focus at launch), so without that menu it could not be quit except from Activity
 
 ### It is as tall as what it shows
 
-The height is **not a setting — it is a fact about the content**, and only the webview can measure
+The height is **a fact about the content, not a setting**, and only the webview can measure
 it. After every render the panel measures its own natural height and hands it to Rust's `resize`
 (`main.rs`), which clamps it and answers with what it applied:
 
@@ -201,14 +200,14 @@ it. After every render the panel measures its own natural height and hands it to
   flex column whose list fills whatever room it is given, so with the window's height in force it can
   only ever measure the window. Nothing is painted between the two writes, so the class is invisible.
 - The measurement is the **rect, never `scrollHeight`**, which answers in whole pixels and rounds a
-  fractional surface down — a number smaller than the content clips the last row.
+  fractional surface down, since a number smaller than the content clips the last row.
 - The clamp is a **pure function** (`panel_geometry`/`fitted_height` in `main.rs`, unit-tested) because neither of its failure modes
   can be seen from an SSH shell: a window taller than the screen puts the bottom of the list out of
-  reach — a popover cannot be dragged — and a window of zero height cannot be clicked to recover.
+  reach (a popover cannot be dragged) and a window of zero height cannot be clicked to recover.
   A webview that has not laid out yet reports `0`, which is why there is a floor.
 - It grows **downward only**. The top edge stays anchored under the tray icon; a popover that
   re-centred itself as its content changed would walk across the menu bar.
-- `min` then `max`, never `clamp` — an icon low enough that the margin eats the screen inverts the
+- `min` then `max`, never `clamp`: an icon low enough that the margin eats the screen inverts the
   range, and `clamp` panics on an inverted one.
 - The window still scrolls when clamped, and an unchanged height is not sent: a platform call a
   second to set the size it already has is the same waste the icon's painter guards against.
@@ -216,15 +215,15 @@ it. After every render the panel measures its own natural height and hands it to
 ## The four bands
 
 Everything the panel draws comes from one `/api/digest` payload. Nothing is derived from a
-transcript, because the tray has no reducer — what it derives is presentation: which band a session
+transcript, because the tray has no reducer. What it derives is presentation: which band a session
 is in, and how long it has been there.
 
-**Only interactive sessions, and the filter is not in the panel.** A headless run (`entrypoint`
+Only interactive sessions, and the filter is not in the panel. A headless run (`entrypoint`
 `sdk-cli`/`sdk-py`) is not a session anybody is sitting at. The rule is the browser picker's
 (`client/sessions.ts`, `isAutomated`), applied **where the digest enters the tray** (`client.rs`,
 `only_interactive`), so the rows, the icon and the notifications read one list. An unrecognised
-entrypoint, and a missing one, are **kept** — a newer Claude Code renaming one must not make the tray
-silently stop watching — and a payload that is not a list passes through untouched, landing in
+entrypoint, and a missing one, are **kept**, since a newer Claude Code renaming one must not make the tray
+silently stop watching, and a payload that is not a list passes through untouched, landing in
 *Unreachable* rather than in "the machine is idle".
 
 **Four bands, in one order** (`ui/bands.ts`), urgency descending. A working row and an idle row are
@@ -233,42 +232,42 @@ parts have anything to say.
 
 | Band | What a session shows |
 | -- | -- |
-| **Broken** | whose call failed — the session's own or a subagent's — and **the message Claude Code showed**, verbatim and monospace (`Not logged in · Please run /login`), plus how long it has been quiet and the context block |
-| **Needs you** | the request VERBATIM — `Waiting for your approval — Bash`, the command on its own line, monospace — and how long it has been stopped, to the second (the PANEL keeps the command; the banner does not — see *A banner is one title and one line*) |
-| **Working** | project · subject, the turn's prompt quoted, **NOW** — the one thing to say about the turn — **how many background commands it has launched** and any **still running**, **how many subagents it has launched**, the agents at work, and the context block, which carries model · effort |
+| **Broken** | whose call failed, the session's own or a subagent's, and **the message Claude Code showed**, verbatim and monospace (`Not logged in · Please run /login`), plus how long it has been quiet and the context block |
+| **Needs you** | the request VERBATIM, as in `Waiting for your approval — Bash`, the command on its own line, monospace, and how long it has been stopped, to the second (the PANEL keeps the command; the banner does not; see *A banner is one title and one line*) |
+| **Working** | project · subject, the turn's prompt quoted, **NOW** (the one thing to say about the turn), **how many background commands it has launched** and any **still running**, **how many subagents it has launched**, the agents at work, and the context block, which carries model · effort |
 | **Idle** | the same, minus what a settled session does not have: project · subject · how long it has been quiet, **NOW**, **how many background commands it launched** and any **still running**, **how many subagents it launched**, and the context block |
 
-**NOW is one rule, computed once, drawn by both surfaces.** `turn.now` in the digest is `nowLine`'s
+NOW is one rule, computed once, drawn by both surfaces. `turn.now` in the digest is `nowLine`'s
 answer (`core/activity-line.ts`), the SAME function the browser's NOW panel calls on the same inputs:
 a block on the user first, then what the turn has DONE since it last spoke, then the agent's own
-words — and, when a running turn has none of that, `working`. It reports which voice is speaking:
+words, and, when a running turn has none of that, `working`. It reports which voice is speaking:
 
 | `kind` | Label | Whose voice |
 | -- | -- | -- |
-| `waiting` | `waiting for you` | seedeep — the session is stopped on you (the *Needs you* band draws its own richer row instead) |
+| `waiting` | `waiting for you` | seedeep: the session is stopped on you (the *Needs you* band draws its own richer row instead) |
 | `activity` | `now` | seedeep counting: *Read 12 files, ran 3 shell commands* |
 | `intent` | `now` on a live turn, `intent` on one that was stopped | the agent's, mid-turn |
 | `output` | `output` | the agent's, its final answer |
-| `working` | `now` | seedeep — the turn is running with nothing of its own to quote: *`/code-review` is running in the background*, *Answering — no tools used, nothing said yet*, or *Started — no output yet* |
+| `working` | `now` | seedeep: the turn is running with nothing of its own to quote: *`/code-review` is running in the background*, `Answering — no tools used, nothing said yet`, or `Started — no output yet` |
 
 The agent's words are italic and seedeep's counting is not; both are labelled, because the line above
 is already a quote. The server sends the text **markdown-stripped and cut to 200 characters, in that
-order** — the tray has no renderer, so a raw `**` would reach the user as two asterisks.
+order**, because the tray has no renderer and a raw `**` would reach the user as two asterisks.
 
-**A word holds NOW for as long as it takes to READ it**, floored at 3 s and capped by the two-line
+A word holds NOW for as long as it takes to READ it, floored at 3 s and capped by the two-line
 clamp, and then the count takes over. The hold runs from the moment the server SAW the word
-(`live-trees.ts` stamps it), never from the line's own timestamp, and **only a word that ARRIVES
-while the server is watching has a sighting** — one first seen more than 60 s later earns no hold, so
+(`live-trees.ts` stamps it), never from the line's own timestamp, and only a word that ARRIVES
+while the server is watching has a sighting, so one first seen more than 60 s later earns no hold, and
 a row the tray has just discovered shows what the turn has DONE instead of replaying an old line.
 
 The rest of a row, in the order it is drawn:
 
-- **The context line carries model · effort**: `Context 232.5k / 1.0M · Opus 5 · high · 23%`, spelled
+- The context line carries model · effort: `Context 232.5k / 1.0M · Opus 5 · high · 23%`, spelled
   out in the portal's own wording and units, where a bare `34%` never said what it measured.
 - **The *Needs you* band keeps its own row.** NOW reports the block (`kind: 'waiting'`) and that band
   draws the request instead: it is the one band whose purpose is to let the user answer without going
   to the terminal, and *"a tool is waiting"* does not tell them whether to say yes.
-- **A background command gets a line of its own**, `● Start the dev server   4m 12s` — monospace
+- A background command gets a line of its own, `● Start the dev server   4m 12s`, monospace
   because it is a command, an **accent** dot because in this panel that colour means *at work*, and
   the age on the right because between its launch and its notification that is the only thing about
   it that changes. What tells a command from an agent is the SHAPE, `●` against `◇`, amber being
@@ -280,92 +279,92 @@ The rest of a row, in the order it is drawn:
   is reading the line that says whether it is. **Not** on *Broken*, which is about the model call that
   ended the session. What ends such a line is the command's **notification** and nothing else, so it
   can outlive the command it names for as long as the session lives.
-- **A command that has ENDED gets no line at all — it gets counted.** `Commands  4 launched`, above
+- A command that has ENDED gets no line at all; it gets counted. `Commands  4 launched`, above
   the running ones, in the same shape and the same two bands as the subagent total; what it did and
   what it exited with is the portal's, one click away on the row.
-- **`Subagents 12 launched` — on *Working* and on *Idle*.** The lines above it are what is at work
+- **`Subagents 12 launched`, on *Working* and on *Idle*. The lines above it are what is at work
   THIS SECOND, so `launched`, the session's whole history, is what lets an idle row mention subagents
   at all; a session that never spawned one gets no line. The count is the server's
-  (`subagents.launched`), never a length of the list beside it: a **Workflow run contributes its
-  MEMBERS** and takes **one line** however many agents it runs, and a **launch with no trace of
+  (`subagents.launched`), never a length of the list beside it: a Workflow run contributes its
+  MEMBERS** and takes **one line however many agents it runs, and a launch with no trace of
   itself is not counted** (`hasStarted`, [`architecture.md`](architecture.md)).
-- **A row's state is a mark down its left edge, never a tinted fill**: amber for a session stopped on
-  you, accent for one at work, nothing for one at rest. Idle is deliberately **not** dimmed, since
+- **A row's state is a mark down its left edge, never a tinted fill: amber for a session stopped on
+  you, accent for one at work, nothing for one at rest. Idle is deliberately not dimmed, since
   `opacity` already means `ended` here.
 
 Rules that are not preferences:
 
-- **The session list never moves.** Rows keep the order they were first seen in and new ones are
+- The session list never moves. Rows keep the order they were first seen in and new ones are
   appended; the digest's own order is the roster's, which re-sorts as sessions work. That is what
   makes a click land on the session the user was looking at rather than on the one that took its
   place.
-- **No session is collapsed to nothing.** Every row in every band names its project.
-- **No cap.** Every live session is drawn and the bands scroll; the cost is bounded by the poll.
-- **An empty band is not drawn.** Three headings over one row would spend a 560 px popover on labels.
-- **A session that ends while the panel is open stays**, dimmed and marked `ended`, until the panel
-  closes — the server drops it from the digest immediately, and the client is the side that knows
+- No session is collapsed to nothing. Every row in every band names its project.
+- No cap. Every live session is drawn and the bands scroll; the cost is bounded by the poll.
+- An empty band is not drawn. Three headings over one row would spend a 560 px popover on labels.
+- A session that ends while the panel is open stays**, dimmed and marked `ended`, until the panel
+  closes: the server drops it from the digest immediately, and the client is the side that knows
   somebody is looking at it. It keeps its own last entry, so it keeps its band: moving it to *Idle*
   on the way out would be the list moving. Its durations freeze at the instant the tray noticed,
   because "stopped 6m 20s ago" about a process that no longer exists asserts what it cannot know.
-- **"While the panel is open" is Rust's answer, not the webview's**, and it rides on every reading as
+- "While the panel is open" is Rust's answer, not the webview's, and it rides on every reading as
   `open`; the webview keeps running while the window is hidden, so a rule built on a `blur` event
   would keep a session that ended overnight on screen for the next person to open the popover.
-  **While nobody is looking the panel is a mirror:** neither the retention nor the stable order means
+  While nobody is looking the panel is a mirror: neither the retention nor the stable order means
   anything then, and both start fresh on the next open (`fold` in `bands.ts`).
 
 **A server not honouring its own configuration** gets a line above the bands: *"This server started
 before config.json was last changed."* It is the server's own verdict (`restart_pending` on
 `/api/config`) and never the tray's, since the flags a process was started with are not readable from
 another one, and a server too old to carry the field reads as nothing pending. It is neither a band
-nor an icon state — both are about sessions, this is about the process — and it is asked **once per
+nor an icon state (both are about sessions, this is about the process) and it is asked **once per
 popover opening**, the value moving only when a human edits that file.
 
 ### Into the portal
 
-**Clicking a session opens it in the browser portal**, at `<portal>/?session=<id>`, which the portal
+Clicking a session opens it in the browser portal, at `<portal>/?session=<id>`, which the portal
 reads to open and activate that session's tab ([`architecture.md`](architecture.md)). The tray never
 replicates the portal and never approves. The URL is built and opened in Rust, because it carries the
-token. **The portal ITSELF is one click away too**, at `<portal>/?token=…`, from two places calling
+token. The portal ITSELF is one click away too, at `<portal>/?token=…`, from two places calling
 that same command: the footer's address on every connected screen, and a button in the empty state.
-A query is only written when it has something to carry — a loopback server with no token opens at the
+A query is only written when it has something to carry: a loopback server with no token opens at the
 bare `<portal>/`, never `<portal>/?`.
 
 ### What each band is, exactly
 
-- **Broken is the digest's `error` being non-null, and nothing else** — the one band that reads an
+- Broken is the digest's `error` being non-null, and nothing else, the one band that reads an
   answer instead of re-deriving it, because the fact exists only downstream of the parser. The server
   sets it on any call flagged `isApiErrorMessage` and clears it on the next call that reaches a
   model; `error.agentId` names a subagent whose call failed, which the row says out loud because a
   fan-out that lost a worker and a session that stopped call for different reactions. It is read
   **first**, above the wait, so a red icon never sends you to a panel where that session sits under
   *Idle*.
-- **Needs you is not `status === 'waiting'`.** Claude Code writes that for **every** open dialog, the
+- Needs you is not `status === 'waiting'`. Claude Code writes that for **every** open dialog, the
   model picker included, so the raw status would file "the user opened a menu" under *Needs you*. The
   rule is the server's own (`client/sessions.ts`, `pendingInput`): the two labels `permission prompt`
-  and `input needed`, and **an unrecognised label is deliberately not a wait** — a band that cries
+  and `input needed`, and an unrecognised label is deliberately not a wait, since a band that cries
   wolf is ignored on the day it is right.
-- **Working is not `status === 'busy'` either.** Claude Code writes **`shell`** while a command the
+- Working is not `status === 'busy'` either. Claude Code writes **`shell`** while a command the
   session launched in the background is still running and the turn itself is over, so the value
   travels raw and `isWorking` (`core/types.ts`) is the rule: the icon stays lit for as long as the
   command runs, and the "Finished" notification fires when the command really ends. A value nobody
   has seen yet still becomes `null`, and a session with no status is filed under *Idle* on purpose,
   because a band is a claim.
 
-The last two exist in **three** copies — the server's, the panel's (`bands.ts`) and Rust's
-(`poll.rs`, for the icon's count) — because the tray links no seedeep code and Rust cannot ask a
+The last two exist in **three** copies (the server's, the panel's `bands.ts` and Rust's
+`poll.rs`, for the icon's count) because the tray links no seedeep code and Rust cannot ask a
 webview. Each is pinned to the server's by a test enumerating every label Claude Code writes; a
 fourth reader means a fourth test.
 
 ### The poll
 
-**1 s while the panel is open, 5 s while it is closed** (`OPEN` and `CLOSED` in `poll.rs`), and the
+1 s while the panel is open, 5 s while it is closed (`OPEN` and `CLOSED` in `poll.rs`), and the
 loop lives in **Rust**, not in the panel: the icon has to be right *before* anyone opens the panel,
 and a hidden window's timers are throttled by the platform. The clock runs whether or not a window
 exists, sets the icon from every reading, and pushes the same reading to the panel when one is
-listening — one reading, so the rows and the icon can never disagree. That payload is
+listening: one reading, so the rows and the icon can never disagree. That payload is
 `{ status, entries, open }`, produced in exactly one place (`Poller::tick`). Every read after the
 first is a **conditional GET** (`sendCacheable`), so an unchanged digest costs a 304 and no body,
-while the discovery's own request cannot be conditional — it has to see a digest to know it is
+while the discovery's own request cannot be conditional, since it has to see a digest to know it is
 talking to a seedeep.
 
 ## Reaching the server
@@ -386,67 +385,67 @@ set from the portal ([Notifications](#notifications)).
 | Where the server is | What the tray needs |
 | -- | -- |
 | This machine, loopback mode, **any port** | **Nothing.** No TLS and no token, so there is nothing to paste, nothing to pin and nothing stored. |
-| This machine, remote access ON | **Nothing either** — the credentials are read from the file the server wrote them in. See below. |
-| Another machine | **One field** — the URL the portal's Settings → Remote access already computes and copies, token included. |
+| This machine, remote access ON | **Nothing either**: the credentials are read from the file the server wrote them in. See below. |
+| Another machine | **One field**: the URL the portal's Settings → Remote access already computes and copies, token included. |
 
-**A co-located server is never something to paste a URL for.** The tray reads
+A co-located server is never something to paste a URL for. The tray reads
 `<seedeep home>/config.json` and connects itself, and three things make that legitimate rather than
 convenient:
 
-- **A live record has already proved the server is here**, with a pid this kernel knows — the same
+- A live record has already proved the server is here, with a pid this kernel knows, the same
   proof Stop relies on when it sends that pid a SIGTERM, which is a great deal more than reading a
   file.
-- **No privilege boundary is crossed.** `config.json` is `0600` and belongs to the user the tray runs
+- No privilege boundary is crossed. `config.json` is `0600` and belongs to the user the tray runs
   as; anything learned there, that user's own shell can `cat`.
-- **The fingerprint comes from the certificate FILE, not from the handshake**, so the identity
+- The fingerprint comes from the certificate FILE, not from the handshake, so the identity
   presented over the wire is still confirmed against something else.
 
 Nothing is stored: the config is the source of truth and is re-read whenever nothing is in the store,
-so persisting would only put a second copy of a secret on disk. When there is nothing to read — no
-config, or a `SEEDEEP_HOME` the tray cannot see — the panel asks for the URL.
+so persisting would only put a second copy of a secret on disk. When there is nothing to read, meaning no
+config or a `SEEDEEP_HOME` the tray cannot see, the panel asks for the URL.
 
-**"Any port" is the record's doing.** With nothing stored, the tray reads
-`<seedeep home>/servers/*.json` — where every running server writes the address it answers on — and
+"Any port" is the record's doing. With nothing stored, the tray reads
+`<seedeep home>/servers/*.json`, where every running server writes the address it answers on, and
 tries those before falling back to guessing `44842`, which is what makes `seedeep --port 9000`
 reachable with nothing to paste. Two rules keep that from being a lottery:
 
-- **The default port wins, then the lowest.** `read_dir` has no order, so without sorting, which of
+- The default port wins, then the lowest. `read_dir` has no order, so without sorting, which of
   two records under one home the tray adopts is the filesystem's choice.
-- **Only a plaintext record is adopted on sight.** Nothing is pinned when the tray tries an announced
-  address, so an `https://` one would be trusted with no fingerprint — the confirmation the *paste a
+- Only a plaintext record is adopted on sight. Nothing is pinned when the tray tries an announced
+  address, so an `https://` one would be trusted with no fingerprint, the confirmation the *paste a
   URL* path refuses to skip.
 
 That third row of the table is the one worth stating, because the obvious guess is wrong: the server
-decides TLS and the token check from the **host it was configured with, never from the peer**
+decides TLS and the token check from the host it was configured with, never from the peer
 ([`architecture.md`](architecture.md)). One listener has one certificate, so with remote access on,
 `127.0.0.1` speaks HTTPS and demands the token too. The tray tells that apart from an empty machine
 instead of shrugging: after the plaintext probe finds nothing it tries `https://127.0.0.1:44842`, and
 seedeep's own `401 {"error":"unauthorized"}` proves a seedeep is there.
 
-The token leaves the pasted URL immediately and travels as `Authorization: Bearer` from then on —
+The token leaves the pasted URL immediately and travels as `Authorization: Bearer` from then on,
 a `?token=` would land in the server's own request log and in shell history.
 
 ### Trust on first use, and what is deliberately not checked
 
 The first handshake **learns** the leaf certificate's SHA-256 and stores nothing. The panel shows it
-whole — all 32 bytes, because an abbreviated hash teaches the habit of comparing the first three
-groups, which is not a comparison — and asks for it to be confirmed against the value the server
+whole, all 32 bytes, because an abbreviated hash teaches the habit of comparing the first three
+groups and is not a comparison, and asks for it to be confirmed against the value the server
 prints on every start and shows in Settings → TLS. Only then is it stored, and only then does the
 tray call itself connected: `trust` re-connects with the pin in force, so "connected" is never a
 claim inherited from the learning mode.
 
-Once pinned, that hash is the server's identity. **Nothing else about the certificate is
-checked** — not the chain, not the hostname, not the expiry — and each omission is deliberate:
+Once pinned, that hash is the server's identity. Nothing else about the certificate is
+checked: not the chain, not the hostname, not the expiry. Each omission is deliberate:
 
 - a **chain** check has no input, since nobody vouches for a self-signed certificate;
 - a **hostname** check adds nothing a pinned leaf has not already settled, while refusing the
   aliases a user legitimately reaches their own machine by;
-- an **expiry** check would one day break a tray whose server never changed — an outage with no
+- an **expiry** check would one day break a tray whose server never changed, an outage with no
   security gain, because what is being asserted is the key, not the date.
 
 A pin is refused on the two values, not on the error text rustls happens to produce, so how that
-message is worded cannot change what the tray concludes. A replaced certificate is a normal event — the server regenerates one when its `commonName` no longer
-matches, and `~/.seedeep` can be deleted — so the refusal is recoverable in one confirmation: **Trust
+message is worded cannot change what the tray concludes. A replaced certificate is a normal event, since the server regenerates one when its `commonName` no longer
+matches and `~/.seedeep` can be deleted, so the refusal is recoverable in one confirmation: **Trust
 the new certificate**, next to the old value for comparison. Never a silent re-pin, and never a dead
 end that requires editing a file by hand.
 
@@ -454,24 +453,24 @@ end that requires editing a file by hand.
 
 | State | When |
 | -- | -- |
-| **Connected** | Reachable and authorised. The footer names the host, and the host is the way into the portal — a click opens seedeep in the browser (see [Into the portal](#into-the-portal)). Settings shows the fingerprint whole, which is where it can be COMPARED with the line the server printed. |
+| **Connected** | Reachable and authorised. The footer names the host, and the host is the way into the portal: a click opens seedeep in the browser (see [Into the portal](#into-the-portal)). Settings shows the fingerprint whole, which is where it can be COMPARED with the line the server printed. |
 | **Needs a URL** | Nothing stored and nothing to adopt. Names the local-remote case when the 401 proved one. |
 | **Is this its certificate?** | A fingerprint learned and not yet confirmed. Nothing is stored in this state. |
 | **The certificate changed** | The pin refused. Shows **both** values, so the new one can be compared with what the server printed on its last start. |
-| **The token was refused** | Reachable, wrong token — with the field on the same screen as the reason. |
-| **Not answering** | A stored server that is down. The reason comes from Rust, which is the only side that knows whether the connection was REFUSED (nothing listening) or simply never answered (a machine asleep) — the panel adds no guess of its own. The connection is kept: forgetting it would ask for a URL the tray already has. |
-| **Looking / Connecting** | While an answer is being waited for. Shown for an action the USER took — the first open, a pasted URL, a retry — and deliberately NOT for the automatic refresh, so a screen that already says something true does not blink every time the popover is reopened. It carries no controls at all, or it would read as a screen waiting on the user. |
+| **The token was refused** | Reachable, wrong token, with the field on the same screen as the reason. |
+| **Not answering** | A stored server that is down. The reason comes from Rust, which is the only side that knows whether the connection was REFUSED (nothing listening) or simply never answered (a machine asleep). The panel adds no guess of its own. The connection is kept: forgetting it would ask for a URL the tray already has. |
+| **Looking / Connecting** | While an answer is being waited for. Shown for an action the USER took (the first open, a pasted URL, a retry) and deliberately NOT for the automatic refresh, so a screen that already says something true does not blink every time the popover is reopened. It carries no controls at all, or it would read as a screen waiting on the user. |
 
 Every state whose only control accepts something also offers **Use a different URL**: a decision with
 one button is not a decision, and a panel with no exit is one a user has to quit the app to escape.
-The waiting screen exists because the first open is the slow one — a stored server that is asleep
+The waiting screen exists because the first open is the slow one: a stored server that is asleep
 takes seconds to fail, and the first tick can be a whole poll interval away, so without it the
 panel's first paint is a blank rectangle.
 
-**The field it opens is a VIEW, not a status** (`view === 'url'` in `ui/panel.ts`), because a status
-is what the next tick overwrites. As a view it obeys the same rule the settings screen does —
+The field it opens is a VIEW, not a status (`view === 'url'` in `ui/panel.ts`), because a status
+is what the next tick overwrites. As a view it obeys the same rule the settings screen does,
 readings keep arriving and are kept, only the redraw is withheld, so what is behind the field is
-current the moment it ends. It ends on **closing the popover** (the mirror rule — a half-typed
+current the moment it ends. It ends on **closing the popover** (the mirror rule: a half-typed
 address is not what the next click on the icon shows), or on the user being ANSWERED: a URL that
 connects, a retry, a start. A URL that was refused keeps the field up with the reason under it,
 because that address is what has to be corrected.
@@ -479,12 +478,12 @@ because that address is what has to be corrected.
 ### Where the connection lives
 
 The **app config dir** is `~/Library/Application Support/app.seedeep.tray` on macOS and
-`%APPDATA%\app.seedeep.tray` on Windows — Tauri derives it from the bundle identifier in
-`tauri.conf.json`, which is also the macOS bundle ID. **Changing that string makes a different
-application** to both operating systems: the old install stays alongside the new one and its stored
+`%APPDATA%\app.seedeep.tray` on Windows, and Tauri derives it from the bundle identifier in
+`tauri.conf.json`, which is also the macOS bundle ID. Changing that string makes a different
+application to both operating systems: the old install stays alongside the new one and its stored
 connection is abandoned, not migrated. It is an identity, not a setting.
 
-**One file in it** — or in `<SEEDEEP_HOME>/tray` when a dev run sets that — mode **0600**, written
+**One file in it**, or in `<SEEDEEP_HOME>/tray` when a dev run sets that, mode **0600**, written
 and read by Rust only: `connection.json`.
 
 ```json
@@ -496,8 +495,8 @@ temporary name whose mode is set **at creation** and then renamed (`src/store.rs
 never exists in a world-readable file even for an instant, and a crash mid-write leaves the previous
 pin intact rather than a truncated one.
 
-**No keychain**, because the two fields need different things. The fingerprint is not a secret — it
-travels in the clear in every handshake — what it needs is INTEGRITY, which a file only the user can
+**No keychain**, because the two fields need different things. The fingerprint is not a secret, since it
+travels in the clear in every handshake. What it needs is INTEGRITY, which a file only the user can
 write already gives. The token *is* a secret, and it is what 0600 is for; the server keeps the same
 token in plaintext at the same mode in `~/.seedeep/config.json`, so storing it differently on the
 client would not make the pair safer, only inconsistent. On Windows there are no POSIX modes, but the
@@ -508,35 +507,35 @@ successful connect overwrites it, which is a recovery a user can perform.
 
 ## Starting and stopping the server
 
-**The tray can start and stop a seedeep on the same machine, and only there.** A server on another
+The tray can start and stop a seedeep on the same machine, and only there. A server on another
 host is somebody else's process; the tray connects to it and offers nothing about its lifecycle.
 Everything below is `src/local.rs`.
 
 Two decisions frame it, and neither is an implementation detail:
 
-- **The server survives the tray's quit.** It behaves like one started from a terminal — only an
+- The server survives the tray's quit. It behaves like one started from a terminal: only an
   explicit Stop ends it. Quitting the tray must not close the portal open in a browser tab.
-- **Start is an explicit button, never an auto-start**, and it exists only where there is something
+- Start is an explicit button, never an auto-start, and it exists only where there is something
   to run. No server found on this machine means no button, not a button that fails.
 
 There is no notion of "the tray's server": the record on disk is what makes a process stoppable and
 says nothing about who launched it, so one started from a terminal is stoppable from the tray too.
 
-**Co-located is decided by IDENTITY, never by spelling.** A server with remote access on announces
-the name it was configured with, and `dev-mac.local` is not spelled `127.0.0.1` — it resolves to it.
+Co-located is decided by IDENTITY, never by spelling. A server with remote access on announces
+the name it was configured with, and `dev-mac.local` is not spelled `127.0.0.1`; it resolves to it.
 So the spelling is tried first because it is free, and otherwise the name goes to the resolver:
-**loopback is conclusive on its own**, and any other answer is put to a bind on port 0, which the
+loopback is conclusive on its own, and any other answer is put to a bind on port 0, which the
 kernel refuses with `EADDRNOTAVAIL` for an address this machine does not hold. No crate enumerates
 interfaces and nothing is asked of the network. It is **not** a reachability test: a server elsewhere
 may answer faster than a local one, and "I can talk to it" has never meant "I can signal it".
 
-The resolution never happens on the poll's thread — a name that has gone away costs seconds to fail,
+The resolution never happens on the poll's thread, because a name that has gone away costs seconds to fail,
 and *Offline* is exactly when a name is most likely to have gone. So an unseen name answers `false`
 once and starts a look, and the answer is re-asked after `LOOKUP_RETRY` (30 s) in BOTH directions: a
 laptop that changes network changes what its own name resolves to.
 
-**Start comes up on the address the screen names.** The button sits under a sentence saying that
-address is not answering, so it passes `--port` from the stored URL — never `--host`, since locality
+Start comes up on the address the screen names. The button sits under a sentence saying that
+address is not answering, so it passes `--port` from the stored URL, never `--host`, since locality
 is already proven by the host and an explicit one risks tipping the server into its non-loopback
 mode, where it demands TLS and a token. With nothing stored there is no address to honour and the
 server's own `config.json` decides, which is what a user who configured a port expects.
@@ -549,21 +548,21 @@ need different words on screen:
 | The panel says | Start state | What is drawn |
 | -- | -- | -- |
 | Nothing stored, nothing answering here, and a seedeep was found | `ready` | The **Start** button. The first-run case, and the one the tray exists to remove: asking a user to copy a URL out of a portal that is not up is a dead end. |
-| A stored **loopback** server is silent, and a seedeep was found | `ready` | Start, with *Try again* demoted below it — a server coming up on its own is still real. |
-| Nothing stored, and **nothing was found to run** | `notInstalled` | No Start. A sentence naming the case, and **Look again** — the control that sentence points at, on the one screen that has no other retry. |
-| A stored server is silent, and **nothing was found to run** | `notInstalled` | No Start. The same sentence, above the **Try again** this screen already carries. Both buttons clear the lookup's throttle; the label differs because on this screen retrying the address is the other thing worth offering. |
+| A stored **loopback** server is silent, and a seedeep was found | `ready` | Start, with *Try again* demoted below it, since a server coming up on its own is still real. |
+| Nothing stored, and nothing was found to run | `notInstalled` | No Start. A sentence naming the case, and **Look again**, the control that sentence points at, on the one screen that has no other retry. |
+| A stored server is silent, and nothing was found to run | `notInstalled` | No Start. The same sentence, above the **Try again** this screen already carries. Both buttons clear the lookup's throttle; the label differs because on this screen retrying the address is the other thing worth offering. |
 | A seedeep is here with remote access on | `elsewhere` | Nothing about starting: it is already running, and what it wants is its URL. |
 | A stored server **elsewhere** is silent | `elsewhere` | Nothing: starting one here would not make that address answer. |
-| Anything answered at all — even a 401, even with the wrong certificate | `elsewhere` | Nothing: something is on that port, and a second server would fail on the bind. |
+| Anything answered at all, even a 401, even with the wrong certificate | `elsewhere` | Nothing: something is on that port, and a second server would fail on the bind. |
 
-**`notInstalled` carries whether the tray is a development build, and the two instructions are
-opposites.** A checkout's server is `bun run dev`, which is not something the tray can exec, so that
+`notInstalled` carries whether the tray is a development build, and the two instructions are
+opposites. A checkout's server is `bun run dev`, which is not something the tray can exec, so that
 user is told to start it themselves; a released tray says `npm i -g seedeep`. Sending the first to
 install a release would send them away from the very thing they are working on.
 
 **Look again** is a control and not a wait: the lookup's own 30-second retry is not an answer to
-somebody who has just finished installing. It **waits for the shell** — the one gesture in the panel
-that does — because a reading starts the look in the background and returns the same instant, so
+somebody who has just finished installing. It **waits for the shell**, the one gesture in the panel
+that does, because a reading starts the look in the background and returns the same instant, so
 clearing the cache and then taking one could only ever answer *not installed*.
 
 Stop lives in **Settings → Server**, under the address, and appears only when the tray is connected
@@ -574,23 +573,23 @@ surface is for, and a control that ends everything on screen does not belong in 
 
 A macOS GUI app inherits `PATH=/usr/bin:/bin:/usr/sbin:/sbin`. Neither `seedeep` nor `npm` is on it,
 whichever channel installed them, so `spawn("seedeep")` cannot work and `npm prefix -g` cannot be
-asked either. The tray therefore runs the user's own shell — `$SHELL -l -i -c 'command -v seedeep'`, or `where.exe`
+asked either. The tray therefore runs the user's own shell: `$SHELL -l -i -c 'command -v seedeep'`, or `where.exe`
 on Windows, where a GUI process does inherit the registry's PATH. **Both `-l` and `-i`**: `-l` alone
 reads `.zprofile` (where Homebrew's installer writes) and not `.zshrc` (where bun's and nvm's do), so
-it can miss `~/.bun/bin` entirely — one of the three channels seedeep ships through. The lookup is
+it can miss `~/.bun/bin` entirely, one of the three channels seedeep ships through. The lookup is
 capped at `LOOKUP_TIMEOUT` (5 s), and a result of *nothing* is not asked again for `LOOKUP_RETRY`
 (30 s); the panel's *Try again* clears that, which is how somebody who has just installed seedeep
 tells the tray to look now.
 
-**The 30 seconds throttle the poll, never a click.** A click is somebody saying they have changed
+The 30 seconds throttle the poll, never a click. A click is somebody saying they have changed
 something, and answering it from a remembered *nothing* is answering the question the button was
 pressed to re-ask. A look that a click overtook cannot write its answer either: each one carries the
 generation it started in, so a cold shell still running from before the retry cannot land its
 *nothing* on top of the path the warm one just found.
 
-**The lookup is not run where Start can never appear**, and **the poll never waits for it.** A
+The lookup is not run where Start can never appear, and the poll never waits for it. A
 reading takes what is already known and starts a look in the background when one is due, because that
-loop is what paints the menu-bar icon and sends the notifications — a user with a version manager in
+loop is what paints the menu-bar icon and sends the notifications, and a user with a version manager in
 their `.zshrc`, the very reason the shell is interactive, would otherwise have the icon freeze for up
 to five seconds every thirty. The cost is that a newly installed seedeep appears one tick late. Only
 a **start** waits for the answer, because a start has to have one.
@@ -601,24 +600,24 @@ Only a line that is an existing absolute file counts. An interactive shell may p
 ### A start is proven by the server, not by the spawn
 
 What is on `PATH` may not be the server. npm's postinstall replaces a placeholder that prints
-instructions and exits 1, and `bun install -g` without `--trust` leaves that placeholder in place —
+instructions and exits 1, and `bun install -g` without `--trust` leaves that placeholder in place,
 so the tray never inspects the file, it runs it and waits for the server to **announce itself** in
 `<seedeep home>/servers/<pid>.json` ([`architecture.md`](architecture.md), *Announcing a running
 server*). A new record within `START_TIMEOUT` (15 s) is a start; the process exiting first is a
-failure, reported with the first line it printed — which for the placeholder is the sentence that
+failure, reported with the first line it printed, which for the placeholder is the sentence that
 names the problem.
 
 It is launched through `sh -c 'exec "$0" "$@"' <path> [--port <n>]`, and that is not a flourish. The
-placeholder carries no shebang on purpose, so `execve` on it fails with `ENOEXEC` and reports *"Exec
+placeholder carries no shebang, so `execve` on it fails with `ENOEXEC` and reports *"Exec
 format error"* instead of the four lines the file exists to print; a shell takes its ENOEXEC fallback
 and produces the real message. `exec` leaves no shell in between, so the pid is the server's; `"$0"`
 carries the path as an argument and `"$@"` the flags, so neither a path with spaces nor a port needs
-quoting rules of ours. `setsid` puts it in its own session — a terminal signalling the tray's process
+quoting rules of ours. `setsid` puts it in its own session, so a terminal signalling the tray's process
 group must not take the server with it.
 
-**Its output goes to `<seedeep home>/server.log`**, truncated by each start, mode **0600**. A process
-started from a menu bar has no terminal, and the first thing seedeep prints is the URL it serves —
-which in remote mode carries the **token** — followed by the TLS fingerprint a pinned client is asked
+Its output goes to `<seedeep home>/server.log`, truncated by each start, mode **0600**. A process
+started from a menu bar has no terminal, and the first thing seedeep prints is the URL it serves,
+which in remote mode carries the **token**, followed by the TLS fingerprint a pinned client is asked
 to compare: neither may be lost, and neither may sit in a world-readable file next to a config kept
 at 0600.
 
@@ -628,7 +627,7 @@ bar is what would have started from a terminal, browser tab included if that is 
 ### A stop is aimed at the connection
 
 The tray stops the server it is **showing**: it looks for a live record naming the address it is
-connected to. Co-location is proven by that record and never by the URL — a server with remote access
+connected to. Co-location is proven by that record and never by the URL, since a server with remote access
 on announces the host it was configured with (`https://<machine>:44842`), so a rule reading the
 address would refuse to stop a server running on this very machine.
 
@@ -638,31 +637,31 @@ is `http://127.0.0.1:44842`. Scheme, port and host are compared with every spell
 collapsed into one, which is safe because a port cannot be bound twice on a host.
 
 `SIGTERM`, so the server runs its own shutdown and withdraws its record; the tray then waits for that
-record to disappear, because a signal returning says only that it was delivered. **Two live records
-claiming one address is refused, not resolved** — that is a crashed server's file plus a pid the OS
+record to disappear, because a signal returning says only that it was delivered. Two live records
+claiming one address is refused, not resolved: that is a crashed server's file plus a pid the OS
 has given to something else, and picking either would be a signal sent to an unrelated process.
 
 Known limits, none of them silent:
 
-- `taskkill /F` on Windows is a hard stop — the server never runs its shutdown path, so its record is
+- `taskkill /F` on Windows is a hard stop: the server never runs its shutdown path, so its record is
   left for the next start's sweep. Marked `// LIMIT:` at both sites. The lookup there also has a rule
   this platform does not need: `npm i -g` installs three shims and `where.exe` lists the
-  extensionless sh script first, so only a file `cmd` can actually start — `.exe`, `.cmd`, `.bat`,
-  `.com` — counts as having found seedeep.
+  extensionless sh script first, so only a file `cmd` can actually start (`.exe`, `.cmd`, `.bat`,
+  `.com`) counts as having found seedeep.
 - Every process the tray starts on Windows passes `CREATE_NO_WINDOW`, and that is a rule rather than
   a detail: a GUI application has no console, so Windows gives one to each console child it spawns
-  and the user sees it flash. It is one shared constant in `local.rs` and not three literals — a
+  and the user sees it flash. It is one shared constant in `local.rs` and not three literals, because a
   fourth spawn site cannot be added without meeting it.
-- **A user who sets `SEEDEEP_HOME` in their shell profile gets a server whose records the tray cannot
-  see**: a GUI app inherits no shell environment, so the tray looks in `~/.seedeep`. Stop is then not
-  offered, which is the honest outcome — nothing is stopped by guesswork.
+- A user who sets `SEEDEEP_HOME` in their shell profile gets a server whose records the tray cannot
+  see: a GUI app inherits no shell environment, so the tray looks in `~/.seedeep`. Stop is then not
+  offered, which is the honest outcome: nothing is stopped by guesswork.
 - A name that has stopped resolving gets no Start for one tick, because a name the tray has not seen
   is answered `false` once while it goes and asks.
 
 ## Notifications
 
-**Four triggers, four switches — and three of the four are the SERVER's.** A session entering
-`waiting`, a session whose API call FAILED, a session finishing a turn (off unless it is asked for) —
+Four triggers, four switches, and three of the four are the SERVER's. A session entering
+`waiting`, a session whose API call FAILED, a session finishing a turn (off unless it is asked for).
 and a newer seedeep having been published. Nothing else notifies: not a subagent finishing, not a
 tool error. A tray that notifies about everything is a tray you mute.
 
@@ -671,18 +670,18 @@ them on its event stream; the tray subscribes and posts what arrives, composing 
 verdict (`stream_notifications` in `client.rs`, posted from `poll.rs`). It obeys every rule below and
 implements none of them, because two implementations of one rule are free to diverge. The fourth is
 the tray's own, being about the machine this tray runs on (`update.rs`). Posting is Rust's either
-way, so the webview never needs the permission — which is why it is absent from
+way, so the webview never needs the permission, which is why it is absent from
 `capabilities/default.json`.
 
-**The switches are edited in the portal's Settings**, under *Tray notifies you when* — not on this
-app's own surface, which carries none (see [Settings](#settings)) — and live in `notifications.tray`
+The switches are edited in the portal's Settings, under *Tray notifies you when*, not on this
+app's own surface, which carries none (see [Settings](#settings)), and live in `notifications.tray`
 in `~/.seedeep/config.json`, beside a second set governing the webhook channel: the same moment can
 be worth a banner on the machine you are sitting at and not worth a push somewhere else.
 
 | Trigger | Setting | Default | What the banner says |
 | -- | -- | -- | -- |
 | A session stops on the human (`waiting`, and only the two labels above) | *A session needs you* | **on** | `project — subject` / `Waiting for your approval — Bash` |
-| A session's model call fails (`error` becomes non-null) | *A session fails* | **on** | `project — subject` / `The last API call failed` — or `A subagent's API call failed` |
+| A session's model call fails (`error` becomes non-null) | *A session fails* | **on** | `project — subject` / `The last API call failed`, or `A subagent's API call failed` |
 | A session that was `busy` becomes `idle`, having called the model at least once | *A session finishes a turn* | **off** | `project — subject` / `Turn finished` |
 | The connected SERVER is behind npm (`standing`, from `/api/update`) | *A new server version is out* | **on** | `seedeep <latest> is available` / `The server is running <its version>.` |
 
@@ -690,44 +689,44 @@ be worth a banner on the machine you are sitting at and not worth a push somewhe
 act, while a session that finished is news you can read whenever you like; with a single toggle the
 only way to stop the last is to silence the others. The failure banner ships **ON**, with the
 approvals, because the session has stopped and *nothing on screen said so*. **The switch says *fails*
-while the band says *Broken***, deliberately: the switch is read on its own in a list of four, where
+while the band says *Broken***: the switch is read on its own in a list of four, where
 *a session breaks* is as easily read as a session taking a break. The banner carries Claude Code's
-own words — `Not logged in · Please run /login` — because a category invented on top of the CLI's
+own words (`Not logged in · Please run /login`) because a category invented on top of the CLI's
 would send the user to the terminal to find out what happened.
 
-**It fires on the TRANSITION, never on the state.** The watch (`notify-watch.ts`, in the server)
+It fires on the TRANSITION, never on the state. The watch (`notify-watch.ts`, in the server)
 remembers which sessions were stopped on the human, which were at work and which had broken, last
-time it could see, and announces only what was not there before — per session, never as counts, so
+time it could see, and announces only what was not there before, per session and never as counts, so
 one prompt answered and another raised in the same interval still interrupts. Each rule that follows
 is a way of not lying about when something happened:
 
-- **A failure announces once, and re-arms on recovery.** Still-broken is not news on the next tick,
-  and only a successful call — which clears the server's `error` — makes the next failure
+- A failure announces once, and re-arms on recovery. Still-broken is not news on the next tick,
+  and only a successful call, which clears the server's `error`, makes the next failure
   announceable. A session that breaks while it was ALSO stopped on the user raises **one** banner,
   the failure, being the more serious of the two.
-- **A turn the user interrupted is never announced** (`turn.state === 'interrupted'`). Esc means the
+- A turn the user interrupted is never announced (`turn.state === 'interrupted'`). Esc means the
   user is standing at that terminal, and telling them what they just did is how a notification earns
   a mute. Nor did a turn that never called the model *finish*, Esc before the first reply leaving
   nothing in the transcript to mark; nor is `busy → waiting` a finish, being the other trigger; nor
   is a session that simply LEAVES the digest, which the user closed.
-- **A session already waiting — or already idle — when the tray arrives is not an event.** The first
+- A session already waiting, or already idle, when the tray arrives is not an event. The first
   digest SEEDS the sets and announces nothing, and the sets are forgotten the moment the last
   listener leaves, so whoever subscribes next also starts from a seed. Without that, opening the tray
   would replay every open prompt as if it had just happened.
 - LIMIT: a session that enters a wait, or finishes, during a stretch that could not be read is
-  **never** announced — the next reading seeds it. There is no way to know when it happened, and the
+  **never** announced, and the next reading seeds it. There is no way to know when it happened, and the
   icon and the panel are what say where it now stands.
 
-**A banner is one title and one line, and never the detail.** The line names the event — `Waiting for
-your approval — Bash`, `in the terminal` when the transcript has not named the call, `The last API
-call failed`, `Turn finished` — and stops there. The command awaiting approval, the CLI's error text
+A banner is one title and one line, and never the detail. The line names the event: `Waiting for your approval — Bash`,
+`in the terminal` when the transcript has not named the call, `The last API
+call failed`, `Turn finished`, and stops there. The command awaiting approval, the CLI's error text
 and the turn's own last words do not follow on a second line: a banner truncates exactly that line
-first, every one of them is one click away in the panel, and the webhook — the one channel whose
-payload leaves the machine — would be shipping the contents of a work session to a third-party
+first, every one of them is one click away in the panel, and the webhook, the one channel whose
+payload leaves the machine, would be shipping the contents of a work session to a third-party
 service to say what the first line already said. Both channels carry identical text. The title is the
 session (`project — subject`), because the banner already carries the app's name.
 
-**A switch silences its banner, not the bookkeeping.** The switches filter the OUTPUT of the watch
+A switch silences its banner, not the bookkeeping. The switches filter the OUTPUT of the watch
 and never its input (`notify-engine.ts`), so turning one back on announces what happens next rather
 than the backlog. The menu-bar icon is covered by none of them: it is peripheral information that
 costs nothing to ignore, and a user who silenced the interruption has not asked to be blinded.
@@ -740,44 +739,44 @@ the digest, while this one is about the tray itself and can be true while nothin
 - **Once per released VERSION, per RUN of the tray.** A banner repeated on every check is the
   notification people silence first, and remembering it forever is worse: a freshly installed
   unsigned bundle has no notification permission yet, so a banner can be sent, never shown, and
-  recorded as announced. The memory is therefore in MEMORY — no file, no cleanup — and a fresh start
+  recorded as announced. The memory is therefore in MEMORY, with no file and no cleanup, and a fresh start
   is the second chance, which is when a reinstall has just happened.
-- **The banner is about the SERVER, not the tray**, which is the thing that is run and that a stale
+- The banner is about the SERVER, not the tray, which is the thing that is run and that a stale
   version affects. The verdict is the SERVER's own `standing` from `/api/update`, so the tray never
-  recomputes it — only `latest` is taken from that response. The PANEL still names both builds and
+  recomputes it, and only `latest` is taken from that response. The PANEL still names both builds and
   marks whichever is behind (`update_view`); the tray's own version comes from `PackageInfo`, i.e.
   `tauri.conf.json > version`, and **never** from `env!("CARGO_PKG_VERSION")`, which is the
   deliberately inert `0.0.0`.
 - **Asked every 15 minutes** (`UPDATE_EVERY`), SPAWNED rather than awaited so an unreachable server
   cannot hold the loop that paints the icon, and never overlapping, since the clock is claimed before
   the request. The server answers from a file it refreshes once an hour and the tray's period is
-  DELIBERATELY shorter, because asking on the cache's own period would make the worst case two hours.
+  shorter, because asking on the cache's own period would make the worst case two hours.
   The first check runs on the first tick.
-- **The switch silences the banner, not the bookkeeping** — the same rule as the other three.
+- **The switch silences the banner, not the bookkeeping**, the same rule as the other three.
 
 ### What an unsigned build can actually deliver
 
-seedeep ships **unsigned** — no Apple Developer ID, no notarization — and both platforms restrict
+seedeep ships **unsigned**, with no Apple Developer ID and no notarization, and both platforms restrict
 notifications for such builds, differently.
 
-**macOS** — measured by sending one notification each way and then asking Notification Center what it
+**macOS**, measured by sending one notification each way and then asking Notification Center what it
 received (its store lives at `~/Library/Group Containers/group.com.apple.usernoted/db2/db`):
 
 | Run | `show()` returns | Delivered |
 | -- | -- | -- |
-| Unbundled binary — what `tauri dev` runs | `Ok(())` | **No.** The app is never registered and no record exists |
+| Unbundled binary, what `tauri dev` runs | `Ok(())` | **No.** The app is never registered and no record exists |
 | Bundled `.app`, unsigned | `Ok(())` | **Yes.** The app is registered and the exact title and body sent are stored |
 
-So **unsigned is not the obstacle on macOS; being unbundled is** — a `.app` carrying only the
+So unsigned is not the obstacle on macOS; being unbundled is: a `.app` carrying only the
 linker's ad-hoc signature notifies, and signing buys a clean install past Gatekeeper rather than a
 banner. And **`Ok(())` is not evidence**: the API returns success in the case where nothing is
 delivered, so a dev run can never confirm this feature. Verify notifications from the packaged
 artifact, or do not claim to have verified them.
 
-**Windows** — Tauri documents that notifications work only for an INSTALLED application; in
+**Windows**: Tauri documents that notifications work only for an INSTALLED application; in
 development the PowerShell name and icon are shown instead, which is why the Windows deliverable is
-an installer. Together: **on both platforms the notification only works from the packaged
-artifact**, for different reasons.
+an installer. Together: on both platforms the notification only works from the packaged
+artifact, for different reasons.
 
 ## Settings
 
@@ -786,7 +785,7 @@ the footer and left by the header's back button. The popover dismisses on focus 
 makes it behave like a menu; a second window would either inherit that rule and vanish while being
 used, or break it and leave the app with two competing surfaces.
 
-**The panel states, it does not explain** — a design rationale is what this document is for. Three
+The panel states, it does not explain, since a design rationale is what this document is for. Three
 sentences survive on the surface itself: the menu-bar icon is never silenced by a toggle, quitting
 the tray does not stop the server, and a banner is the only proof that a notification was delivered.
 The first two prevent a MISREADING rather than justify a default; the third is the only honest thing
@@ -797,85 +796,85 @@ Five things, which is the whole surface:
 | | |
 | -- | -- |
 | **The server** | Its address, and what identifies it: the pinned certificate whole, all 32 bytes, through the same renderer the trust screen uses |
-| **One field** | The URL the portal's Settings → Remote access copies — the same `connect` command as the connection screen, so a server changed from here goes through the same trust and mismatch screens |
-| **Notifications** | No switch: one line saying they are configured in seedeep's settings, in the browser — the server owns them, and two places to answer one question is one place too many (see [Notifications](#notifications)). Under it, a test banner on demand: the panel closes as it sends, because macOS draws nothing for the app in front |
-| **Stop seedeep** | Only when the server is on this machine and Rust can name exactly one process for it — see [A stop is aimed at the connection](#a-stop-is-aimed-at-the-connection) |
-| **About** | Both builds — `seedeep tray <version>` from `getVersion()`, and `seedeep server <version>` from `GET /api/config`, read when this view opens and never on the poll. Whichever is behind npm carries `— <latest> available` **on its own line**, so which install needs updating is never left to the reader; nothing is added when neither is |
+| **One field** | The URL the portal's Settings → Remote access copies, the same `connect` command as the connection screen, so a server changed from here goes through the same trust and mismatch screens |
+| **Notifications** | No switch: one line saying they are configured in seedeep's settings, in the browser, because the server owns them and two places to answer one question is one place too many (see [Notifications](#notifications)). Under it, a test banner on demand: the panel closes as it sends, because macOS draws nothing for the app in front |
+| **Stop seedeep** | Only when the server is on this machine and Rust can name exactly one process for it; see [A stop is aimed at the connection](#a-stop-is-aimed-at-the-connection) |
+| **About** | Both builds: `seedeep tray <version>` from `getVersion()`, and `seedeep server <version>` from `GET /api/config`, read when this view opens and never on the poll. Whichever is behind npm carries `— <latest> available` **on its own line**, so which install needs updating is never left to the reader; nothing is added when neither is |
 
 Rules that are not preferences:
 
-- **A tick does not redraw this view**, since nothing on it moves on the server's clock and
+- A tick does not redraw this view, since nothing on it moves on the server's clock and
   re-rendering once a second would wipe a half-typed URL out of the field. The one thing that gets
   through is a status that has stopped being `connected`, which takes the panel back to the screen
-  that can fix it — and does not leave the flag behind to spring back on the next tick.
-- **Closing the popover leaves the settings behind.** *While nobody is looking the panel is a mirror*
+  that can fix it, and does not leave the flag behind to spring back on the next tick.
+- Closing the popover leaves the settings behind. *While nobody is looking the panel is a mirror*
   covers which SURFACE is up, not only the rows: the window is hidden and shown, never reloaded, so
   without this rule a settings screen left open yesterday is what the next click on the icon would
   show. Same flag (`open` on the reading), same rule as the ended row.
-- **A message is the first thing on the surface**, whatever produced it — the same rule as the bands'
+- A message is the first thing on the surface, whatever produced it, the same rule as the bands'
   error. This view is taller than the popover and every render starts it at the top, so a message
   appended at the end is one about a click that just happened, below the fold.
 - **The settings exist only over a connected server**, so there is no gear on the connection screens.
-- **Each version says whose it is** — `seedeep tray 0.1.1` and `seedeep server 0.1.1`, never a bare
+- Each version says whose it is: `seedeep tray 0.1.1` and `seedeep server 0.1.1`, never a bare
   number, since the two are separate downloads that update apart and a bare version would be quoted
   in a bug report as the other's. A pair that differs is the ordinary state and draws **no warning**;
   a server that did not answer with one gets no line rather than an "unknown", and a version that
   could not be read draws no About section at all.
-- **The server section says three different things, not one with holes in it**: a pinned certificate,
-  or "plain HTTP, so there is nothing to pin", or — for `http://127.0.0.1:44842` — "the tray found
+- The server section says three different things, not one with holes in it: a pinned certificate,
+  or "plain HTTP, so there is nothing to pin", or, for `http://127.0.0.1:44842`, "the tray found
   this one by itself". An empty space where a fingerprint would be reads as *not checked yet* rather
   than as *nothing to check*.
-- **Nothing on this surface writes a setting**, which is why none of it can be left showing a value
+- Nothing on this surface writes a setting, which is why none of it can be left showing a value
   the disk does not hold. What is here either states a fact (the server, the versions) or performs an
   act (connect, test, stop) whose answer is the next screen.
 
-**Why a test button exists at all.** There is no way to ASK whether notifications will arrive: the
+Why a test button exists at all. There is no way to ASK whether notifications will arrive: the
 plugin's `permission_state()` is a hardcoded `Granted` on desktop (verified in
 tauri-plugin-notification 2.3.3, `desktop.rs`), and `show()` returns `Ok(())` even when nothing is
-delivered. So the honest surfacing of that degradation is the only check that exists — send one and
+delivered. So the honest surfacing of that degradation is the only check that exists: send one and
 look.
 
-**The popover closes as it sends, and that is the test, not a courtesy.** macOS does not PRESENT a
-notification posted by the app that is FRONTMOST — Apple says so on `shouldPresentNotification:`
+The popover closes as it sends, and that is the test, not a courtesy. macOS does not PRESENT a
+notification posted by the app that is FRONTMOST (Apple says so on `shouldPresentNotification:`
 ("the Notification Center has decided not to present your notification, for example when your
-application is front most", `NSUserNotification.h`) — and clicking this button is the one moment the
+application is front most", `NSUserNotification.h`) and clicking this button is the one moment the
 tray is frontmost, because the popover takes focus when it opens. The delegate callback Apple
 documents as the override is not implemented by `mac-notification-sys`, so there is nothing of ours
-to answer YES with — the tray has to stop being frontmost instead. `test_notification` therefore
+to answer YES with, so the tray has to stop being frontmost instead. `test_notification` therefore
 hides the panel, **hides the app**, waits out `NOTIFY_SETTLE` (400 ms), and only then sends.
 
-**Hiding the WINDOW does not do it, and neither does asking to deactivate.** An `Accessory` app owns
+Hiding the WINDOW does not do it, and neither does asking to deactivate. An `Accessory` app owns
 no other window to fall back to, so hiding its only one leaves it the ACTIVE app with nothing on
-screen — the state that matters is activation, not visibility. `NSApplication.deactivate` says
+screen, since the state that matters is activation rather than visibility. `NSApplication.deactivate` says
 exactly that intent and does nothing, because nothing is there to take the activation; `NSApp.hide:`
-— Tauri's `AppHandle::hide` — hands it to the next app in line.
+(Tauri's `AppHandle::hide`) hands it to the next app in line.
 
-**Its cost is the HIDDEN state, and `toggle_panel` is what pays it**: every window of a hidden app
+Its cost is the HIDDEN state, and `toggle_panel` is what pays it: every window of a hidden app
 stays down until something unhides it, so the click after a test would otherwise open nothing. It
 calls `AppHandle::show` before showing the window, which is harmless in every other case, and the
-branch above it stays correct on its own — a window of a hidden app reports `is_visible() == false`,
+branch above it stays correct on its own: a window of a hidden app reports `is_visible() == false`,
 so the click takes the path that opens the panel rather than the one that dismisses it. Whether
 `show` also ACTIVATES is left unstated here and in the code, because the documentation cannot settle
 it; nothing depends on it, since `set_focus` decides the activation on the next line.
 
-**There is no receipt, and there must not be**: the surface that would carry it is the one being put
-away. The banner IS the answer — the same rule the stop follows — and the caveat that a system can
+There is no receipt, and there must not be: the surface that would carry it is the one being put
+away. The banner IS the answer, the same rule the stop follows, and the caveat that a system can
 hide them silently sits on the button's own note, read while deciding to click. The note also says
 the panel will close: a popover that vanishes unannounced reads as a crash.
 
 ## Platforms
 
-macOS and Windows. **Linux is not a target**, and not because nobody got to it: Tauri documents
-that tray click events are not emitted on Linux — the icon appears and right-click still opens
+macOS and Windows. Linux is not a target, and not because nobody got to it: Tauri documents
+that tray click events are not emitted on Linux: the icon appears and right-click still opens
 a context menu, but the left-click that opens this panel never arrives. A Linux build would
 silently be a different product, a context menu instead of a panel. If it ever ships it has to
-be designed as that, deliberately.
+be designed as that from the start.
 
 ### The one permission the tray asks for
 
 macOS gates reaching the local network, and the tray reaches it for one reason: a server announces
 the address it answers on, and with remote access configured that address is a hostname on the LAN
-rather than loopback. Resolving it — the identity test above — and connecting to it are both on the
+rather than loopback. Resolving it (the identity test above) and connecting to it are both on the
 far side of that gate.
 
 The reason is DECLARED, in `src-tauri/Info.plist`: `NSLocalNetworkUsageDescription`. Tauri looks for
@@ -887,47 +886,47 @@ Refusing it is a supported state, not a broken one: the tray falls back to askin
 Start stops being offered for a server that names itself by hostname. In the default loopback setup
 the gate is never reached at all.
 
-**Every update re-asks, and that is what unsigned costs.** macOS attaches a permission to a code
-IDENTITY, and an unsigned app has none that survives a rebuild — `codesign -d -r-` on the installed
+Every update re-asks, and that is what unsigned costs. macOS attaches a permission to a code
+IDENTITY, and an unsigned app has none that survives a rebuild: `codesign -d -r-` on the installed
 app says *"code object is not signed at all"*, so a rebuild is a different object. Preferences and the
 stored connection survive (those hang off the bundle identifier), the permissions do not. The
 user-facing half of that, notifications included, is in
 [`install.md`](install.md#installing-the-tray).
 
 Which is also why the dialog naming the right app matters. It says **`seedeep-tray`**, which is the
-honest answer to *"who is asking?"* — the tray, on behalf of the server it started, since macOS
+honest answer to *"who is asking?"*: the tray, on behalf of the server it started, since macOS
 attributes a child's request to the app responsible for it.
 
-The **server** trips a different one — `~/Documents`, when a session's repository lives there and the
+The **server** trips a different one, `~/Documents`, when a session's repository lives there and the
 Commits or Changed files card runs read-only git in it. That belongs to the server, not here:
 [`install.md`](install.md#the-macos-permission-the-server-asks-for).
 
 ## Packaging and releases
 
-`.github/workflows/release.yml` builds what a user downloads. **A tag is the only thing that
-publishes**: pushing `v*` creates a **draft** release, the build jobs upload into it, and a last job
-flips it — only after every one of them succeeded, so a Windows failure leaves a draft rather than
+`.github/workflows/release.yml` builds what a user downloads. A tag is the only thing that
+publishes: pushing `v*` creates a **draft** release, the build jobs upload into it, and a last job
+flips it, only after every one of them succeeded, so a Windows failure leaves a draft rather than
 putting half a download page in front of people. A manual run (`workflow_dispatch`) builds exactly
 the same artifacts and leaves them on the workflow run: every step that writes to the repository is
 gated on `github.ref_type == 'tag'`. How the workflow is wired is in
 [`CONTRIBUTING.md`](../CONTRIBUTING.md#how-a-release-is-built); what a user downloads and installs is
 in [`install.md`](install.md#installing-the-tray).
 
-**Every asset says which app it belongs to** — `seedeep-tray_<version>_universal.dmg`,
+Every asset says which app it belongs to: `seedeep-tray_<version>_universal.dmg`,
 `seedeep-server_<version>_macos-arm64`. The bundler names its output after `productName`, which **is**
 `seedeep-tray`, so nothing needs renaming on the way out. The two programs are named apart because
-sharing one name made a **system permission dialog unreadable** — macOS names an app by
+sharing one name made a **system permission dialog unreadable**, since macOS names an app by
 `CFBundleDisplayName`, which is `productName`, so the dialog said *"seedeep"* whether it was asking
-for the tray or on behalf of the server — and made `killall seedeep` reach the server rather than the
+for the tray or on behalf of the server, and made `killall seedeep` reach the server rather than the
 app the user meant. The bundle IDENTIFIER is unchanged (`app.seedeep.tray`), so the permission already
 granted, the config directory and the Windows uninstall key all survive that naming.
 
-**The release note is install instructions, not a disclaimer.** Both systems interrupt the first
-launch, and a note that does not say so lets that interruption read as a broken download — so it
+The release note is install instructions, not a disclaimer. Both systems interrupt the first
+launch, and a note that does not say so lets that interruption read as a broken download, so it
 carries the gesture that gets past each one, in the words the system itself uses (*Open Anyway*,
 *Run anyway*), and never a label about how the build was made.
 
-**Nothing is signed, and everything is attested.** The bundle carries only the linker's ad-hoc
+Nothing is signed, and everything is attested. The bundle carries only the linker's ad-hoc
 signature: `spctl -a --type exec` answers `rejected — source=no usable signature`, and Apple's
 `syspolicy_check distribution` calls it *"not signed at all"*, so macOS refuses the first launch and
 SmartScreen stops the Windows installer. Signing and notarization stay out of scope until there is a
@@ -938,5 +937,5 @@ generated by the release workflow and checkable by anyone:
 gh attestation verify seedeep-tray_<version>_universal.dmg -R duqaXxX/seedeep
 ```
 
-That answers a different question from Gatekeeper's — it says where the bytes came from, not who
-signed them — and it is the only one of the two seedeep can answer today.
+That answers a different question from Gatekeeper's: it says where the bytes came from, not who
+signed them, and it is the only one of the two seedeep can answer today.


### PR DESCRIPTION
## What

Every public document rewritten so it states things instead of selling them, plus one blocking test that keeps the measurable half of that from coming back.

| | Before | After |
|---|---:|---:|
| Em dash in prose | 1094 | **0** |
| Paragraphs closing on an aphorism | 20 | **0** |
| Bold wrapping a whole sentence | 436 | **0** |
| `deliberately` / `on purpose` | 54 | **25** |
| Bold spans, total | 953 | **637** |

Also in here:

- `README.md` leads with the install command, which sat at line 149 of 257.
- The explanation of why the installed tray cannot read `SEEDEEP_HOME` was written out in both `CONTRIBUTING.md` and `configuration.md`. It now lives in `configuration.md`, which owns the variable.
- `apps/server/tests/docs.test.ts` gains `no em dash in a public doc's prose`.

## Why

The only public comment this project has received was that its README reads as generated. The substance was not the problem: the platform-honesty table, the corpus figures and the admissions of what has not been tested are the opposite of that, and none of them was touched here. The register was the problem, and a reader decides in about two sentences.

The counts above are the tells catalogued by [Wikipedia:Signs of AI writing](https://en.wikipedia.org/wiki/Wikipedia:Signs_of_AI_writing); no single one proves anything, and this corpus stacked four of them at high density. The root cause is the one [Art of README](https://github.com/hackergrrl/art-of-readme) names: *don't sell users on your work, let them evaluate it as objectively as possible*. The em dashes were the symptom.

The corpus lost 11% of its words and not one fact.

### Why the test reads the file and not the diff

An em dash is legitimate in three places: a heading, whose slug other docs link to; a fenced block; and a backtick span quoting a literal seedeep prints, such as `Waiting for your approval — Bash`, which the doc would be lying about if it rewrote it. Only a checker that reads the finished file can tell those apart. A diff-shaped gate would flag every reformatted line that merely contains one, so this belongs in the suite rather than in the pre-push hook.

Verified in both directions: red on an em dash added to prose, green on the same character inside a heading or a code span.

## Checks

- [x] `bun run test` (1763 pass, 0 fail) and `bun run typecheck` pass. Nothing under `apps/tray/` changed.
- [x] No client code changed, so no bundle rebuild is involved.
- [x] Docs are the change, and `docs/CHANGELOG.md` has a dated entry under Unreleased.
- [x] Markdown only. No fixture, screenshot or session content is added, and no path, address or identifier appears in the diff.

## Note for the reviewer

The pre-push prose gate warns on two shapes here. Both are in the changelog entry, where history and dated figures belong, and the three hits it finds in the docs themselves are the rule that forbids the shape, a measurement that already states its corpus, and an example sentence.