### PR TITLE
docs: replace the two figures a reader could not reproduce

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,9 @@ npm i -g seedeep && seedeep     # Node or Bun; binaries below for neither
 Eight things a Claude Code session does not report, and what `seedeep` shows instead.
 
 - A failed API call ends the turn silently. An expired login, a session limit, an
-  overloaded server: the turn stops and the terminal keeps looking normal. Across
-  1830 real transcripts, 39 of 47 failed calls were the last line their session ever
-  wrote. seedeep turns the tab red, files the session under *Broken*, and turns the
-  menu-bar icon red above every other signal.
+  overloaded server: the turn stops, the terminal keeps looking normal, and the
+  transcript's last line is the error itself. seedeep turns the tab red, files the
+  session under *Broken*, and turns the menu-bar icon red above every other signal.
 - An approval dialog reaches no log at all, so a session stopped on a permission
   prompt looks identical to one that is thinking. seedeep reads Claude Code's own
   live state, turns the tab amber the moment it stops, and names what is waiting to
@@ -50,9 +49,12 @@ Eight things a Claude Code session does not report, and what `seedeep` shows ins
 - The window size depends on the model. The bar follows the model your calls really
   run on, so `/model` mid-session moves it, and a Haiku subagent is measured against
   200k inside a session running on 1M.
-- A resumed turn re-pays for its context. After the cache goes cold, the turn
-  re-creates its whole prompt before doing any work. On a real corpus that accounts
-  for a quarter of every token spent, and on screen it looks like work.
+- Most of what you spend is context you already sent. Measured on 2026-08-25 over
+  one machine's 770 session files and 34,724 API calls: 98% of the tokens processed
+  were cache reads, and 0.3% were output. Weighted by what each kind actually costs,
+  re-read context is still 71% of the bill. The recipe is in
+  [`docs/features.md`](docs/features.md#checking-the-numbers-yourself), so you can run
+  it on your own sessions.
 - Waste is scored per turn. Seven deterministic checks (no LLM) run as each turn
   closes, each quoting the Claude Code documentation that justifies it. They report
   what the turn did right as well.
@@ -95,7 +97,7 @@ notifies: not a subagent finishing, not a tool error.
 | Banner | Ships | Why |
 | -- | -- | -- |
 | **Waiting for your approval** | on | the session cannot continue until you answer |
-| **The last API call failed** | on | it has stopped and nothing on screen says so (39 of 47 real failures were the last line their session wrote) |
+| **The last API call failed** | on | it has stopped, and nothing on screen says so |
 | **Turn finished** | **off** | routine news, off by default so the two above stay unmuted |
 
 Each banner is one title and one line: which session, and what happened. The command

--- a/apps/server/tests/doc-shots-check.test.ts
+++ b/apps/server/tests/doc-shots-check.test.ts
@@ -137,6 +137,8 @@ const SECTIONS_WITHOUT_A_FIGURE: Record<string, string> = {
     'PENDING — the strip is only worth a figure with SEVERAL tabs in different states, and a capture opens one session',
   Notifications:
     "the surface is an OS banner and a POST to somebody else's service — neither is a crop of seedeep, and the switches that configure it are already in the two Settings figures",
+  'Checking the numbers yourself':
+    'a recipe, not a surface — it is the ten lines that recompute the token split from the session files, and a screenshot of seedeep cannot verify seedeep',
 };
 
 describe('docs/features.md — a figure per surface', () => {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,16 @@ Everything released before `0.20.0` — including the pre-publication developmen
 
 ## Unreleased
 
+### Fixed
+
+- The README's two loudest figures could not be reproduced by a reader. "39 of 47 failed calls were
+  the last line their session ever wrote", measured once over 1830 transcripts, comes back as 3 of 8
+  on a 770-file corpus, and "a quarter of every token spent" carried neither a date nor a corpus.
+  The failed-call bullet now states the mechanism, which is what a reader can check, and the token
+  figure is replaced by one that names its date, its corpus and its method.
+- `docs/features.md` gains *Checking the numbers yourself*: the ten lines that recompute the token
+  split straight from the session files, including the deduplication that a naive sum gets wrong.
+
 ## 0.31.2 (2026-08-25)
 
 ### Changed

--- a/docs/features.md
+++ b/docs/features.md
@@ -492,8 +492,8 @@ is why a stopped session looks exactly like a thinking one everywhere else.*
 
 An API call that fails (an expired login, a session limit, an overloaded server)
 ends the turn and leaves the session sitting there. It is the quietest failure
-there is: a failed call is usually the last model line its session ever writes,
-and nothing on screen says so.
+there is: the error is the last line the transcript carries for that turn, and
+nothing on screen says so.
 
 seedeep makes it a state rather than a passing message: the tab dot turns **red**,
 the menu-bar icon turns red above every other signal, the tray panel files the
@@ -605,6 +605,39 @@ view follows it; a spawn block IS its subagent (launch intent, tools, real
 duration) and unfolds the child's own flow as a parallel lane below, filling
 **while the agent runs**. Every block clicks through to the same drawer as the rest
 of the app. The full rules live in [`trace.md`](trace.md).
+
+## Checking the numbers yourself
+
+Every figure seedeep draws comes from the session files Claude Code already wrote, so
+any of them can be recomputed without seedeep. This is the one that decides how the
+retrospective reads, and it takes ten lines:
+
+```python
+import json, glob, os, collections
+tot, seen = collections.Counter(), set()
+for f in glob.glob(os.path.expanduser('~/.claude/projects/*/**/*.jsonl'), recursive=True):
+    for line in open(f, encoding='utf8'):
+        if '"usage"' not in line: continue
+        try: msg = json.loads(line).get('message') or {}
+        except Exception: continue
+        u, rid = msg.get('usage'), msg.get('id')
+        if not isinstance(u, dict) or not rid or rid in seen: continue
+        seen.add(rid)                      # one usage block per CALL, repeated on every line of it
+        for k in ('input_tokens', 'output_tokens',
+                  'cache_read_input_tokens', 'cache_creation_input_tokens'):
+            tot[k] += u.get(k) or 0
+T = sum(tot.values())
+print(f'{len(seen):,} calls, {T:,} tokens')
+for k, v in tot.most_common(): print(f'  {k:30} {v:>14,}  {100*v/T:5.1f}%')
+```
+
+The `seen` set is the part that matters: Claude Code writes one line per content block
+and repeats the call's whole `usage` on every one of them, so summing per line
+multiplies the total. seedeep guards the same way, with `newCall`.
+
+On the machine seedeep is developed on, over 770 session files and 34,724 calls on
+2026-08-25, that prints 98.4% cache reads and 0.3% output. Your own corpus will not
+match those figures, and that is the point of running it.
 
 ## Home — your retrospective, from minute zero
 


### PR DESCRIPTION
## What

The README carried two numbers a reader cannot get back. Both are replaced, and `docs/features.md` gains the recipe for the one that survives.

| Claim | Status |
|---|---|
| "39 of 47 failed calls were the last line their session ever wrote", over 1830 transcripts | removed |
| "a quarter of every token spent", no date, no corpus | replaced |

## Why

The failed-call figure was measured once, over a corpus that no longer exists. Re-run today over 770 session files it comes back as **3 of 8**. It was the first number anyone would try on their own machine, and the one they would fail to get, which is the failure mode the project's own documentation rule exists to prevent: a measurement a reader cannot reproduce does not belong in a public doc.

The bullet now states the mechanism, which is checkable: a failed call ends the turn and the error is the last line the transcript carries for it. The feature it justifies is unchanged and still described.

The token figure is replaced by one that names its date, its corpus and its method: over 770 files and 34,724 calls on 2026-08-25, 98% of the tokens processed were cache reads and 0.3% were output; weighted by what each kind costs, re-read context is 71% of the bill.

`docs/features.md` gains *Checking the numbers yourself*: the ten lines that recompute that split from the session files alone, with the deduplication a naive sum gets wrong (Claude Code repeats a call's whole `usage` on every line of it, so summing per line multiplies the total). The doc says outright that another machine will not match the figures, because running it is the point.

## Checks

- [x] `bun run test` (1763 pass, 0 fail) and `bun run typecheck` pass. Nothing under `apps/tray/` changed.
- [x] No client code changed.
- [x] `docs/CHANGELOG.md` has a dated entry under Unreleased.
- [x] Markdown and one test file. The recipe reads `~/.claude/projects` through a path with no user in it, and prints only totals.

## One thing the suite caught

Adding a section to `features.md` failed `doc-shots-check.test.ts`: every section there must carry a figure or be listed as deliberately without one. The new section is a recipe rather than a surface, so it is now listed with that reason. Worth noting because the gate did exactly its job on the first change that could have slipped past it.