### PR TITLE
Accept the schema radar's known set, with each field decided

### DIFF
--- a/apps/server/data/known-fields.json
+++ b/apps/server/data/known-fields.json
@@ -6,6 +6,19 @@
       "sessionId",
       "type"
     ],
+    "artifact-autoreact-ledger": [
+      "accountUuid",
+      "artifacts",
+      "sessionId",
+      "type",
+      "v"
+    ],
+    "artifact-comment-monitor": [
+      "artifacts",
+      "sessionId",
+      "type",
+      "v"
+    ],
     "assistant": [
       "agentId",
       "apiError",
@@ -35,6 +48,11 @@
       "uuid",
       "version"
     ],
+    "atis-latch": [
+      "atis",
+      "sessionId",
+      "type"
+    ],
     "attachment": [
       "agentId",
       "attachment",
@@ -52,6 +70,33 @@
       "uuid",
       "version"
     ],
+    "bridge-session": [
+      "bridgeSessionId",
+      "lastSequenceNum",
+      "ownerAccountUuid",
+      "ownerOrganizationUuid",
+      "sessionId",
+      "type"
+    ],
+    "cost-state": [
+      "hasUnknownModelCost",
+      "modelUsage",
+      "sessionId",
+      "startTime",
+      "totalAPIDuration",
+      "totalAPIDurationWithoutRetries",
+      "totalCostUSD",
+      "totalDuration",
+      "totalLinesAdded",
+      "totalLinesRemoved",
+      "totalToolDuration",
+      "type"
+    ],
+    "custom-title": [
+      "customTitle",
+      "sessionId",
+      "type"
+    ],
     "file-history-delta": [
       "backup",
       "messageId",
@@ -67,6 +112,7 @@
       "type"
     ],
     "frame-link": [
+      "artifactCount",
       "frameUrl",
       "path",
       "sessionId",
@@ -101,19 +147,9 @@
     "queue-operation": [
       "content",
       "operation",
+      "reason",
       "sessionId",
       "timestamp",
-      "type"
-    ],
-    "result": [
-      "agentId",
-      "key",
-      "result",
-      "type"
-    ],
-    "started": [
-      "agentId",
-      "key",
       "type"
     ],
     "system": [
@@ -146,6 +182,7 @@
       "timestamp",
       "toolUseID",
       "type",
+      "url",
       "userType",
       "uuid",
       "version"
@@ -161,6 +198,7 @@
       "isMeta",
       "isSidechain",
       "isVisibleInTranscriptOnly",
+      "mcpMeta",
       "message",
       "origin",
       "parentUuid",
@@ -168,6 +206,7 @@
       "promptId",
       "promptSource",
       "queuePriority",
+      "queueSkipAttachments",
       "sessionId",
       "session_id",
       "slug",
@@ -177,11 +216,23 @@
       "toolDenialKind",
       "toolEndsTurn",
       "toolUseResult",
+      "turnCompanion",
       "type",
       "userFeedback",
       "userType",
       "uuid",
       "version"
+    ],
+    "result": [
+      "agentId",
+      "key",
+      "result",
+      "type"
+    ],
+    "started": [
+      "agentId",
+      "key",
+      "type"
     ],
     "agent-name": [
       "agentName",
@@ -212,9 +263,13 @@
       "input_tokens",
       "iterations",
       "output_tokens",
+      "output_tokens_details",
       "server_tool_use",
       "service_tier",
       "speed"
+    ],
+    "message.usage.output_tokens_details": [
+      "thinking_tokens"
     ],
     "toolUseResult": [
       "afkTimeoutMs",
@@ -224,8 +279,12 @@
       "annotations",
       "answers",
       "appliedLimit",
+      "artifactRead",
+      "artifact_id",
       "artifacts",
+      "audience",
       "authUrl",
+      "background",
       "backgroundCwdHint",
       "backgroundTaskId",
       "backgroundedByUser",
@@ -238,6 +297,7 @@
       "command",
       "commandName",
       "content",
+      "contract",
       "count",
       "countIsComplete",
       "dangerouslyDisableSandbox",
@@ -256,6 +316,7 @@
       "isAsync",
       "isImage",
       "level",
+      "listing",
       "liveSubscription",
       "localSent",
       "matches",
@@ -309,6 +370,7 @@
       "task_id",
       "task_type",
       "tasks",
+      "threads",
       "timedOutAfterMs",
       "timeoutMs",
       "title",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,26 @@ Everything released before `0.20.0` — including the pre-publication developmen
 
 ## Unreleased
 
+### Changed
+
+- The schema radar's known set is accepted, so it reports nothing again. What each newly seen
+  field was decided to be, rather than merely accepted: `output_tokens_details.thinking_tokens` is
+  READ (it splits the Output row). Everything else is knowingly ignored, each for a measured
+  reason. `atis-latch` carries one field, `atis`, and it is the empty string on all 2,377 lines.
+  `turnCompanion` marks lines that all carry `isMeta: true`, which the prompt gate already
+  excludes. `mcpMeta` holds server info seedeep already attributes through
+  `attributionMcpServer` / `attributionMcpTool`. `queue-operation.reason` has one value across 5
+  occurrences of 2,919 queue operations. `queueSkipAttachments` is queue behaviour, not an
+  observable fact about a session. `bridge-session` and the `bridge_status` line are a feature
+  seedeep does not report.
+- `cost-state` is ignored in full, and not because of the dollars. Its scope is the PROCESS, while
+  seedeep's unit is the session file: `totalDuration` measures how long a terminal stayed open
+  (23.7h against 4 minutes of API and tool time on one real session), and `modelUsage` ranges from
+  0.18x to 1.95x of the tokens in the file it belongs to, naming models that file never used.
+  Two numbers that disagree on one screen with neither being wrong is the trap the Changed files
+  card was moved off this same ledger to avoid. It is also absent from 81 of 93 sessions on
+  2.1.251 and written at exit.
+
 ### Added
 
 - The **Output** row of the Session card splits into the part the model spent reasoning and the


### PR DESCRIPTION
## What

`known-fields.json` is regenerated, so the radar reports nothing again. The point is not the silence but what it records: every field it had been raising is now decided, and the reason for each is written down where it can be read back.

| Field | Decision |
|---|---|
| `message.usage.output_tokens_details.thinking_tokens` | **read** — it splits the Output row (shipped in #76) |
| `atis-latch` | ignore — its only field, `atis`, is the empty string on all 2,377 lines |
| `user → turnCompanion` | ignore — all 65 lines carry `isMeta: true`, which the prompt gate already excludes |
| `user → mcpMeta` | ignore — seedeep attributes MCP through `attributionMcpServer` / `attributionMcpTool` |
| `queue-operation → reason` | ignore — one value, on 5 of 2,919 queue operations |
| `user → queueSkipAttachments` | ignore — queue behaviour, not an observable fact about a session |
| `bridge-session`, `system/bridge_status` | ignore — a feature seedeep does not report |
| `cost-state` | ignore in full — see below |

## Why `cost-state` goes, and why the dollars are not the reason

The dollar figure is list-price arithmetic: fitting `costUSD` against the token counters recovers round published rates ($1.00 input, $5.00 output, $1.25 cache write, $0.10 cache read per million, $10 per 1000 web searches) to within floating-point noise. A subscription is not modelled, so on a Max account it is money nobody paid. That alone made it a product decision, and it was declined.

What removes the rest of the line is scope. **`cost-state` measures a PROCESS; seedeep's unit is the session file.**

- `totalDuration` is how long the terminal stayed open. On one real session it reads 23.7h against 3.5m of API time and 0.4m of tool time, on a file whose own span is 5.3 minutes. On four of the eight longest, API plus tool is 0-1% of it.
- `modelUsage` runs from **0.18x to 1.95x** of the tokens in the file it belongs to, and names models that file never used. Above, because it reaches subagents; below, because a resumed session's file keeps a history the new process never saw. Six files carry two of these lines and one carries five, one per process.

Putting either beside a figure seedeep derives from the transcript would show two numbers that disagree, with neither being wrong. That is the trap the Changed files card was moved off this same ledger to avoid.

Coverage settles it independently: the line appears in 12 of 93 sessions on 2.1.251, first exists from 2.1.246, and 29 of 52 occurrences are the last line of their file. A surface reading it would be empty on most sessions and would appear only after you quit.

## The cost of `--update`

It rewrites the whole set, so it also accepted about 20 entries that arrived after the fields above were catalogued: `artifact-autoreact-ledger`, `artifact-comment-monitor`, `custom-title`, `frame-link.artifactCount`, and `toolUseResult.artifact_id` / `audience` / `contract` / `threads` / `artifactRead` / `background` / `listing`. Most come from the Artifact tool. A new field cannot break seedeep, so nothing is at risk, but the radar will not raise them again. That is inherent to a set that only grows, and it is stated here rather than discovered later.

## Verification

`bun run test` 1783 pass, 0 fail. `bun run lint` and `bun run typecheck` clean. The radar's own test prints an empty report.
