### PR TITLE
Split the Output figure into reasoning and answer

### DIFF
--- a/apps/server/public/css/feed.css
+++ b/apps/server/public/css/feed.css
@@ -262,3 +262,54 @@
 }
 
 /* Result preview block at the top of the activity card */
+
+/* The Output row's thinking/answer split. Spans the ledger's three columns so the bar lines up
+   with the row it belongs to rather than starting at the value column. Two tones of one indigo:
+   the darker is the reasoning, the lighter the answer, and neither is a category colour from the
+   Context segbar, which would make this read as a fifth thing that adds to the total. */
+.led .tsplit {
+  grid-column: 1 / -1;
+  margin: 0.1rem 0 0.35rem;
+}
+.tsbar {
+  display: flex;
+  height: 6px;
+  border-radius: 4px;
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.06);
+}
+.tsbar > i {
+  display: block;
+  height: 100%;
+  background: #818cf8;
+}
+.tsbar > i.answer {
+  background: #c7d2fe;
+}
+.tskey {
+  display: flex;
+  gap: 0.8rem;
+  margin-top: 0.3rem;
+  font: 0.68rem var(--mono);
+  color: var(--lo);
+}
+.tskey span {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+}
+.tskey i {
+  width: 7px;
+  height: 7px;
+  border-radius: 2px;
+  flex: none;
+  background: #818cf8;
+}
+.tskey span.answer i {
+  background: #c7d2fe;
+}
+.tskey b {
+  color: var(--ink);
+  font-weight: 500;
+  font-variant-numeric: tabular-nums;
+}

--- a/apps/server/public/lib/app.js
+++ b/apps/server/public/lib/app.js
@@ -128,6 +128,7 @@ function createSessionTree(opts) {
     mainModels.push(mainModel);
   let mainFill = 0;
   let usageInput = 0, usageOutput = 0;
+  let usageThinking = 0, usageThinkingReported = false;
   let weightedMain = 0;
   const weightedByModel = new Map;
   const mainWeightedByModel = new Map;
@@ -295,6 +296,10 @@ function createSessionTree(opts) {
           }
           usageInput += e.delta.input;
           usageOutput += e.delta.output;
+          if (e.thinking !== null) {
+            usageThinking += e.thinking;
+            usageThinkingReported = true;
+          }
           cacheTotals.read += e.delta.cacheRead;
           cacheTotals.created += e.delta.cacheCreation;
           const w = callWeight(e.model, e.delta);
@@ -308,6 +313,10 @@ function createSessionTree(opts) {
               currentTurn.state = "live";
             currentTurn.inputTotal += e.delta.input;
             currentTurn.out += e.delta.output;
+            if (e.thinking !== null) {
+              currentTurn.thinking += e.thinking;
+              currentTurn.thinkingReported = true;
+            }
             currentTurn.apiCalls++;
             currentTurn.cacheTotals.read += e.delta.cacheRead;
             currentTurn.cacheTotals.created += e.delta.cacheCreation;
@@ -369,6 +378,8 @@ function createSessionTree(opts) {
           cacheTotals: { read: 0, created: 0 },
           inputTotal: 0,
           out: 0,
+          thinking: 0,
+          thinkingReported: false,
           weighted: 0,
           skillTurns: new Map,
           skillInvokes: new Map,
@@ -821,6 +832,7 @@ function createSessionTree(opts) {
         state,
         cutoff: t.cutoff,
         durationMs: t.durationMs,
+        thinking: t.thinkingReported ? t.thinking : null,
         messageCount: t.messageCount,
         apiCalls: t.apiCalls,
         deltaFill: t.fillEnd - prevFill,
@@ -1029,6 +1041,7 @@ function createSessionTree(opts) {
         cacheTotals: { ...cacheTotals },
         inputTotal: usageInput,
         outputTotal: usageOutput,
+        thinkingTotal: usageThinkingReported ? usageThinking : null,
         weighted: weightedMain,
         weightedByModel: [...mainWeightedByModel].map(([model, weight]) => ({ model, weight })).sort((a, b) => b.weight - a.weight)
       },
@@ -4309,7 +4322,14 @@ function backgroundCommands(tools, opts) {
 }
 function tokenUsage(m) {
   const input = m.inputTotal, cacheWrite = m.cacheTotals.created, cacheRead = m.cacheTotals.read, output = m.outputTotal;
-  return { input, cacheWrite, cacheRead, output, total: input + cacheWrite + cacheRead + output };
+  return {
+    input,
+    cacheWrite,
+    cacheRead,
+    output,
+    thinking: m.thinkingTotal,
+    total: input + cacheWrite + cacheRead + output
+  };
 }
 function subagentsChronological(subagents) {
   return [...subagents].sort((a, b) => {
@@ -4355,6 +4375,7 @@ function scopeToTurn(s, turnIndex) {
       cacheTotals: { ...turn.cacheTotals },
       inputTotal: turn.inputTotal,
       outputTotal: turn.out,
+      thinkingTotal: turn.thinking,
       weighted: turn.weighted,
       weightedByModel: []
     },
@@ -6927,6 +6948,25 @@ function legendItem(color, txt) {
   g.append(sw, document.createTextNode(txt));
   return g;
 }
+function thinkingSplit(thinking, output) {
+  const box = E("div", "tsplit");
+  const bar = E("div", "tsbar");
+  const share = Math.max(0, Math.min(1, output > 0 ? thinking / output : 0));
+  const a = E("i");
+  a.style.width = share * 100 + "%";
+  const b = E("i", "answer");
+  b.style.width = (1 - share) * 100 + "%";
+  bar.append(a, b);
+  const key = E("div", "tskey");
+  const one = (cls, label, n) => {
+    const sp = E("span", cls);
+    sp.append(E("i"), document.createTextNode(label + " "), E("b", null, k(n)));
+    return sp;
+  };
+  key.append(one("think", "thinking", thinking), one("answer", "answer", output - thinking));
+  box.append(bar, key);
+  return box;
+}
 var scrollLocks = 0;
 function lockPageScroll() {
   if (scrollLocks++ === 0) {
@@ -7449,6 +7489,8 @@ function createGraph(container, state, opts = {}) {
       const led = E("div", "led");
       for (const [label, val, sep, est] of rows) {
         led.append(E("div", "lk" + (sep ? " sep" : ""), label), E("div", "ld" + (sep ? " sep" : "")), E("div", "lv" + (sep ? " sep" : ""), (est ? "~" : "") + k(val)));
+        if (label === "Output" && u.thinking !== null && val > 0)
+          led.append(thinkingSplit(u.thinking, val));
       }
       usageCard.append(led);
       appendSubagentModels(usageCard, s);
@@ -9039,6 +9081,12 @@ last event: ` + c.lastEvent : c.sentence ?? c.command;
         setKV(inTile, kc(totalIn));
         setKV(newTile, kc(newThis));
         setKV(outTile, kc(u.output || 0));
+        const th = res.thinking;
+        if (typeof th === "number" && (u.output || 0) > 0) {
+          const bl = E("div", "block");
+          bl.append(E("div", "blabel", "Output composition"), thinkingSplit(th, u.output || 0));
+          compBlock.after(bl);
+        }
         compBlock.replaceChildren(stackBlock("Input composition", kc(totalIn) + " total", [
           { label: "cached", value: u.cacheRead || 0, color: "var(--cache)", detail: kc(u.cacheRead || 0) },
           {

--- a/apps/server/src/client/graph.ts
+++ b/apps/server/src/client/graph.ts
@@ -143,6 +143,8 @@ export interface CallIOResult {
   model: string | null;
   effort?: string | null;
   usage?: { input?: number; output?: number; cacheRead?: number; cacheCreation?: number } | null;
+  /** Of `usage.output`, the part this call spent thinking; null when it reported no split. */
+  thinking?: number | null;
   input?: ToolOutputResult | null;
   output?: ToolOutputResult | null;
   outputHasTools?: boolean;
@@ -230,6 +232,30 @@ function legendItem(color: string, txt: string): HTMLElement {
   sw.style.background = color;
   g.append(sw, document.createTextNode(txt));
   return g;
+}
+
+// The Output row's split into reasoning and answer, shared by the Session card's ledger and the
+// turn drawer so the two cannot drift apart. Two tones of ONE hue on purpose: `thinking` is part
+// of the number above it, and a second colour off the category palette would read as a fifth
+// category adding to the hero. The caller decides WHETHER to draw it; this only draws it.
+function thinkingSplit(thinking: number, output: number): HTMLElement {
+  const box = E('div', 'tsplit');
+  const bar = E('div', 'tsbar');
+  const share = Math.max(0, Math.min(1, output > 0 ? thinking / output : 0));
+  const a = E('i');
+  a.style.width = share * 100 + '%';
+  const b = E('i', 'answer');
+  b.style.width = (1 - share) * 100 + '%';
+  bar.append(a, b);
+  const key = E('div', 'tskey');
+  const one = (cls: string, label: string, n: number) => {
+    const sp = E('span', cls);
+    sp.append(E('i'), document.createTextNode(label + ' '), E('b', null, k(n)));
+    return sp;
+  };
+  key.append(one('think', 'thinking', thinking), one('answer', 'answer', output - thinking));
+  box.append(bar, key);
+  return box;
 }
 
 // Page scroll-lock, ref-counted across ALL Graph instances (one per open tab).
@@ -1019,6 +1045,12 @@ export function createGraph(
           E('div', 'ld' + (sep ? ' sep' : '')),
           E('div', 'lv' + (sep ? ' sep' : ''), (est ? '~' : '') + k(val)),
         );
+        // The Output row splits in place: on a median call 39% of it is reasoning nobody reads
+        // as an answer (measured 2026-08-29 over 22,995 calls). Two tones of ONE hue, because
+        // thinking is a SUBSET of the row above and a fourth colour would read as a category
+        // that adds to the hero. Drawn only when the scope reported a split at all, and only
+        // when there is something to split: `0 of 0` is a bar of nothing.
+        if (label === 'Output' && u.thinking !== null && val > 0) led.append(thinkingSplit(u.thinking, val));
       }
       usageCard.append(led);
       appendSubagentModels(usageCard, s);
@@ -3515,6 +3547,15 @@ export function createGraph(
         setKV(inTile, kc(totalIn));
         setKV(newTile, kc(newThis));
         setKV(outTile, kc(u.output || 0));
+        // The same split the Session card's ledger draws, on ONE call. It is the finer of the two
+        // readings: a session's 39% median hides calls that were almost all reasoning and calls
+        // that were none, and this is where that shows.
+        const th = res.thinking;
+        if (typeof th === 'number' && (u.output || 0) > 0) {
+          const bl = E('div', 'block');
+          bl.append(E('div', 'blabel', 'Output composition'), thinkingSplit(th, u.output || 0));
+          compBlock.after(bl);
+        }
         compBlock.replaceChildren(
           stackBlock('Input composition', kc(totalIn) + ' total', [
             { label: 'cached', value: u.cacheRead || 0, color: 'var(--cache)', detail: kc(u.cacheRead || 0) },

--- a/apps/server/src/core/selectors.ts
+++ b/apps/server/src/core/selectors.ts
@@ -201,13 +201,24 @@ export function tokenUsage(m: TreeSnapshot['main']): {
   cacheWrite: number;
   cacheRead: number;
   output: number;
+  /** Of `output`, the part spent thinking; null when nothing in the scope reported a split. */
+  thinking: number | null;
   total: number;
 } {
   const input = m.inputTotal,
     cacheWrite = m.cacheTotals.created,
     cacheRead = m.cacheTotals.read,
     output = m.outputTotal;
-  return { input, cacheWrite, cacheRead, output, total: input + cacheWrite + cacheRead + output };
+  // NOT part of the total: it is already inside `output`, and adding it would count those
+  // tokens twice in the figure the card puts at the top.
+  return {
+    input,
+    cacheWrite,
+    cacheRead,
+    output,
+    thinking: m.thinkingTotal,
+    total: input + cacheWrite + cacheRead + output,
+  };
 }
 
 /** Subagents ranked by tool count (desc) — the "output size" order. Does not mutate the input. */
@@ -288,6 +299,9 @@ export function scopeToTurn(s: TreeSnapshot, turnIndex: number): TreeSnapshot {
       cacheTotals: { ...turn.cacheTotals },
       inputTotal: turn.inputTotal,
       outputTotal: turn.out,
+      // Scoped with `outputTotal`, never left to the spread above: the session's thinking drawn
+      // against this turn's output is the same silent lie `weightedByModel` avoids below.
+      thinkingTotal: turn.thinking,
       weighted: turn.weighted,
       // LIMIT: a turn carries its total weight but no per-model split of it, so the scoped view
       // reports none rather than handing back the SESSION's split — an empty list renders as

--- a/apps/server/src/core/session-tree.ts
+++ b/apps/server/src/core/session-tree.ts
@@ -254,6 +254,9 @@ export interface TurnNode {
   cacheTotals: CacheTotals; // summed over the turn's calls — see the type
   inputTotal: number; // input_tokens summed over the turn (Token usage card)
   out: number; // output tokens produced in this turn
+  /** Of `out`, the part the model spent thinking, and null when no call in the turn reported a
+   * split (see the session-level counter for why the two are told apart). */
+  thinking: number | null;
   /** This turn's MAIN-thread weight — see {@link callWeight}. Excludes its subagents, whose
    * weight is a fact about the child (and reaches the session total via `weightedSubagents`). */
   weighted: number;
@@ -341,6 +344,8 @@ export interface TreeSnapshot {
     cacheTotals: CacheTotals;
     inputTotal: number;
     outputTotal: number;
+    /** Of `outputTotal`, the part spent thinking; null when no call reported a split. */
+    thinkingTotal: number | null;
     weighted: number;
     /** `weighted` split by the model of the call, MAIN THREAD ONLY, weight descending. Distinct from
      * the session-level `weightedByModel`, which folds the subagents in. */
@@ -509,6 +514,8 @@ interface TurnAcc {
   cacheTotals: CacheTotals;
   inputTotal: number; // input_tokens SUMMED over the turn (breakdown.input is the last call)
   out: number;
+  thinking: number;
+  thinkingReported: boolean;
   weighted: number; // main-thread weight of this turn's calls (see TurnNode.weighted)
   skillTurns: Map<string, number>; // same two counters as the session, scoped to this turn
   skillInvokes: Map<string, number>;
@@ -677,6 +684,13 @@ export function createSessionTree(opts: { windowFor: WindowFor; mainModel?: stri
   // Token usage card has all four. Distinct from mainOut, which is the LAST call's output.
   let usageInput = 0,
     usageOutput = 0;
+  // Of `usageOutput`, the part spent thinking. A SUM beside a sum, never a member of the
+  // breakdown: it is a split of output, and a fifth counter next to the four that add up to the
+  // total is one refactor away from being added to it. `reported` is the whole reason this is two
+  // numbers: Claude Code writes `output_tokens_details: null` as well as the object, and a model
+  // that did no thinking writes 0 — "nothing to say" and "no thinking" must not render alike.
+  let usageThinking = 0,
+    usageThinkingReported = false;
   // Whole-session MAIN-thread weight. Subagent weight is summed from the agents, so
   // the two never double-count: they are the two sides of the reducer's `owner === null` branch.
   let weightedMain = 0;
@@ -985,6 +999,10 @@ export function createSessionTree(opts: { windowFor: WindowFor; mainModel?: stri
           }
           usageInput += e.delta.input;
           usageOutput += e.delta.output;
+          if (e.thinking !== null) {
+            usageThinking += e.thinking;
+            usageThinkingReported = true;
+          }
           cacheTotals.read += e.delta.cacheRead;
           cacheTotals.created += e.delta.cacheCreation;
           // Charged to the model of THIS call, inside the same per-call guard as the sums above:
@@ -1002,6 +1020,10 @@ export function createSessionTree(opts: { windowFor: WindowFor; mainModel?: stri
             if (currentTurn.closedByResult && currentTurn.state === 'done') currentTurn.state = 'live';
             currentTurn.inputTotal += e.delta.input;
             currentTurn.out += e.delta.output;
+            if (e.thinking !== null) {
+              currentTurn.thinking += e.thinking;
+              currentTurn.thinkingReported = true;
+            }
             currentTurn.apiCalls++;
             currentTurn.cacheTotals.read += e.delta.cacheRead;
             currentTurn.cacheTotals.created += e.delta.cacheCreation;
@@ -1092,6 +1114,8 @@ export function createSessionTree(opts: { windowFor: WindowFor; mainModel?: stri
           cacheTotals: { read: 0, created: 0 },
           inputTotal: 0,
           out: 0,
+          thinking: 0,
+          thinkingReported: false,
           weighted: 0,
           skillTurns: new Map(),
           skillInvokes: new Map(),
@@ -1745,6 +1769,7 @@ export function createSessionTree(opts: { windowFor: WindowFor; mainModel?: stri
         state,
         cutoff: t.cutoff,
         durationMs: t.durationMs,
+        thinking: t.thinkingReported ? t.thinking : null,
         messageCount: t.messageCount,
         apiCalls: t.apiCalls,
         deltaFill: t.fillEnd - prevFill,
@@ -2051,6 +2076,7 @@ export function createSessionTree(opts: { windowFor: WindowFor; mainModel?: stri
         cacheTotals: { ...cacheTotals },
         inputTotal: usageInput,
         outputTotal: usageOutput,
+        thinkingTotal: usageThinkingReported ? usageThinking : null,
         weighted: weightedMain,
         weightedByModel: [...mainWeightedByModel]
           .map(([model, weight]) => ({ model, weight }))

--- a/apps/server/src/core/types.ts
+++ b/apps/server/src/core/types.ts
@@ -328,6 +328,17 @@ interface EventBase {
 export interface UsageEvent extends EventBase {
   type: 'usage';
   delta: TokenCounts;
+  /**
+   * Of `delta.output`, the part the model spent thinking (`message.usage.
+   * output_tokens_details.thinking_tokens`). Deliberately NOT a fifth member of `TokenCounts`:
+   * it is a SPLIT of output, not a peer of it, and beside the four counters that do sum to the
+   * total it would eventually be added to one of them. Null when the call carries no split — the shape Claude Code writes on a
+   * `<synthetic>` line, which is not a model call at all (measured 2026-08-29 over 2.1.237+: the
+   * object is on 200 of 200 haiku, 12,233 of 12,233 opus and 650 of 650 sonnet lines, and every
+   * null is synthetic). A model that did no thinking reports 0, so zero and null are different
+   * answers and must stay so.
+   */
+  thinking: number | null;
   fill: number; // last absolute input + cacheRead + cacheCreation
   /**
    * Reasoning effort this call ran at, from the assistant line's ROOT `effort` (not inside

--- a/apps/server/src/server/call-io.ts
+++ b/apps/server/src/server/call-io.ts
@@ -22,6 +22,12 @@ export interface CallIO {
   callId: string;
   model: string | null;
   usage: TokenCounts | null;
+  /**
+   * Of `usage.output`, the part the call spent thinking. Null when the line reported no split:
+   * Claude Code writes `output_tokens_details: null` as well as the object, and a call that did
+   * no thinking writes 0, so the two must stay distinguishable.
+   */
+  thinking: number | null;
   input: CallSide;
   output: CallSide;
   /** True when the output contains a tool_use — the viewer renders it verbatim (code) not markdown. */
@@ -47,6 +53,9 @@ export interface CallIO {
 
 const CAP = 20000;
 
+function numOrNull(v: unknown): number | null {
+  return typeof v === 'number' && Number.isFinite(v) ? v : null;
+}
 function num(v: unknown): number {
   return typeof v === 'number' && Number.isFinite(v) ? v : 0;
 }
@@ -126,6 +135,7 @@ function scanForCall(lines: string[], callId: string, cap: number): CallIO | nul
   // Root-level on the assistant line, not inside `message` — verified across 977 files.
   const effort = typeof first.effort === 'string' && first.effort.length > 0 ? first.effort : null;
   let usage: TokenCounts | null = null;
+  let thinking: number | null = null;
   const u = first.message?.usage;
   if (u && typeof u === 'object') {
     usage = {
@@ -134,6 +144,10 @@ function scanForCall(lines: string[], callId: string, cap: number): CallIO | nul
       cacheRead: num(u.cache_read_input_tokens),
       cacheCreation: num(u.cache_creation_input_tokens),
     };
+    // Read through the container rather than off it: `output_tokens_details` is either an object
+    // or null, and reading `.thinking_tokens` off the null shape throws.
+    const det = (u as Record<string, unknown>).output_tokens_details;
+    thinking = det && typeof det === 'object' ? numOrNull((det as Record<string, unknown>).thinking_tokens) : null;
   }
   const outParts: string[] = [];
   // The intent is collected per LINE, because the stop_reason that tells an intent from the
@@ -181,6 +195,7 @@ function scanForCall(lines: string[], callId: string, cap: number): CallIO | nul
     model,
     effort,
     usage,
+    thinking,
     input: side(input, cap),
     output: side(outParts.join('\n'), cap),
     outputHasTools,

--- a/apps/server/src/server/parser.ts
+++ b/apps/server/src/server/parser.ts
@@ -323,6 +323,14 @@ export function parseLine(
         cacheRead: num(usage.cache_read_input_tokens),
         cacheCreation: num(usage.cache_creation_input_tokens),
       };
+      // `output_tokens_details` is EITHER an object or null, so reading `.thinking_tokens` off it
+      // directly throws on the null one. Measured 2026-08-29 over 2.1.237+: every line from a real
+      // model carries the object (200/200 haiku, 12,233/12,233 opus, 650/650 sonnet) and every
+      // null sits on a `<synthetic>` line, which made no call. Null is therefore "nothing was
+      // asked of a model", not zero: a model that did no thinking reports 0.
+      const details = usage.output_tokens_details;
+      const thinking =
+        details && typeof details === 'object' ? numOrNull((details as Record<string, unknown>).thinking_tokens) : null;
       const callId = typeof d.message?.id === 'string' ? d.message.id : null;
       const effort = typeof d.effort === 'string' && d.effort.length > 0 ? d.effort : null;
       // `<synthetic>` is not a model — it is the placeholder Claude Code stamps on assistant lines
@@ -336,6 +344,7 @@ export function parseLine(
         type: 'usage',
         ...base,
         delta,
+        thinking,
         fill: delta.input + delta.cacheRead + delta.cacheCreation,
         callId,
         effort,

--- a/apps/server/src/server/schema-contract.ts
+++ b/apps/server/src/server/schema-contract.ts
@@ -183,6 +183,28 @@ export const CLAIMS: Claim[] = [
       }),
   },
   {
+    id: 'C29',
+    scene: 1,
+    describe: 'message.usage.output_tokens_details.thinking_tokens splits the output figure',
+    reader: 'server/parser.ts:parseLine, server/call-io.ts:readCallIO',
+    investigate:
+      'the Session card and the call drawer split their Output row with it. If it goes, the split silently stops being drawn and Output goes back to being a number whose larger part nobody reads as an answer (39% of it on a median call).',
+    kind: 'gesture',
+    provoked: (ctx) => typed(ctx, 'assistant').length > 0,
+    // The container is asserted on a line that REACHED a model, never on any assistant line:
+    // `<synthetic>` lines carry `output_tokens_details: null`, and measured 2026-08-29 over
+    // 2.1.237+ that is the only null there is (the object is on 200/200 haiku, 12,233/12,233
+    // opus, 650/650 sonnet). Reading the whole set would let one synthetic line satisfy a claim
+    // about model calls.
+    holds: (ctx) =>
+      anyAssistant(ctx, (d) => {
+        if (typeof d?.message?.model !== 'string' || d.message.model === '<synthetic>') return false;
+        const det = d?.message?.usage?.output_tokens_details;
+        return !!det && typeof det === 'object' && typeof det.thinking_tokens === 'number';
+      }),
+  },
+
+  {
     id: 'C3',
     scene: 1,
     describe: 'message.id identifies the API call',

--- a/apps/server/src/server/schema-known-fields.ts
+++ b/apps/server/src/server/schema-known-fields.ts
@@ -36,7 +36,16 @@ import { cliRoot } from './roots.ts';
  * the set of containers the parser dereferences — add a path here when it starts
  * reading a new one.
  */
-export const OBSERVED_CONTAINERS = ['message', 'message.usage', 'toolUseResult', 'compactMetadata', 'origin'] as const;
+export const OBSERVED_CONTAINERS = [
+  'message',
+  'message.usage',
+  // The parser dereferences this one for `thinking_tokens`, so without it here the radar would be
+  // blind INSIDE it: a field added beside thinking_tokens would never be reported.
+  'message.usage.output_tokens_details',
+  'toolUseResult',
+  'compactMetadata',
+  'origin',
+] as const;
 
 /** Keys observed per line type, plus the keys seen inside each {@link OBSERVED_CONTAINERS} path. */
 export interface ObservedSchema {

--- a/apps/server/tests/golden-transcript.test.ts
+++ b/apps/server/tests/golden-transcript.test.ts
@@ -141,6 +141,27 @@ const assistant = (uuid: string, fill: number, out = 100) =>
       },
     },
   });
+// The same call, carrying the split of `output_tokens` Claude Code writes as
+// `usage.output_tokens_details`. Both real shapes are reachable: an OBJECT with `thinking_tokens`,
+// and `null`. Measured 2026-08-29 over 1046 session files — 22,995 lines carry the object and 9
+// carry null, so a reader that dereferences without checking meets the null one eventually.
+const assistantThinking = (uuid: string, fill: number, out: number, details: { thinking_tokens: number } | null) =>
+  JSON.stringify({
+    type: 'assistant',
+    uuid,
+    timestamp: '2026-07-14T10:00:05.000Z',
+    message: {
+      role: 'assistant',
+      model: 'claude-opus-4-8',
+      usage: {
+        input_tokens: 10,
+        output_tokens: out,
+        cache_read_input_tokens: fill - 10,
+        cache_creation_input_tokens: 0,
+        output_tokens_details: details,
+      },
+    },
+  });
 // Field names taken from a real line: {type:'system', subtype:'turn_duration', durationMs, messageCount}
 const turnDuration = (uuid: string) =>
   JSON.stringify({
@@ -817,6 +838,7 @@ test('golden transcript: Token usage sums every call in the scope, by API catego
     output: 200,
     cacheRead: 445_000,
     cacheWrite: 187_203,
+    thinking: null,
     total: 632_419,
   });
   assert.deepEqual(snap.main.cacheTotals, { read: 445_000, created: 187_203 });
@@ -828,6 +850,7 @@ test('golden transcript: Token usage sums every call in the scope, by API catego
     output: 200,
     cacheRead: 445_000,
     cacheWrite: 187_203,
+    thinking: null,
     total: 632_419,
   });
 
@@ -4361,4 +4384,82 @@ test('golden transcript: the Trace closes a desktop-hosted turn too, not only th
     traceTurns.map((t) => t.state),
     'and the two surfaces never disagree about a turn',
   );
+});
+
+// ── The thinking split of output_tokens ─────────────────────────────────────────────────────
+// Claude Code reports how much of a call's output was reasoning. On a median call it is 39% of
+// the figure the Session card labels `Output` (p50 0.389, p90 0.809, >0 on 70.3% of 22,995 calls
+// measured 2026-08-29), so the card was stating a number whose larger part nobody reads as an
+// answer. What follows asserts the three things a reader can be wrong about.
+
+test('golden transcript: thinking sums over the session and never joins the total', () => {
+  const snap = timelineOf([
+    typed('u1', 'first prompt'),
+    assistantThinking('a1', 40_000, 100, { thinking_tokens: 40 }),
+    assistantThinking('a2', 45_000, 300, { thinking_tokens: 120 }),
+    turnDuration('t1'),
+  ]);
+
+  const u = tokenUsage(snap.main);
+  assert.equal(u.output, 400, 'output is the whole of it, unchanged');
+  assert.equal(u.thinking, 160, 'thinking is summed across the calls');
+  assert.equal(
+    u.total,
+    u.input + u.cacheWrite + u.cacheRead + u.output,
+    'thinking is INSIDE output, so adding it to the hero would count those tokens twice',
+  );
+});
+
+test('golden transcript: a scoped turn reports ITS thinking, not the session-wide figure', () => {
+  // The trap this catches: `scopeToTurn` overrides `outputTotal` with the turn's, so a
+  // `thinkingTotal` left to the spread would draw the SESSION's reasoning against ONE turn's
+  // output — a ratio that is wrong in a way nothing on screen would reveal.
+  const snap = timelineOf([
+    typed('u1', 'first prompt'),
+    assistantThinking('a1', 40_000, 100, { thinking_tokens: 40 }),
+    turnDuration('t1'),
+    typed('u2', 'second prompt'),
+    assistantThinking('a2', 45_000, 900, { thinking_tokens: 600 }),
+    turnDuration('t2'),
+  ]);
+
+  assert.equal(tokenUsage(snap.main).thinking, 640, 'the session sums both turns');
+  const first = tokenUsage(scopeToTurn(snap, snap.turnList[0]!.index).main);
+  assert.equal(first.output, 100);
+  assert.equal(first.thinking, 40, "the first turn's own reasoning");
+  const second = tokenUsage(scopeToTurn(snap, snap.turnList[1]!.index).main);
+  assert.equal(second.output, 900);
+  assert.equal(second.thinking, 600);
+});
+
+test('golden transcript: output_tokens_details null is not zero, and does not throw', () => {
+  // Both are real shapes. Reported-as-zero means the call did no thinking; not reported at all
+  // means the call said nothing about it, and a card that prints `0` for the second one states
+  // a fact Claude Code never gave it.
+  const none = timelineOf([
+    typed('u1', 'first prompt'),
+    assistantThinking('a1', 40_000, 100, null),
+    turnDuration('t1'),
+  ]);
+  assert.equal(tokenUsage(none.main).thinking, null, 'nothing reported stays null');
+  assert.equal(none.turnList[0]!.thinking, null);
+
+  const zero = timelineOf([
+    typed('u1', 'first prompt'),
+    assistantThinking('a1', 40_000, 100, { thinking_tokens: 0 }),
+    turnDuration('t1'),
+  ]);
+  assert.equal(tokenUsage(zero.main).thinking, 0, 'a reported zero is a fact, not an absence');
+  assert.equal(zero.turnList[0]!.thinking, 0);
+});
+
+test('golden transcript: one call reporting nothing does not erase what the others reported', () => {
+  const snap = timelineOf([
+    typed('u1', 'first prompt'),
+    assistantThinking('a1', 40_000, 100, { thinking_tokens: 40 }),
+    assistantThinking('a2', 45_000, 300, null),
+    turnDuration('t1'),
+  ]);
+  assert.equal(tokenUsage(snap.main).output, 400);
+  assert.equal(tokenUsage(snap.main).thinking, 40, 'the split covers the calls that stated one');
 });

--- a/apps/server/tests/graph-derive.test.ts
+++ b/apps/server/tests/graph-derive.test.ts
@@ -23,6 +23,7 @@ function turn(over: Partial<TurnNode> = {}): TurnNode {
   return {
     index: 1,
     prompt: 'do the thing',
+    thinking: null,
     command: null,
     kind: 'work',
     startedAt: null,

--- a/apps/server/tests/graph-shell.test.ts
+++ b/apps/server/tests/graph-shell.test.ts
@@ -22,6 +22,7 @@ function baseSnapshot() {
       cacheTotals: { read: 4_120_000, created: 380_000 },
       inputTotal: 90_000,
       outputTotal: 60_000,
+      thinkingTotal: null as number | null,
       weighted: 0,
       weightedByModel: [],
     },
@@ -468,6 +469,7 @@ function makeTurn(index: number, opts: Partial<TurnNode> = {}): TurnNode {
   return {
     index,
     prompt: 'Turn ' + index + ' prompt',
+    thinking: null,
     startedAt: '2026-07-14T10:00:00Z',
     kind: opts.kind ?? 'work',
     command: opts.command ?? null,
@@ -2707,6 +2709,35 @@ test('Session card: footer carries whole-session turn KPIs and the Explore toggl
   assert.equal(findByClass(foot, 'obtn').length, 0, 'no Explore button without timeline entries');
 
   view.destroy();
+  g.document = prevDoc;
+});
+
+test('Session card: the Output row carries the thinking split, and only when there is one', () => {
+  const g = globalThis as any;
+  const prevDoc = g.document;
+  g.document = fakeDoc();
+
+  // Reported: the bar is drawn, inside the ledger, so it lines up with the row it splits.
+  const withSplit = g.document.createElement();
+  const snap = baseSnapshot();
+  snap.main.outputTotal = 1_000;
+  snap.main.thinkingTotal = 390;
+  const a = createGraph(withSplit, { snapshot: () => snap, onChange: () => () => {}, onEvent: () => () => {} });
+  const led = findByClass(findByClass(withSplit, 'burnw')[0], 'led')[0];
+  const split = findByClass(led, 'tsplit')[0];
+  assert.ok(split, 'the split is drawn inside the ledger, not appended after it');
+  assert.match(textOf(split), /thinking/, 'and it names which half is which');
+  a.destroy();
+
+  // Not reported: nothing is drawn. A `0 / 0` bar would state a fact Claude Code never gave.
+  const without = g.document.createElement();
+  const snap2 = baseSnapshot();
+  snap2.main.outputTotal = 1_000;
+  snap2.main.thinkingTotal = null;
+  const b = createGraph(without, { snapshot: () => snap2, onChange: () => () => {}, onEvent: () => () => {} });
+  assert.equal(findByClass(without, 'tsplit').length, 0, 'no split when the scope reported none');
+  b.destroy();
+
   g.document = prevDoc;
 });
 

--- a/apps/server/tests/schema-contract.test.ts
+++ b/apps/server/tests/schema-contract.test.ts
@@ -8,7 +8,10 @@ import { CLAIMS, CTRLB_COMMAND, claimsForScene, ECHO_MARKER, SCENE1_MARKER } fro
  * The scene-1 lines a real driven session produces. The SHAPE is not invented:
  * it is what the 2026-07-17 probe run actually wrote on CC 2.1.212 (verified
  * `origin.kind=human`, `promptSource=typed`, `system/turn_duration`,
- * `message.usage`, `entrypoint=cli`). Content is synthetic; shape is a fact.
+ * `message.usage`, `entrypoint=cli`), plus `output_tokens_details`, which Claude
+ * Code added later and writes on every line from a real model (measured 2026-08-29
+ * over 2.1.237+: 200/200 haiku, 12,233/12,233 opus, 650/650 sonnet). Content is
+ * synthetic; shape is a fact, and the fact moved.
  */
 const REAL_SHAPE_LINES = [
   {
@@ -34,7 +37,13 @@ const REAL_SHAPE_LINES = [
       model: 'claude-haiku-4-5-20251001',
       stop_reason: 'end_turn',
       content: [{ type: 'text', text: 'ok' }],
-      usage: { input_tokens: 4, output_tokens: 5, cache_read_input_tokens: 100, cache_creation_input_tokens: 20 },
+      usage: {
+        input_tokens: 4,
+        output_tokens: 5,
+        cache_read_input_tokens: 100,
+        cache_creation_input_tokens: 20,
+        output_tokens_details: { thinking_tokens: 2 },
+      },
     },
     uuid: 'a-1',
   },
@@ -139,6 +148,33 @@ test('removing origin.kind from a real turn makes C1 BROKEN — the guard bites'
   const c1 = r.find((x) => x.claim.id === 'C1')!;
   assert.equal(c1.outcome, 'BROKEN');
   assert.ok(isBroken(r));
+});
+
+test('removing output_tokens_details makes C29 BROKEN — the split stops being drawn', () => {
+  // A guard that must bite on the SHAPE, not on the value: a model that did no thinking writes
+  // `thinking_tokens: 0`, which is a fact and must keep holding. What breaks the claim is the
+  // container going away, since the reader then has nothing to split Output with.
+  const lines = structuredClone(REAL_SHAPE_LINES);
+  delete (lines[1] as any).message.usage.output_tokens_details;
+  const c29 = evaluate(claimsForScene(1), ctxOf(lines)).find((x) => x.claim.id === 'C29')!;
+  assert.equal(c29.outcome, 'BROKEN');
+});
+
+test('C29 holds on a call that reports zero thinking', () => {
+  const lines = structuredClone(REAL_SHAPE_LINES);
+  (lines[1] as any).message.usage.output_tokens_details = { thinking_tokens: 0 };
+  const c29 = evaluate(claimsForScene(1), ctxOf(lines)).find((x) => x.claim.id === 'C29')!;
+  assert.equal(c29.outcome, 'HOLDS');
+});
+
+test('a synthetic line alone cannot satisfy C29', () => {
+  // `<synthetic>` lines carry `output_tokens_details: null` and made no call. Reading any
+  // assistant line would let one of them stand in for the model call the claim is about.
+  const lines = structuredClone(REAL_SHAPE_LINES);
+  (lines[1] as any).message.model = '<synthetic>';
+  (lines[1] as any).message.usage.output_tokens_details = null;
+  const c29 = evaluate(claimsForScene(1), ctxOf(lines)).find((x) => x.claim.id === 'C29')!;
+  assert.equal(c29.outcome, 'BROKEN');
 });
 
 test('removing turn_duration makes C4 BROKEN', () => {

--- a/apps/server/tests/selectors.test.ts
+++ b/apps/server/tests/selectors.test.ts
@@ -93,6 +93,7 @@ test('tokenUsage: the four API categories and their total, from the scope sums',
     cacheTotals: { read: 400_000, created: 200_000 },
     inputTotal: 12_000,
     outputTotal: 3_000,
+    thinkingTotal: 1_200,
     weighted: 0,
     weightedByModel: [],
   } as any;
@@ -101,6 +102,8 @@ test('tokenUsage: the four API categories and their total, from the scope sums',
     cacheWrite: 200_000,
     cacheRead: 400_000,
     output: 3_000,
+    // Inside `output`, so the total is unchanged by it. That is the point of the assertion.
+    thinking: 1_200,
     total: 615_000,
   });
 });
@@ -110,10 +113,11 @@ test('tokenUsage: an empty scope is all zeros, total zero', () => {
     cacheTotals: { read: 0, created: 0 },
     inputTotal: 0,
     outputTotal: 0,
+    thinkingTotal: null,
     weighted: 0,
     weightedByModel: [],
   } as any;
-  assert.deepEqual(tokenUsage(m), { input: 0, cacheWrite: 0, cacheRead: 0, output: 0, total: 0 });
+  assert.deepEqual(tokenUsage(m), { input: 0, cacheWrite: 0, cacheRead: 0, output: 0, thinking: null, total: 0 });
 });
 
 test('subagentsByWeight: ranks by tool count desc, without mutating the input', () => {

--- a/apps/server/tests/view-shell.test.ts
+++ b/apps/server/tests/view-shell.test.ts
@@ -27,6 +27,7 @@ function stubs() {
       cacheTotals: { read: 0, created: 0 },
       inputTotal: 0,
       outputTotal: 0,
+      thinkingTotal: null,
       weighted: 0,
       weightedByModel: [],
     },

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,22 @@ Everything released before `0.20.0` — including the pre-publication developmen
 
 ## Unreleased
 
+### Added
+
+- The **Output** row of the Session card splits into the part the model spent reasoning and the
+  part it wrote as an answer, and the same split appears in the call drawer for a single call.
+  Claude Code reports it as `usage.output_tokens_details.thinking_tokens`, and it is a large share
+  of a figure that read as the answer: over 22,995 calls measured 2026-08-29 the reasoning is 39%
+  of output on a median call, above 80% on a tenth of them, and greater than zero on 70%. Two
+  tones of one hue rather than a fifth colour, because it is a subset of the row above and adding
+  it to the hero would count those tokens twice. A call that did no thinking reports zero, a
+  `<synthetic>` line reports null, and null draws nothing rather than a zero nobody asserted.
+- Contract claim **C29** holds Claude Code to that field, on a line that reached a real model:
+  every model line carries it (200 of 200 haiku, 12,233 of 12,233 opus, 650 of 650 sonnet,
+  measured over 2.1.237+), and every null belongs to a `<synthetic>` line that made no call. The
+  radar's `OBSERVED_CONTAINERS` gains `message.usage.output_tokens_details`, without which it
+  would be blind to anything added beside `thinking_tokens`.
+
 ### Fixed
 
 - Custom slash commands are read as commands again. Claude Code 2.1.237 began writing

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -493,7 +493,7 @@ The parser flattens the raw log into a small set of events consumers care about:
 
 | Event             | Source field(s)                                              | Meaning                          |
 |-------------------|-------------------------------------------------------------|----------------------------------|
-| `usage`           | `message.usage` + `message.model` + root `effort`           | context fill + per-call delta, and the model/effort THAT CALL ran on; for a line flagged `isApiErrorMessage` also `apiError` (status + the message shown to the user), meaning the call FAILED |
+| `usage`           | `message.usage` + `message.model` + root `effort`           | context fill + per-call delta, and the model/effort THAT CALL ran on; `thinking` carries `usage.output_tokens_details.thinking_tokens`, the part of `output` spent reasoning, and is null when the line reported no split; for a line flagged `isApiErrorMessage` also `apiError` (status + the message shown to the user), meaning the call FAILED |
 | `attribution`     | `attributionSkill` / `attributionMcpServer` / `attributionMcpTool` | what is filling the context (skill turns are counted from this) |
 | `compaction`      | `compactMetadata` / `isCompactSummary`                     | a compaction (context deflate)   |
 | `user-turn`       | a user line that is `origin.kind: 'human'`, **or** carries `<command-name>`, **or** is the plain text of a command (see below) | the user sent something, which opens a timeline entry; `prompt` is the text (a command's `<command-args>`, or its arguments), `command` the slash command that carried it, `promptId` the invocation the line belongs to |
@@ -613,6 +613,15 @@ The **Session** card's ledger reports the four categories Anthropic names in the
 | Cache write  | `cache_creation_input_tokens`  |
 | Cache read   | `cache_read_input_tokens`      |
 | Output       | `output_tokens`                |
+
+The Output row is split in place into the part the model spent reasoning and the part it wrote
+as an answer, from `usage.output_tokens_details.thinking_tokens`. It is drawn as two tones of one
+hue rather than a fifth colour, because it is a subset of the row above it: adding it to the hero
+would count those tokens twice. The same split appears in the call drawer, on one call, which is
+the finer reading of the two: a session's median hides calls that were almost all reasoning and
+calls that were none. Drawn only when the scope reported a split at all. A call that did no
+thinking reports zero, a `<synthetic>` line reports null, and null renders as nothing rather than
+as a zero nobody asserted.
 
 The four category rows are the **main thread's** consumption and are headed *main session*,
 because they and the Subagents row measure different things, a category versus an actor, and

--- a/docs/features.md
+++ b/docs/features.md
@@ -170,6 +170,11 @@ has **worked**: the sum of its turns, not the wall-clock span. The two differ by
 Three equal-height cards: **Session** (tokens by API category plus turn KPIs),
 **Skills used** beside **Commands**, and **Changed files**.
 
+In the Session card the **Output** row splits into reasoning and answer, so the figure is
+no longer one number whose larger part is not the answer: over 22,995 calls measured on
+2026-08-29 the reasoning is 39% of output on a median call, and above 80% on a tenth of them.
+The same split is in the call drawer, where it is one call rather than a session's average.
+
 In the Session card the main-thread categories are headed *main session*, and the
 **Subagents** figure below them opens into a **by-model** bar, so the subagent tokens
 split by which model actually burned them (charged per call, so a subagent that ran


### PR DESCRIPTION
## What

The Session card's **Output** row now splits into the part the model spent reasoning and the part it wrote as an answer, and the same split appears in the call drawer for a single call. The source is `usage.output_tokens_details.thinking_tokens`, which Claude Code has been reporting all along.

Two places because they are two different readings: the ledger follows the scope, so selecting a turn shows that turn's split; the drawer answers it for one call, which is where a session's median stops hiding the calls that were almost all reasoning and the calls that were none.

## Why

`Output` was a single number, and on a median call 39% of it is not the answer. Measured 2026-08-29 over 22,995 calls:

| | thinking as a share of output |
|---|---|
| p50 | **0.389** |
| p90 | 0.809 |
| max | 0.998 |
| greater than zero | 70.3% of calls |

## Choices worth reviewing

**Two tones of one hue, not a fifth colour.** `thinking` is a subset of the row above it, and the four categories beside it are the ones that sum to the hero. A new colour off the category palette would read as a fifth thing that adds to the total.

**Not a fifth member of `TokenCounts`.** It is a field of its own on the usage event, so no future sum can pick it up by sitting next to the four that do add up. `tokenUsage` returns it outside `total` for the same reason, and one golden-transcript case asserts exactly that.

**Zero and null are different answers.** A model that did no thinking reports `0`; a `<synthetic>` line, which made no model call, reports `null`. Null draws nothing rather than a zero Claude Code never asserted. Measured over 2.1.237+, every line from a real model carries the object (200 of 200 haiku, 12,233 of 12,233 opus, 650 of 650 sonnet) and every null is synthetic.

**`scopeToTurn` sets `thinkingTotal` explicitly.** Left to the spread it would carry the SESSION's thinking through while `outputTotal` is overridden with the turn's, and the resulting ratio is wrong in a way nothing on screen reveals. That was caught by writing the test before trusting the code, and it is one of the cases below.

## The guard

Claim **C29** holds Claude Code to the field, asserted on a line that reached a real model rather than on any assistant line, so a synthetic one cannot stand in for it. Three contract tests: removing the container makes it BROKEN, a reported zero still HOLDS, and a synthetic line alone cannot satisfy it.

`OBSERVED_CONTAINERS` gains `message.usage.output_tokens_details`, since the parser now dereferences it and the radar would otherwise be blind to anything added beside `thinking_tokens`. It already shows the new path in its report.

`known-fields.json` is deliberately NOT accepted in this PR. `--update` rewrites the whole set, which would silence the radar on the seven other new fields nobody has ruled on yet; accepting belongs with the decision on all of them.

## Tests

Four golden-transcript cases, raw jsonl through the real parser and the real reducer: the session sum, the per-turn scoping, the null shape (which must not throw and must not become zero), and a mixed transcript where one call reports nothing. Plus a rendered-DOM case asserting the bar appears inside the ledger when a split was reported and nowhere at all when it was not.

Falsified rather than assumed. Removing the `scopeToTurn` line reds exactly the scoping case; removing the parser read reds five.

## Verification

`bun run test` 1783 pass, 0 fail. `bun run lint` and `bun run typecheck` clean. The client bundle is rebuilt and committed, since it is tracked. `docs/architecture.md`, `docs/features.md` and `docs/CHANGELOG.md` move in the same commit as the code.

Not done: no browser was driven. The rendering is asserted through the shell harness, not through a real click.
