### PR TITLE
0.31.2

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,8 @@ Everything released before `0.20.0` — including the pre-publication developmen
 
 ## Unreleased
 
+## 0.31.2 (2026-08-25)
+
 ### Changed
 
 - Every public document rewritten to read as a reference rather than as a pitch. The prose carried

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "seedeep",
-  "version": "0.31.1",
+  "version": "0.31.2",
   "private": true,
   "type": "module",
   "description": "Live context & subagent visualizer for Claude Code",


### PR DESCRIPTION
## What

Version bump to 0.31.2, and the `Unreleased` heading cut into `## 0.31.2 (2026-08-25)` with a fresh empty `Unreleased` above it.

## Why

The release carries one change: the public documentation rewritten to read as a reference rather than as a pitch, plus the blocking test that keeps the measurable half of it from coming back. Nothing that runs changed, so this is a patch.

## Checks

- [x] `bun run test` (1763 pass, 0 fail) and `bun run typecheck` pass. Nothing under `apps/tray/` changed.
- [x] No client code changed.
- [x] `docs/CHANGELOG.md` carries the dated section; `Unreleased` is empty again.
- [x] Two files, both metadata. No session content, path, address or identifier is involved.