### PR TITLE
An automated run never notifies, and a vanished session ends its tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,8 @@ window is, with no browser tab open. ([rules](docs/tray.md))
 <img src="docs/assets/notifications.png" width="420" alt="Three tray notifications: waiting for approval on Bash, a failed API call, and a finished turn">
 
 Three events are worth interrupting you for, and each has its own switch. Nothing else
-notifies: not a subagent finishing, not a tool error.
+notifies: not a subagent finishing, not a tool error, and never an automated run, since
+nobody is sitting at a `claude -p` to get up.
 
 | Banner | Ships | Why |
 | -- | -- | -- |

--- a/apps/server/public/lib/app.js
+++ b/apps/server/public/lib/app.js
@@ -1374,7 +1374,7 @@ function el(tag, className, text) {
 function labelOf(row) {
   if (row.subject)
     return row.subject.replace(/\s+/g, " ").trim();
-  if (row.entrypoint && row.entrypoint.startsWith("sdk"))
+  if (isAutomated(row))
     return "Automated run · " + row.entrypoint;
   return "Session " + row.sessionId.slice(0, 8);
 }
@@ -2814,7 +2814,7 @@ function appendHighlighted(into, text, terms) {
 function labelOf2(r) {
   if (r.subject && r.subject.trim())
     return r.subject.replace(/\s+/g, " ").trim();
-  if (r.entrypoint && r.entrypoint.startsWith("sdk"))
+  if (isAutomated(r))
     return "Automated run · " + r.entrypoint;
   return "Session " + r.sessionId.slice(0, 8);
 }
@@ -10117,10 +10117,15 @@ var navMenu = createNavMenu(navEl, {
   onSwitch: switchTo
 });
 var dropdown = createDropdown(dropdownEl, { onOpen: openFromDropdown });
+function readRoster(r) {
+  if (!r.ok)
+    throw new Error(`roster reading failed: ${r.status}`);
+  return r.json();
+}
 var ROSTER_POLL_MS = 3000;
 var roster = createRoster({
-  fetchCatalogue: (signal) => authFetch("/api/sessions", { signal }).then((r) => r.json()),
-  fetchLive: (signal) => authFetch("/api/live", { signal }).then((r) => r.json()),
+  fetchCatalogue: (signal) => authFetch("/api/sessions", { signal }).then((r) => readRoster(r)),
+  fetchLive: (signal) => authFetch("/api/live", { signal }).then((r) => readRoster(r)),
   pollMs: ROSTER_POLL_MS
 });
 var endGuard = createEndGuard({

--- a/apps/server/public/lib/app.js
+++ b/apps/server/public/lib/app.js
@@ -1602,7 +1602,7 @@ function createIdChip(sessionId, opts = {}) {
 // apps/server/src/core/roster.ts
 function mergeRoster(catalogue, live, now = Date.now()) {
   const liveById = new Map(live.sessions.map((s) => [s.sessionId, s]));
-  const rows = catalogue.map((c) => liveById.get(c.sessionId) ?? ended(c, live.pidVisible, now));
+  const rows = catalogue.map((c) => liveById.get(c.sessionId) ?? (live.complete ? ended(c, live.pidVisible, now) : null)).filter((r) => r !== null);
   const known = new Set(catalogue.map((c) => c.sessionId));
   for (const s of live.sessions)
     if (!known.has(s.sessionId))
@@ -1687,6 +1687,7 @@ function createRoster(deps) {
   let timer = null;
   let stopped = false;
   let taken = 0;
+  let complete = false;
   const listeners = new Set;
   async function refresh() {
     let live;
@@ -1706,6 +1707,7 @@ function createRoster(deps) {
     const next = mergeRoster(catalogue, live);
     rows = next;
     taken++;
+    complete = live.complete;
     const nextKey = rosterKey(next);
     if (nextKey !== key) {
       key = nextKey;
@@ -1732,6 +1734,7 @@ function createRoster(deps) {
     },
     current: () => rows,
     readings: () => taken,
+    complete: () => complete,
     onChange(cb) {
       listeners.add(cb);
       return () => listeners.delete(cb);
@@ -10360,10 +10363,12 @@ roster.onChange((rows) => {
       }
     }
   }
-  const listed = new Set(rows.map((r) => r.sessionId));
-  for (const [sessionId, t] of openTabs)
-    if (!t.ended && !listed.has(sessionId))
-      endGuard.gone(sessionId);
+  if (roster.complete()) {
+    const listed = new Set(rows.map((r) => r.sessionId));
+    for (const [sessionId, t] of openTabs)
+      if (!t.ended && !listed.has(sessionId))
+        endGuard.gone(sessionId);
+  }
   if (rows.length !== lastPaintedLen) {
     lastPaintedLen = rows.length;
     homeView.repaint();

--- a/apps/server/public/lib/app.js
+++ b/apps/server/public/lib/app.js
@@ -79,6 +79,9 @@ var HIST_BINS = [
 function isLive(s) {
   return s.isOpen ?? s.isActive;
 }
+function isAutomated(s) {
+  return !!s.entrypoint && s.entrypoint.startsWith("sdk");
+}
 function isWorking(s) {
   return s.status === "busy" || s.status === "shell";
 }
@@ -1653,9 +1656,6 @@ function withDeadline(read, ms) {
 }
 
 // apps/server/src/client/sessions.ts
-function isAutomated(s) {
-  return !!s.entrypoint && s.entrypoint.startsWith("sdk");
-}
 function sessionsToAutoOpen(rows, known, openIds) {
   return rows.filter((s) => isLive(s) && !isAutomated(s) && !known.has(s.sessionId) && !openIds.has(s.sessionId));
 }
@@ -10355,6 +10355,10 @@ roster.onChange((rows) => {
       }
     }
   }
+  const listed = new Set(rows.map((r) => r.sessionId));
+  for (const [sessionId, t] of openTabs)
+    if (!t.ended && !listed.has(sessionId))
+      endGuard.gone(sessionId);
   if (rows.length !== lastPaintedLen) {
     lastPaintedLen = rows.length;
     homeView.repaint();

--- a/apps/server/src/client/app.ts
+++ b/apps/server/src/client/app.ts
@@ -527,6 +527,15 @@ roster.onChange((rows) => {
       }
     }
   }
+  // And the tabs the loop above cannot reach: it walks `rows`, so it only ever visits sessions
+  // the roster still lists. A session whose FILE is gone — a throwaway cwd cleaned up under it,
+  // `~/.claude/projects` pruned by hand — leaves the roster entirely, and its tab was never
+  // handed to the guard at all: it kept the live chrome for the life of the page, a turn clock
+  // ticking on a session that ended an hour ago and a pending-approval banner nothing could
+  // clear. Same confirmation window, and `stillGone` already answers this case ("gone from the
+  // roster entirely counts as gone") — it was simply never armed for it.
+  const listed = new Set(rows.map((r) => r.sessionId));
+  for (const [sessionId, t] of openTabs) if (!t.ended && !listed.has(sessionId)) endGuard.gone(sessionId);
   // Free, and NOT guarded by `booted`: Home's empty box states whether this machine has any
   // session at all, and it paints before the first roster reading lands. Without this the box
   // keeps saying "there is none on this machine" over a picker that lists one — measured on a

--- a/apps/server/src/client/app.ts
+++ b/apps/server/src/client/app.ts
@@ -548,13 +548,23 @@ roster.onChange((rows) => {
   // clear. Same confirmation window, and `stillGone` already answers this case ("gone from the
   // roster entirely counts as gone") — it was simply never armed for it.
   //
-  // Safe to arm on an EMPTY roster only because a reading that did not land never gets here: a
-  // scan that could not be made throws instead of reporting zero sessions (discovery.ts), the
-  // response is read as a failure instead of as data (`readRoster`), and the poll then serves the
-  // previous rows unchanged. Without that chain an unreadable `~/.claude/projects` would end every
-  // tab on the page while the sessions behind them were still running.
-  const listed = new Set(rows.map((r) => r.sessionId));
-  for (const [sessionId, t] of openTabs) if (!t.ended && !listed.has(sessionId)) endGuard.gone(sessionId);
+  // Guarded on the reading being WHOLE, which is the difference between this and every other line
+  // in this listener: they act on what a session IS, and a partial list still states that
+  // correctly, while this one acts on a session being ABSENT, which a partial list cannot support.
+  // Three ways a reading can fail to support it, each needing its own mechanism, because each
+  // reaches a different consumer:
+  //   - a ROOT that will not answer throws, comes back as a failed reading (`readRoster`), and
+  //     never reaches this listener at all;
+  //   - one PROJECT directory that will not answer serves the rest and says `complete: false`,
+  //     since an EACCES there is usually permanent and refusing the whole roster for as long as it
+  //     stands would be worse than the sessions it hides;
+  //   - and a catalogue entry the partial payload did not claim is dropped by `mergeRoster` rather
+  //     than reported not-live, which is the path the loop above walks and this flag never sees.
+  // Without all three an EMFILE would close tabs whose sessions are still running.
+  if (roster.complete()) {
+    const listed = new Set(rows.map((r) => r.sessionId));
+    for (const [sessionId, t] of openTabs) if (!t.ended && !listed.has(sessionId)) endGuard.gone(sessionId);
+  }
   // Free, and NOT guarded by `booted`: Home's empty box states whether this machine has any
   // session at all, and it paints before the first roster reading lands. Without this the box
   // keeps saying "there is none on this machine" over a picker that lists one — measured on a

--- a/apps/server/src/client/app.ts
+++ b/apps/server/src/client/app.ts
@@ -1,6 +1,7 @@
 import type { SessionCommits } from '../core/commit-attribution.ts';
 import { windowFor } from '../core/context-windows.ts';
 import type { SessionFiles } from '../core/file-attribution.ts';
+import type { CatalogueRecord, LivePayload } from '../core/roster.ts';
 import { createSessionTree } from '../core/session-tree.ts';
 import type { SessionCards } from '../core/tracker-cards.ts';
 import { tabLabel } from '../core/tree-format.ts';
@@ -109,6 +110,18 @@ const navMenu = createNavMenu(navEl, {
   onSwitch: switchTo,
 });
 const dropdown = createDropdown(dropdownEl, { onOpen: openFromDropdown });
+/**
+ * A roster reading, or a throw. `authFetch` resolves on any status, so a 500 — which is what a
+ * scan that could not be made answers with (see discovery.ts) — would otherwise be parsed as
+ * data, and an unparseable body is only accidentally a failure. Throwing is what puts it on the
+ * path the poll already has for a reading that did not land: keep the last good rows, retry in
+ * 3s. Serving `[]` there would say every session on the machine is gone.
+ */
+function readRoster<T>(r: Response): Promise<T> {
+  if (!r.ok) throw new Error(`roster reading failed: ${r.status}`);
+  return r.json() as Promise<T>;
+}
+
 // Named here rather than left to createRoster's default because the end-of-session
 // confirmation window below is defined RELATIVE to it: a confirmation that does not outlast
 // one poll would re-read the very same reading it is meant to check.
@@ -118,8 +131,8 @@ const ROSTER_POLL_MS = 3000;
 const roster = createRoster({
   // The signal is the roster's deadline (see READING_TIMEOUT_MS): honouring it is what lets a
   // request the network will never answer be dropped instead of held open forever.
-  fetchCatalogue: (signal) => authFetch('/api/sessions', { signal }).then((r) => r.json()),
-  fetchLive: (signal) => authFetch('/api/live', { signal }).then((r) => r.json()),
+  fetchCatalogue: (signal) => authFetch('/api/sessions', { signal }).then((r) => readRoster<CatalogueRecord[]>(r)),
+  fetchLive: (signal) => authFetch('/api/live', { signal }).then((r) => readRoster<LivePayload>(r)),
   pollMs: ROSTER_POLL_MS,
 });
 // Committing "this session is over": it costs the tab its live presentation, so it happens only
@@ -534,6 +547,12 @@ roster.onChange((rows) => {
   // ticking on a session that ended an hour ago and a pending-approval banner nothing could
   // clear. Same confirmation window, and `stillGone` already answers this case ("gone from the
   // roster entirely counts as gone") — it was simply never armed for it.
+  //
+  // Safe to arm on an EMPTY roster only because a reading that did not land never gets here: a
+  // scan that could not be made throws instead of reporting zero sessions (discovery.ts), the
+  // response is read as a failure instead of as data (`readRoster`), and the poll then serves the
+  // previous rows unchanged. Without that chain an unreadable `~/.claude/projects` would end every
+  // tab on the page while the sessions behind them were still running.
   const listed = new Set(rows.map((r) => r.sessionId));
   for (const [sessionId, t] of openTabs) if (!t.ended && !listed.has(sessionId)) endGuard.gone(sessionId);
   // Free, and NOT guarded by `booted`: Home's empty box states whether this machine has any

--- a/apps/server/src/client/compare-view.ts
+++ b/apps/server/src/client/compare-view.ts
@@ -1,5 +1,5 @@
 import type { CompareRow, CompareWindow, Comparison } from '../core/types.ts';
-import { COMPARE_TOP_N } from '../core/types.ts';
+import { COMPARE_TOP_N, isAutomated } from '../core/types.ts';
 
 // The Compare tab: which session weighed the most in a time window. The unit is a token
 // count weighted by the kind of token and by the model that spent it — NEVER a cost in dollars,
@@ -84,7 +84,7 @@ function el(tag: string, className?: string, text?: string): HTMLElement {
  * (95 of 996 local sessions have no subject — an sdk run such as the docs gate). */
 function labelOf(row: CompareRow): string {
   if (row.subject) return row.subject.replace(/\s+/g, ' ').trim();
-  if (row.entrypoint && row.entrypoint.startsWith('sdk')) return 'Automated run · ' + row.entrypoint;
+  if (isAutomated(row)) return 'Automated run · ' + row.entrypoint;
   return 'Session ' + row.sessionId.slice(0, 8);
 }
 

--- a/apps/server/src/client/search-view.ts
+++ b/apps/server/src/client/search-view.ts
@@ -105,7 +105,7 @@ function appendHighlighted(into: HTMLElement, text: string, terms: readonly stri
 /** A session's label: its first task-bearing prompt, or what it is when it has none. */
 function labelOf(r: SearchRow): string {
   if (r.subject && r.subject.trim()) return r.subject.replace(/\s+/g, ' ').trim();
-  if (r.entrypoint && r.entrypoint.startsWith('sdk')) return 'Automated run · ' + r.entrypoint;
+  if (isAutomated(r)) return 'Automated run · ' + r.entrypoint;
   return 'Session ' + r.sessionId.slice(0, 8);
 }
 

--- a/apps/server/src/client/sessions.ts
+++ b/apps/server/src/client/sessions.ts
@@ -147,6 +147,9 @@ export function createRoster(deps: {
   let timer: Timer | null = null;
   let stopped = false;
   let taken = 0; // readings actually completed — a failed poll serves the previous rows unchanged
+  // Whether the LAST landed reading read everything it met. Starts false so a consumer asking
+  // before the first reading cannot act on a list that does not exist yet.
+  let complete = false;
   const listeners = new Set<(rows: SessionRecord[]) => void>();
 
   async function refresh(): Promise<void> {
@@ -185,6 +188,7 @@ export function createRoster(deps: {
     // left a repaired record — a refetched catalogue, a settled `lastActivity` — invisible.
     rows = next;
     taken++;
+    complete = live.complete;
     const nextKey = rosterKey(next);
     if (nextKey !== key) {
       key = nextKey;
@@ -225,6 +229,12 @@ export function createRoster(deps: {
      * needs a SECOND, independent opinion (end-guard.ts) counts these instead of waiting.
      */
     readings: () => taken,
+    /**
+     * Whether the last landed reading read every directory it met. False means sessions this
+     * machine has are MISSING from `current()`, so a consumer must not read a session's absence
+     * as the session being over — see `LivePayload.complete`.
+     */
+    complete: () => complete,
     onChange(cb: (rows: SessionRecord[]) => void): () => void {
       listeners.add(cb);
       return () => listeners.delete(cb);

--- a/apps/server/src/client/sessions.ts
+++ b/apps/server/src/client/sessions.ts
@@ -1,23 +1,22 @@
 import { type CatalogueRecord, type LivePayload, mergeRoster } from '../core/roster.ts';
-import { isLive, isModelBusy, isWorking, type PendingKind, pendingInput, type SessionRecord } from '../core/types.ts';
+import {
+  isAutomated,
+  isLive,
+  isModelBusy,
+  isWorking,
+  type PendingKind,
+  pendingInput,
+  type SessionRecord,
+} from '../core/types.ts';
 import { withDeadline } from './deadline.ts';
 
 type Timer = { cancel(): void };
 
-/**
- * A headless/programmatic run (`sdk-cli`, `sdk-py`) rather than an interactive session.
- * One definition, because the picker and the auto-open rule must never disagree on what
- * "automated" means — and because they are 1017 of 1217 sessions on a real machine.
- */
-export function isAutomated(s: Pick<SessionRecord, 'entrypoint'>): boolean {
-  return !!s.entrypoint && s.entrypoint.startsWith('sdk');
-}
-
-// `isLive`, `isWorking` and `pendingInput` moved to types.ts, beside SessionRecord: the watcher
-// needs the same answer as the picker, the digest the same answer as the NOW panel, and the tray's
-// band the same answer as the browser's tab badge (see their JSDoc). Re-exported here so the client
-// keeps one import site for the session predicates.
-export { isLive, isModelBusy, isWorking, type PendingKind, pendingInput };
+// `isAutomated`, `isLive`, `isWorking` and `pendingInput` all live in types.ts, beside
+// SessionRecord: the watcher needs the same answer as the picker, the digest the same answer as
+// the NOW panel, and the tray's band the same answer as the browser's tab badge (see their
+// JSDoc). Re-exported here so the client keeps one import site for the session predicates.
+export { isAutomated, isLive, isModelBusy, isWorking, type PendingKind, pendingInput };
 
 /**
  * The sessions that should be handed a tab right now: live, interactive, never offered

--- a/apps/server/src/core/roster.ts
+++ b/apps/server/src/core/roster.ts
@@ -37,6 +37,14 @@ export interface LivePayload {
    * travels once per poll and lets the merge rebuild the tri-state instead of flattening it.
    */
   pidVisible: boolean;
+  /**
+   * Whether every directory the scan met was actually read. The second property of the SCAN
+   * rather than of a session, and the one that says what ABSENCE from this payload means: on
+   * `false` the list is missing sessions this machine has, so a client must not read a session's
+   * absence as the session being over. Only the tab sweep asks (`app.ts`); everything else acts
+   * on the sessions that ARE listed, which a partial scan still states correctly.
+   */
+  complete: boolean;
 }
 
 /** Project a full record onto the catalogue half; `lastActivity` survives only if final. */
@@ -53,13 +61,21 @@ export function toCatalogue(s: SessionRecord): CatalogueRecord {
   };
 }
 
-/** Split a roster into what the poll sends: the live sessions, and how many exist in total. */
-export function liveOf(roster: readonly SessionRecord[]): LivePayload {
+/**
+ * Split a roster into what the poll sends: the live sessions, and how many exist in total.
+ *
+ * `complete` cannot be derived from the records the way `pidVisible` is — a directory that was
+ * not read leaves none — so the scan has to hand it over. It defaults to true so a caller
+ * holding a roster and no scan beside it (every test that builds one by hand) keeps the meaning
+ * it always had: this list is everything.
+ */
+export function liveOf(roster: readonly SessionRecord[], complete = true): LivePayload {
   return {
     total: roster.length,
     sessions: roster.filter(isLive),
     // Vacuously true for an empty roster: there is nothing to rebuild the tri-state for.
     pidVisible: roster.every((r) => r.isOpen !== null),
+    complete,
   };
 }
 
@@ -85,7 +101,15 @@ export function mergeRoster(
   now: number = Date.now(),
 ): SessionRecord[] {
   const liveById = new Map(live.sessions.map((s) => [s.sessionId, s]));
-  const rows = catalogue.map((c) => liveById.get(c.sessionId) ?? ended(c, live.pidVisible, now));
+  // A catalogue entry the payload did not claim is normally an ENDED session, and `ended()` says
+  // so. On a PARTIAL reading it is not: the scan did not read the directory that session lives in,
+  // so the payload's silence about it is not an answer, and turning it into `isOpen: false` hands
+  // the GUI a session reported as over while it runs. Dropped from the reading instead, which
+  // costs that row one poll in the picker and keeps every consumer from concluding anything: the
+  // tab sweep is guarded on `complete` too, but this is the path that does not go through it.
+  const rows = catalogue
+    .map((c) => liveById.get(c.sessionId) ?? (live.complete ? ended(c, live.pidVisible, now) : null))
+    .filter((r): r is SessionRecord => r !== null);
   const known = new Set(catalogue.map((c) => c.sessionId));
   for (const s of live.sessions) if (!known.has(s.sessionId)) rows.push(s);
   // Most recent first — discovery's own order (discovery.ts), reapplied here because the

--- a/apps/server/src/core/types.ts
+++ b/apps/server/src/core/types.ts
@@ -233,6 +233,23 @@ export function isLive(s: Pick<SessionRecord, 'isOpen' | 'isActive'>): boolean {
 }
 
 /**
+ * A headless/programmatic run (`sdk-cli`, `sdk-py`) rather than a session somebody is sitting at.
+ *
+ * One definition, beside {@link isLive}, because four surfaces answer it and they must not
+ * disagree: the picker's Human/Automated split, the auto-open rule, the tray's row filter (which
+ * holds its own copy in `client.rs`), and whether an event is worth interrupting anyone for. The
+ * desktop app's Code tab is deliberately NOT automated — somebody is sitting at it; what it shares
+ * with a headless run is only being driven over stream-json, which is a fact about the transport.
+ *
+ * An entrypoint this does not recognise — and a missing one — is NOT automated. The failure modes
+ * are not symmetric: one session too many is a row you ignore, while hiding one because a newer
+ * Claude Code renamed its entrypoint is a session that silently stops being watched.
+ */
+export function isAutomated(s: Pick<SessionRecord, 'entrypoint'>): boolean {
+  return !!s.entrypoint && s.entrypoint.startsWith('sdk');
+}
+
+/**
  * The session is DOING something — which is not the same as "its agent is thinking".
  *
  * `busy` is the agent at work. `shell` is Claude Code's own word for a turn that is OVER while a

--- a/apps/server/src/core/types.ts
+++ b/apps/server/src/core/types.ts
@@ -209,7 +209,7 @@ export interface SessionRecord {
   // How the session was launched: 'cli' = interactive TUI; 'claude-desktop' = the desktop app's
   // Code tab; 'sdk-cli'/'sdk-py' = headless/programmatic (git-hook `claude -p`, scripts). Lets the
   // GUI badge the non-interactive ones instead of passing them off as normal sessions — which the
-  // desktop app is NOT: somebody is sitting at it, and `isAutomated` (client/sessions.ts) files it
+  // desktop app is NOT: somebody is sitting at it, and {@link isAutomated}, below, files it
   // with the interactive ones. What it shares with the headless runs is only that Claude Code is
   // driven over stream-json there, which is why neither publishes a status (see statusDerived).
   entrypoint: string | null;
@@ -235,9 +235,10 @@ export function isLive(s: Pick<SessionRecord, 'isOpen' | 'isActive'>): boolean {
 /**
  * A headless/programmatic run (`sdk-cli`, `sdk-py`) rather than a session somebody is sitting at.
  *
- * One definition, beside {@link isLive}, because four surfaces answer it and they must not
+ * One definition, beside {@link isLive}, because every surface answers it and they must not
  * disagree: the picker's Human/Automated split, the auto-open rule, the tray's row filter (which
- * holds its own copy in `client.rs`), and whether an event is worth interrupting anyone for. The
+ * holds its own copy in `client.rs`), whether an event is worth interrupting anyone for, and the
+ * label Compare and Search give a run that has no prompt of its own to show. The
  * desktop app's Code tab is deliberately NOT automated — somebody is sitting at it; what it shares
  * with a headless run is only being driven over stream-json, which is a fact about the transport.
  *

--- a/apps/server/src/server/discovery.ts
+++ b/apps/server/src/server/discovery.ts
@@ -138,6 +138,17 @@ async function scanHead(path: string): Promise<{ meta: FirstLineMeta; complete: 
   }
 }
 
+/** One session's file exists and would not be read. Carries no path into any surface: it is
+ * caught by the scan itself, which turns it into `complete: false`. */
+class UnreadableSession extends Error {
+  constructor(
+    readonly path: string,
+    readonly cause: unknown,
+  ) {
+    super('seedeep: a session file could not be read');
+  }
+}
+
 async function recordFor(
   path: string,
   root: Root,
@@ -147,8 +158,12 @@ async function recordFor(
   let st: Stats;
   try {
     st = await stat(path);
-  } catch {
-    return null;
+  } catch (e: any) {
+    // Null twice over, and the caller has to tell them apart: ENOENT is the file having been
+    // removed between the readdir and this stat, which is an answer; anything else is this
+    // session not being read, which must make the scan say it is partial.
+    if (e?.code === 'ENOENT') return null;
+    throw new UnreadableSession(path, e);
   }
   const meta = await firstLineMeta(path, st.size);
   const sessionId = meta.sessionId ?? basename(path).replace(/\.jsonl$/, '');
@@ -182,12 +197,26 @@ async function recordFor(
   };
 }
 
+/** What one scan of the session roots found, and whether it could read everything it met. */
+export interface Scan {
+  sessions: SessionRecord[];
+  /** Every root and every project directory under it answered. False means sessions are MISSING
+   * from `sessions`, so absence from the list is not evidence that a session is gone. */
+  complete: boolean;
+}
+
 async function scanCliDir(
   slugParent: string,
   now: number,
   openById: Map<string, OpenSession> | null,
-): Promise<SessionRecord[]> {
+): Promise<{ records: SessionRecord[]; complete: boolean }> {
   const out: SessionRecord[] = [];
+  // Flipped by any project directory that exists and would not be read. Those cannot throw the
+  // way the root does: an EACCES on ONE project is usually permanent, and propagating it would
+  // leave the whole roster unreadable for the life of that directory, which is worse than the
+  // partial list it replaces. So the list is served AND declared partial, and the caller that
+  // acts on a missing session (the GUI's tab sweep) abstains instead.
+  let complete = true;
   let slugs: string[];
   try {
     slugs = await readdir(slugParent);
@@ -200,7 +229,7 @@ async function scanCliDir(
     // PID scan already follows through `isOpen: null` (see roster.ts): absence of an answer must
     // never be served as a negative answer. The throw reaches the client as a failed reading,
     // which the roster poll already handles by keeping the last good rows.
-    if (e?.code === 'ENOENT') return out;
+    if (e?.code === 'ENOENT') return { records: out, complete: true };
     throw e;
   }
   for (const slug of slugs) {
@@ -208,23 +237,36 @@ async function scanCliDir(
     let s: Stats;
     try {
       s = await stat(dir);
-    } catch {
+    } catch (e: any) {
+      // ENOENT is the ordinary race: a project directory removed while this loop walks the list
+      // it read a moment ago. Anything else is this entry not being read, which is not the same
+      // as it holding nothing.
+      if (e?.code !== 'ENOENT') complete = false;
       continue;
     }
     if (!s.isDirectory()) continue;
     let files: string[];
     try {
       files = await readdir(dir);
-    } catch {
+    } catch (e: any) {
+      if (e?.code !== 'ENOENT') complete = false;
       continue;
     }
     for (const f of files) {
       if (!f.endsWith('.jsonl') || f === 'audit.jsonl') continue;
-      const rec = await recordFor(join(dir, f), 'cli', now, openById);
-      if (rec) out.push(rec);
+      try {
+        const rec = await recordFor(join(dir, f), 'cli', now, openById);
+        if (rec) out.push(rec);
+      } catch (e) {
+        // One session that could not be read is one session missing from the roster, and under
+        // an EMFILE that is the likeliest shape of all: the error arrives while OPENING files,
+        // which is what this loop does. The rest of the scan is still worth serving.
+        if (!(e instanceof UnreadableSession)) throw e;
+        complete = false;
+      }
     }
   }
-  return out;
+  return { records: out, complete };
 }
 
 /**
@@ -237,10 +279,31 @@ async function scanCliDir(
  * All inputs are injectable via {@link DiscoverOptions} for testing (home, now,
  * roots, openSessions).
  *
- * THROWS when a root directory exists but cannot be read. An empty array therefore always
- * means "no sessions", never "the scan failed" — every caller acts on that distinction.
+ * THROWS when a ROOT exists but cannot be read. An empty array therefore always means "no
+ * sessions", never "the scan failed" — every caller acts on that distinction.
+ *
+ * A partial reading is the case in between, and it is why {@link scanSessions} exists: use this
+ * when you act on the sessions that ARE there, and that one when you act on a session's ABSENCE.
  */
 export async function discoverSessions(opts: DiscoverOptions = {}): Promise<SessionRecord[]> {
+  return (await scanSessions(opts)).sessions;
+}
+
+/**
+ * The sessions, and whether every directory that exists was actually read.
+ *
+ * `complete: false` says the list is missing sessions this machine has, so absence from it proves
+ * nothing. Only a caller that acts on a session NOT being listed needs to ask: the GUI ends the
+ * tab of a session the roster stopped carrying, and doing that on a scan an `EMFILE` truncated
+ * would close tabs whose sessions are still running.
+ *
+ * Not folded into a throw, which is what an unreadable ROOT does: an `EACCES` on one project
+ * directory is usually permanent, so propagating it would leave the whole roster unreadable for
+ * as long as those permissions stand — worse than the partial list it would replace. The same
+ * shape as `pidVisible` in `core/roster.ts`, and for the same reason: it is a property of the
+ * SCAN and not of any session in it.
+ */
+export async function scanSessions(opts: DiscoverOptions = {}): Promise<Scan> {
   const home = opts.home ?? homedir();
   const now = opts.now ?? Date.now();
   const openSessions = opts.openSessions !== undefined ? opts.openSessions : await listOpenSessions({ home });
@@ -248,9 +311,12 @@ export async function discoverSessions(opts: DiscoverOptions = {}): Promise<Sess
 
   const cliDirs = opts.roots ?? [cliRoot(home)];
   const records: SessionRecord[] = [];
+  let complete = true;
   for (const dir of cliDirs) {
-    records.push(...(await scanCliDir(dir, now, openById)));
+    const scan = await scanCliDir(dir, now, openById);
+    records.push(...scan.records);
+    if (!scan.complete) complete = false;
   }
   records.sort((a, b) => b.lastActivity - a.lastActivity);
-  return records;
+  return { sessions: records, complete };
 }

--- a/apps/server/src/server/discovery.ts
+++ b/apps/server/src/server/discovery.ts
@@ -191,8 +191,17 @@ async function scanCliDir(
   let slugs: string[];
   try {
     slugs = await readdir(slugParent);
-  } catch {
-    return out;
+  } catch (e: any) {
+    // ENOENT is an ANSWER: this machine keeps no sessions under that root, so an empty result
+    // states a fact. Every other failure (EMFILE under load, EACCES, a network-backed home that
+    // stops responding) is the scan not happening, and returning `[]` for it would have the
+    // roster report that every session on the machine vanished — which the GUI acts on, ending
+    // every open tab and freezing live sessions into their ended presentation. Same rule the
+    // PID scan already follows through `isOpen: null` (see roster.ts): absence of an answer must
+    // never be served as a negative answer. The throw reaches the client as a failed reading,
+    // which the roster poll already handles by keeping the last good rows.
+    if (e?.code === 'ENOENT') return out;
+    throw e;
   }
   for (const slug of slugs) {
     const dir = join(slugParent, slug);
@@ -227,6 +236,9 @@ async function scanCliDir(
  * (`isActive`).
  * All inputs are injectable via {@link DiscoverOptions} for testing (home, now,
  * roots, openSessions).
+ *
+ * THROWS when a root directory exists but cannot be read. An empty array therefore always
+ * means "no sessions", never "the scan failed" — every caller acts on that distinction.
  */
 export async function discoverSessions(opts: DiscoverOptions = {}): Promise<SessionRecord[]> {
   const home = opts.home ?? homedir();

--- a/apps/server/src/server/main.ts
+++ b/apps/server/src/server/main.ts
@@ -5,7 +5,7 @@ import { openBrowser } from './browser.ts';
 import { planClaudeCommand } from './claude-command.ts';
 import { defaultConfig, readConfigStrict, resolveConfig, type SeedDeepConfig } from './config.ts';
 import { useAsciiConsole } from './console-encoding.ts';
-import { discoverSessions } from './discovery.ts';
+import { discoverSessions, type Scan, scanSessions } from './discovery.ts';
 import { usage, versionLine } from './help.ts';
 import { refreshOwnedCommandFile, runInstallCommand, staleCommandNotice } from './install-command.ts';
 import { openCommand, startCommand } from './open-cmd.ts';
@@ -24,6 +24,9 @@ export interface MainDeps {
   watcher: Pick<EventEmitter, 'on' | 'off'> & { start(): void; stop(): void };
   startServer: typeof startServer;
   discover: () => Promise<SessionRecord[]>;
+  /** The same reading plus its completeness, for the one endpoint that needs it (see ServerDeps).
+   * Optional here too: a test that injects only `discover` gets it reported as complete. */
+  scan?: () => Promise<Scan>;
   openBrowser: (url: string) => void;
   /**
    * Pre-resolved config. When provided, the CLI flags are still applied on top but
@@ -75,6 +78,7 @@ export async function run(argv: string[], deps: MainDeps): Promise<{ stop(): voi
   const server = await deps.startServer({
     watcher: deps.watcher as unknown as EventEmitter,
     discover: deps.discover,
+    scan: deps.scan,
     port: config.port,
     host: config.host,
     config,
@@ -249,6 +253,7 @@ function serve(): void {
     watcher: new Watcher(),
     startServer,
     discover: () => discoverSessions(),
+    scan: () => scanSessions(),
     openBrowser,
     // no `config` → reads from disk
   })

--- a/apps/server/src/server/notify-watch.ts
+++ b/apps/server/src/server/notify-watch.ts
@@ -1,4 +1,4 @@
-import { isWorking, pendingInput } from '../core/types.ts';
+import { isAutomated, isWorking, pendingInput } from '../core/types.ts';
 import type { DigestEntry } from './digest.ts';
 
 /** Which switch an announcement answers to. */
@@ -151,9 +151,11 @@ function finishedAnnouncement(e: DigestEntry): Announcement | null {
 /**
  * The transition detector: fold one reading in and return what the user should be told about.
  *
- * Ported from the tray, which owned it while it was the only thing that notified. Four rules travel
+ * Ported from the tray, which owned it while it was the only thing that notified. Five rules travel
  * with it, and each exists because something went wrong once:
  *
+ * - **Nobody is sitting at an automated run**, so it never reaches the detector at all — see the
+ *   filter in `step`, which is the one thing here that touches the INPUT.
  * - **Seeding.** `null` until a reading has actually been made, and back to `null` after any reading
  *   that could not be. A session already waiting when this starts — or when it restarts — is not
  *   something that just happened, and saying so would misdate it.
@@ -179,7 +181,19 @@ export function createNotifyWatch(): { step(entries: DigestEntry[] | null): Anno
       }
       // An entry with no id is skipped entirely rather than announced: it cannot be remembered, so
       // it would be new again on every single tick.
-      const identified = entries.filter((e) => typeof e.sessionId === 'string' && e.sessionId.length > 0);
+      //
+      // An AUTOMATED run is dropped for a different reason, and here rather than beside the
+      // switches: a notification asks somebody to get up, and there is nobody at a `claude -p`.
+      // This filters the detector's INPUT, which the per-kind switches below deliberately never
+      // do — a switch turned back on must not replay a backlog, whereas a headless run has no
+      // event worth remembering at all, and tracking one would only make it announceable the day
+      // something read `seen` differently. Until 0.31.0 the exclusion was accidental: those hosts
+      // publish no status, so a session that never left `null` could not transition and the
+      // detector never saw one. Deriving their state from the transcript gave them the busy→idle
+      // they had always lacked, and every git push started announcing `Turn finished`.
+      const identified = entries.filter(
+        (e) => typeof e.sessionId === 'string' && e.sessionId.length > 0 && !isAutomated(e),
+      );
       const before = seen;
       seen = {
         waiting: ids(identified, needsYou),

--- a/apps/server/src/server/server.ts
+++ b/apps/server/src/server/server.ts
@@ -28,6 +28,7 @@ import {
   writeConfig,
 } from './config.ts';
 import { type DigestEntry, digestEntry } from './digest.ts';
+import type { Scan } from './discovery.ts';
 import { createLiveTrees } from './live-trees.ts';
 import { createNotifyEngine } from './notify-engine.ts';
 import { sendWebhook } from './notify-webhook.ts';
@@ -46,6 +47,16 @@ import { FROM_SOURCE, VERSION } from './version.ts';
 export interface ServerDeps {
   watcher: EventEmitter;
   discover: () => Promise<SessionRecord[]>;
+  /**
+   * The same reading, with the one thing `discover` cannot express: whether the scan actually
+   * read everything (`scanSessions`, discovery.ts). Only `/api/live` asks, because only the
+   * client's tab sweep acts on a session being ABSENT.
+   *
+   * Optional, and it defaults to `discover` reported as complete. That keeps a caller who injects
+   * one function from silently getting the real filesystem for the other, which is the failure
+   * mode a second dep invites: every endpoint then answers from the same list.
+   */
+  scan?: () => Promise<Scan>;
   port: number;
   /** Bind address for the HTTP(S) server. Defaults to `'127.0.0.1'`. */
   host?: string;
@@ -584,6 +595,10 @@ export async function startServer(deps: ServerDeps): Promise<RunningServer> {
   // for a session nobody is watching, which is what keeps an idle process idle.
   const liveTrees = createLiveTrees({ watcher: deps.watcher });
 
+  /** One reading, with its completeness. See `ServerDeps.scan` for why the fallback says true. */
+  const readScan = async (): Promise<Scan> =>
+    deps.scan ? deps.scan() : { sessions: await deps.discover(), complete: true };
+
   /**
    * Every live session's digest entry — what `/api/digest` answers with, and what the notification
    * engine reads. One session's failure must not answer for the others: a seed that throws would
@@ -927,7 +942,8 @@ export async function startServer(deps: ServerDeps): Promise<RunningServer> {
       // The LIVE half: the handful of sessions that are actually running, in full. This is
       // the only thing the client polls, and it is ~1 KB against the catalogue's ~550 KB.
       if (pathname === '/api/live') {
-        return json(req, liveOf(await deps.discover()));
+        const scan = await readScan();
+        return json(req, liveOf(scan.sessions, scan.complete));
       }
 
       // Live derived state for a client that does NOT own the reducer: the roster's liveness

--- a/apps/server/src/server/watcher.ts
+++ b/apps/server/src/server/watcher.ts
@@ -80,6 +80,7 @@ export class Watcher extends EventEmitter {
   private readonly runMembers = new Set<string>(); // `${sessionId} ${runId} ${agentId}` already announced
   private timer: ReturnType<typeof setInterval> | null = null;
   private ticking = false; // a tick is walking the files; see the guard in tick()
+  private passFailing = false; // a pass is failing and has already been logged; see tick()
 
   constructor(opts: WatcherOptions = {}) {
     super();
@@ -121,6 +122,17 @@ export class Watcher extends EventEmitter {
     this.ticking = true;
     try {
       await this.pass();
+      this.passFailing = false;
+    } catch (err) {
+      // A pass reads the filesystem, so it CAN fail — `discoverSessions` throws when a root
+      // exists but will not be read (see discovery.ts). The timer must survive it: the cause is
+      // usually transient and the next tick is 300ms away, while an escaping rejection from
+      // `void this.tick()` takes the process with it. Logged once per outage, not 3.3 times a
+      // second, so a lasting failure is still visible in the console without burying it.
+      if (!this.passFailing) {
+        this.passFailing = true;
+        console.error('seedeep: watcher pass failed —', err);
+      }
     } finally {
       this.ticking = false;
     }

--- a/apps/server/tests/app-shell.test.ts
+++ b/apps/server/tests/app-shell.test.ts
@@ -81,6 +81,10 @@ test('app boot: auto-opens open sessions, opens ended tabs from the dropdown, cl
   // like to a client that reads the body without looking at the status, and it is the only way
   // this test can tell a reading that was checked from one that merely failed to parse.
   let rosterFails = false;
+  // The reading LANDS and is short: what a scan that could not read one project directory looks
+  // like. `readRoster` cannot save the sweep here — the response is a clean 200 — so only the
+  // payload's own `complete` can.
+  let rosterPartial = false;
   let liveReadings = 0;
   const failed = (body: unknown) => ({ ok: false, status: 500, json: () => Promise.resolve(body) });
   g.fetch = (input: any) => {
@@ -90,7 +94,9 @@ test('app boot: auto-opens open sessions, opens ended tabs from the dropdown, cl
     if (url === '/api/live') {
       liveReadings++;
       return Promise.resolve(
-        rosterFails ? failed(liveOf([])) : { ok: true, json: () => Promise.resolve(liveOf(roster)) },
+        rosterFails
+          ? failed(liveOf([]))
+          : { ok: true, json: () => Promise.resolve(liveOf(rosterPartial ? [] : roster, !rosterPartial)) },
       );
     }
     if (url === '/api/sessions')
@@ -242,6 +248,18 @@ test('app boot: auto-opens open sessions, opens ended tabs from the dropdown, cl
     await until('the roster to have failed several readings', () => liveReadings >= readingsAtFailure + 4);
     assert.equal(liveTab().classList.contains('ended'), false, 'a failed reading is not an empty roster');
     rosterFails = false;
+
+    // And the reading that LANDS but is short: one project directory that would not be read. The
+    // response is a clean 200 listing zero sessions, so nothing about the transport can tell this
+    // from an empty machine — only the payload saying it is partial can, and the sweep is the one
+    // consumer that has to ask, since it acts on absence rather than on presence.
+    rosterPartial = true;
+    const readingsAtPartial = liveReadings;
+    await until('the partial roster to have been read several times', () => liveReadings >= readingsAtPartial + 4);
+    assert.equal(liveTab().classList.contains('ended'), false, 'a partial scan is not an empty roster either');
+    rosterPartial = false;
+    await until('the tab to survive the partial readings', () => liveReadings >= readingsAtPartial + 6);
+    assert.equal(liveTab().classList.contains('ended'), false, 'and it is still live once the scan heals');
 
     roster.splice(0, 1);
     await until('the vanished session to end its tab', () => liveTab().classList.contains('ended'));

--- a/apps/server/tests/app-shell.test.ts
+++ b/apps/server/tests/app-shell.test.ts
@@ -76,13 +76,27 @@ test('app boot: auto-opens open sessions, opens ended tabs from the dropdown, cl
   // — so Share threw in every later test in every later file, silently, on whichever machine won
   // that race. A fake that says `ok` to an endpoint it knows nothing about is not a stub, it is a
   // wrong answer with a stub's confidence.
+  // The roster endpoints answer 500 while `rosterFails` is set, and — deliberately — with a
+  // PARSEABLE body saying zero sessions. That is what a scan which could not be made would look
+  // like to a client that reads the body without looking at the status, and it is the only way
+  // this test can tell a reading that was checked from one that merely failed to parse.
+  let rosterFails = false;
+  let liveReadings = 0;
+  const failed = (body: unknown) => ({ ok: false, status: 500, json: () => Promise.resolve(body) });
   g.fetch = (input: any) => {
     const url = String(input);
     if (url.startsWith('/api/commits'))
       return Promise.resolve({ ok: true, json: () => Promise.resolve({ commits: [], remote: null }) });
-    if (url === '/api/live') return Promise.resolve({ ok: true, json: () => Promise.resolve(liveOf(roster)) });
+    if (url === '/api/live') {
+      liveReadings++;
+      return Promise.resolve(
+        rosterFails ? failed(liveOf([])) : { ok: true, json: () => Promise.resolve(liveOf(roster)) },
+      );
+    }
     if (url === '/api/sessions')
-      return Promise.resolve({ ok: true, json: () => Promise.resolve(roster.map(toCatalogue)) });
+      return Promise.resolve(
+        rosterFails ? failed([]) : { ok: true, json: () => Promise.resolve(roster.map(toCatalogue)) },
+      );
     return Promise.resolve({ ok: false, status: 404, json: () => Promise.reject(new Error(`no fake for ${url}`)) });
   };
   try {
@@ -218,6 +232,17 @@ test('app boot: auto-opens open sessions, opens ended tabs from the dropdown, cl
     // walks the rows it was handed, so this tab was never offered to the end guard at all and
     // kept its live chrome for the life of the page — a turn clock still ticking on a session
     // that had ended, and a pending-approval banner nothing could ever clear.
+    // Before that: the roster endpoint FAILING must not be read as the same thing. A scan that
+    // could not be made answers 500, and a client that took the body at face value would see zero
+    // sessions — the sweep below would then end every tab on the page while the sessions behind
+    // them were still running. Several failed readings, over more than the confirmation window,
+    // and the live tab is untouched.
+    rosterFails = true;
+    const readingsAtFailure = liveReadings;
+    await until('the roster to have failed several readings', () => liveReadings >= readingsAtFailure + 4);
+    assert.equal(liveTab().classList.contains('ended'), false, 'a failed reading is not an empty roster');
+    rosterFails = false;
+
     roster.splice(0, 1);
     await until('the vanished session to end its tab', () => liveTab().classList.contains('ended'));
 

--- a/apps/server/tests/app-shell.test.ts
+++ b/apps/server/tests/app-shell.test.ts
@@ -212,6 +212,15 @@ test('app boot: auto-opens open sessions, opens ended tabs from the dropdown, cl
     });
     await until('the resumed session to reach the strip', () => liveTab().children[0].classList.contains('err'));
 
+    // The other way a session stops being live, and the one no reading of `isOpen` can express:
+    // its FILE is gone, so it leaves the roster entirely rather than turning up not-live in it.
+    // A throwaway cwd cleaned up under a driven session does exactly this. `roster.onChange`
+    // walks the rows it was handed, so this tab was never offered to the end guard at all and
+    // kept its live chrome for the life of the page — a turn clock still ticking on a session
+    // that had ended, and a pending-approval banner nothing could ever clear.
+    roster.splice(0, 1);
+    await until('the vanished session to end its tab', () => liveTab().classList.contains('ended'));
+
     // Close both via ×: panels and tabs drop with them.
     for (const t of [...tabs]) t.children[2].onclick({ stopPropagation: () => {} });
     assert.equal(findByClass(tabsEl, 'tab').length, 0);

--- a/apps/server/tests/client-sessions.test.ts
+++ b/apps/server/tests/client-sessions.test.ts
@@ -336,7 +336,7 @@ test('a provisional record for a session that is not live is refreshed, not carr
   const settled = toCatalogue(rec('B', false, { lastActivity: 777 }));
   const r = createRoster({
     fetchCatalogue: async () => [calls++ === 0 ? bornLive : settled],
-    fetchLive: async () => ({ total: 1, sessions: [], pidVisible: true }),
+    fetchLive: async () => ({ total: 1, sessions: [], pidVisible: true, complete: true }),
     schedule: sched.schedule as any,
   });
   await r.start();

--- a/apps/server/tests/discovery.test.ts
+++ b/apps/server/tests/discovery.test.ts
@@ -273,3 +273,18 @@ test('head cache: an incomplete head is re-scanned when the file grows', async (
   assert.equal(grown.model, 'claude-opus-4-8');
   assert.equal(grown.subject, 'now the task exists');
 });
+
+test('a root that does not exist is zero sessions; one that cannot be read is an error', async () => {
+  // The two are different facts and the caller acts on the difference: an empty array ends every
+  // open tab (the GUI sweeps the tabs the roster stopped listing), so a scan that could not be
+  // made must never produce one. ENOENT is a real answer — this machine keeps no sessions there.
+  assert.deepEqual(await discover(join(tmpdir(), 'seedeep-absent-' + Date.now())), []);
+
+  const root = makeRoot();
+  chmodSync(root, 0o000);
+  try {
+    await assert.rejects(discover(root), 'an unreadable root is reported, not served as empty');
+  } finally {
+    chmodSync(root, 0o755);
+  }
+});

--- a/apps/server/tests/discovery.test.ts
+++ b/apps/server/tests/discovery.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { test } from 'node:test';
 import { isLive } from '../src/core/types.ts';
-import { discoverSessions } from '../src/server/discovery.ts';
+import { discoverSessions, scanSessions } from '../src/server/discovery.ts';
 
 function makeRoot(): string {
   const root = mkdtempSync(join(tmpdir(), 'seedeep-disc-'));
@@ -272,6 +272,36 @@ test('head cache: an incomplete head is re-scanned when the file grows', async (
   const grown = (await discover(root))[0]!;
   assert.equal(grown.model, 'claude-opus-4-8');
   assert.equal(grown.subject, 'now the task exists');
+});
+
+test('a project directory that cannot be read makes the scan say it is partial', async () => {
+  // The ROOT throws, because refusing the whole roster is right when nothing at all was read. One
+  // project directory is the case in between: an EACCES there is usually permanent, so throwing
+  // would leave seedeep unusable for as long as those permissions stand. The readable half is
+  // served AND the scan says so, and the one caller that acts on a session's ABSENCE abstains.
+  const root = makeRoot();
+  const locked = join(root, '-home-dev-other');
+  mkdirSync(locked, { recursive: true });
+  writeFileSync(
+    join(locked, 'cccccccc-0000-0000-0000-000000000003.jsonl'),
+    JSON.stringify({ type: 'assistant', sessionId: 'cccccccc-0000-0000-0000-000000000003', cwd: '/home/dev/other' }) +
+      '\n',
+  );
+
+  const whole = await scanSessions({ roots: [root], openSessions: [] });
+  assert.equal(whole.sessions.length, 3, 'all three are found while all three can be read');
+  assert.equal(whole.complete, true);
+
+  chmodSync(locked, 0o000);
+  try {
+    const partial = await scanSessions({ roots: [root], openSessions: [] });
+    assert.equal(partial.sessions.length, 2, 'the readable half is still served');
+    assert.ok(!partial.sessions.some((r) => r.sessionId.endsWith('003')), 'the locked project is the one missing');
+    assert.equal(partial.complete, false, 'and the scan says the list is missing sessions');
+  } finally {
+    chmodSync(locked, 0o755);
+  }
+  assert.equal((await scanSessions({ roots: [root], openSessions: [] })).complete, true, 'and it heals');
 });
 
 test('a root that does not exist is zero sessions; one that cannot be read is an error', async () => {

--- a/apps/server/tests/notify-watch.test.ts
+++ b/apps/server/tests/notify-watch.test.ts
@@ -20,10 +20,14 @@ function entry(o: {
   turnState?: string;
   apiCalls?: number;
   nowText?: string;
+  entrypoint?: string | null;
 }): DigestEntry {
   return {
     sessionId: o.id as string,
     project: 'atlas',
+    // Defaults to the interactive terminal, which is what every test above is about. Written out
+    // rather than left undefined so a reader can see that `isAutomated` is being asked something.
+    entrypoint: o.entrypoint === undefined ? 'cli' : o.entrypoint,
     subject: 'add a retry to the uploader',
     status: o.status,
     waitingFor: o.waitingFor ?? null,
@@ -298,4 +302,48 @@ test('Esc produces no finish, in both shapes the transcript writes', () => {
 
   // A real turn still announces — the rule must not swallow the event it exists for.
   assert.ok(announced([typed('u1', 'first prompt', 3), assistant('a1', 4)]).includes('finishes'));
+});
+
+test('a headless run never announces — there is nobody at it to get up', () => {
+  // Until 0.31.0 this held by accident: a host driving Claude Code over stream-json publishes no
+  // status, so the entry never left `null` and could not transition. Reading the state off the
+  // transcript gave those sessions the busy→idle they had always lacked, and seedeep's own
+  // docs-freshness gate — a `claude -p` on every push — started announcing `Turn finished` to the
+  // tray and to the webhook.
+  for (const ep of ['sdk-cli', 'sdk-py']) {
+    const finish = createNotifyWatch();
+    finish.step([entry({ id: 'a', status: 'busy', entrypoint: ep })]);
+    assert.deepEqual(finish.step([entry({ id: 'a', status: 'idle', entrypoint: ep })]), [], `${ep} finish`);
+
+    // The derived wait is the other half: `deriveStatus` reaches an unanswered AskUserQuestion,
+    // and it carries Claude Code's own `input needed`, so it reads exactly like a published one.
+    const wait = createNotifyWatch();
+    wait.step([entry({ id: 'a', status: 'busy', entrypoint: ep })]);
+    const w = wait.step([entry({ id: 'a', status: 'waiting', waitingFor: 'input needed', entrypoint: ep })]);
+    assert.deepEqual(w, [], `${ep} wait`);
+
+    // And a failure, which is read before either of them.
+    const fail = createNotifyWatch();
+    fail.step([entry({ id: 'a', status: 'busy', entrypoint: ep })]);
+    const f = fail.step([
+      entry({ id: 'a', status: 'busy', error: { agentId: null, message: 'boom' }, entrypoint: ep }),
+    ]);
+    assert.deepEqual(f, [], `${ep} failure`);
+  }
+});
+
+test('the desktop app is not a headless run — somebody is sitting at it', () => {
+  // The distinction 0.31.0 was actually after. Both hosts are driven over stream-json and neither
+  // publishes a status, so the mechanism that gave them a state cannot tell them apart; the
+  // entrypoint can. An entrypoint nobody recognises stays announceable for the same reason: one
+  // banner too many is ignored, a session silently stopped being watched is not.
+  for (const ep of ['claude-desktop', 'vscode', null]) {
+    const w = createNotifyWatch();
+    w.step([entry({ id: 'a', status: 'busy', entrypoint: ep })]);
+    assert.deepEqual(
+      w.step([entry({ id: 'a', status: 'idle', entrypoint: ep })]).map((a) => a.kind),
+      ['finishes'],
+      `entrypoint ${ep}`,
+    );
+  }
 });

--- a/apps/server/tests/roster.test.ts
+++ b/apps/server/tests/roster.test.ts
@@ -71,10 +71,26 @@ test('a session that ends drops out of the live payload and its tab can see it e
   // merge reads a settled record and only has to strip the liveness.
   const settled = [rec('a', { lastActivity: ago(1_000), isOpen: false, status: null })];
   const { catalogue } = split(settled);
-  const after = mergeRoster(catalogue, { total: 1, sessions: [], pidVisible: true }, NOW);
+  const after = mergeRoster(catalogue, { total: 1, sessions: [], pidVisible: true, complete: true }, NOW);
   assert.equal(isLive(after[0]!), false, 'the tab must be able to end');
   assert.equal(after[0]!.status, null);
   assert.equal(after[0]!.lastActivity, ago(1_000));
+});
+
+test('a PARTIAL reading drops the rows it cannot answer for instead of ending them', () => {
+  // The same absence, with the scan admitting it did not read everything. Absence is then not a
+  // signal at all: `ended()` would report a running session as closed, and the GUI acts on that by
+  // freezing its tab into history. Dropping the row costs the picker one poll and lets no consumer
+  // conclude anything — which is the only honest answer when the directory was never opened.
+  const running = [rec('a', { lastActivity: ago(1_000), isOpen: true, status: 'busy' })];
+  const { catalogue } = split(running);
+
+  const whole = mergeRoster(catalogue, { total: 1, sessions: [], pidVisible: true, complete: true }, NOW);
+  assert.equal(whole.length, 1, 'a COMPLETE reading still reports the session, as ended');
+  assert.equal(isLive(whole[0]!), false);
+
+  const partial = mergeRoster(catalogue, { total: 1, sessions: [], pidVisible: true, complete: false }, NOW);
+  assert.deepEqual(partial, [], 'a partial one says nothing about it rather than saying it is over');
 });
 
 test('isOpen stays null when the PID mechanism itself is unavailable', () => {
@@ -94,7 +110,7 @@ test('isOpen stays null when the PID mechanism itself is unavailable', () => {
 test('a session born after the catalogue is still offered now, not in three seconds', () => {
   const catalogue: CatalogueRecord[] = [toCatalogue(rec('old', { lastActivity: ago(86_400_000) }))];
   const born = rec('new', { lastActivity: ago(500), isOpen: true });
-  const rows = mergeRoster(catalogue, { total: 2, sessions: [born], pidVisible: true }, NOW);
+  const rows = mergeRoster(catalogue, { total: 2, sessions: [born], pidVisible: true, complete: true }, NOW);
   assert.deepEqual(
     rows.map((s) => s.sessionId),
     ['new', 'old'],
@@ -110,7 +126,12 @@ test('merged order follows lastActivity, not the order the catalogue froze', () 
     toCatalogue(rec('fresh-then', { lastActivity: ago(60_000) })),
     toCatalogue(rec('live', { lastActivity: ago(120_000), isOpen: true })),
   ];
-  const live = { total: 2, sessions: [rec('live', { lastActivity: ago(200), isOpen: true })], pidVisible: true };
+  const live = {
+    total: 2,
+    sessions: [rec('live', { lastActivity: ago(200), isOpen: true })],
+    pidVisible: true,
+    complete: true,
+  };
   assert.deepEqual(
     mergeRoster(catalogue, live, NOW).map((s) => s.sessionId),
     ['live', 'fresh-then'],

--- a/apps/server/tests/watcher.test.ts
+++ b/apps/server/tests/watcher.test.ts
@@ -555,3 +555,42 @@ test('no open-session mechanism: the mtime window still decides, as it did befor
   await w.tick();
   assert.deepEqual(seen, ['W'], 'the recently-written session is tailed, the cold one is not');
 });
+
+test('a failing discovery does not kill the watcher: the next tick still delivers', async () => {
+  // `discoverSessions` throws when a root exists but will not be read (see discovery.ts) — that
+  // is the whole point of it, so the roster can never report a scan it could not make as zero
+  // sessions. The timer must outlive it: `start()` calls `tick()` for its side effects, so an
+  // escaping rejection ends the process, and the cause (an EMFILE, a home that stopped
+  // answering) is usually gone by the next tick 300 ms later.
+  const dir = mkdtempSync(join(tmpdir(), 'seedeep-discfail-'));
+  const path = join(dir, 'A.jsonl');
+  writeFileSync(path, usageLine(11));
+  const recs = [rec('A', path, true)];
+  let failing = true;
+  const w = watcherOver(recs, {
+    discover: async () => {
+      if (failing) throw new Error('EMFILE: too many open files');
+      return recs;
+    },
+  });
+  const seen: string[] = [];
+  w.on('event', (e: NormalizedEvent) => {
+    if (e.type === 'usage') seen.push(e.sessionId);
+  });
+  // The watcher says the failure out loud, which is the behaviour wanted in production and noise
+  // here — captured rather than suppressed, so the test also pins that it is reported ONCE.
+  const realError = console.error;
+  const logged: unknown[][] = [];
+  console.error = (...args: unknown[]) => void logged.push(args);
+  try {
+    await w.tick(); // must settle, not reject
+    await w.tick(); // still failing: the same outage must not be re-logged every 300 ms
+  } finally {
+    console.error = realError;
+  }
+  assert.equal(logged.length, 1, 'one line per outage, not one per tick');
+  assert.deepEqual(seen, [], 'a scan that failed places nothing, so nothing is tailed');
+  failing = false;
+  await w.tick();
+  assert.deepEqual(seen, ['A'], 'the very next tick works — the failure was not terminal');
+});

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -69,6 +69,14 @@ Everything released before `0.20.0` — including the pre-publication developmen
   and handed to it. Only a page reload cleared them before. It is reached by any session whose file
   disappears under it: a driven session in a throwaway working directory, or `~/.claude/projects`
   pruned by hand.
+- A scan that cannot be made is no longer reported as an empty machine. The session directory was
+  read with every failure swallowed, so an `EMFILE` under load or a home that stops answering
+  produced zero sessions rather than an error — indistinguishable from a machine with none, and
+  now acted upon: the sweep above would have ended every tab on the page while the sessions behind
+  them were still running. `ENOENT` stays an answer (there is nothing there); anything else throws,
+  the roster endpoints answer `500`, and the poll keeps the last rows it had. The watcher survives
+  the same failure and logs it once per outage instead of on every 300 ms tick. This is the rule
+  `isOpen` already followed as `null`: absence of an answer is never served as a negative one.
 - Custom slash commands are read as commands again. Claude Code 2.1.237 began writing
   `origin: {kind:"human"}` on a command defined by a `.md` file (measured over 1046 session files:
   0 of 97 such lines up to 2.1.234, then 25 of 25; built-in commands like `/clear` still carry

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -69,6 +69,18 @@ Everything released before `0.20.0` — including the pre-publication developmen
   and handed to it. Only a page reload cleared them before. It is reached by any session whose file
   disappears under it: a driven session in a throwaway working directory, or `~/.claude/projects`
   pruned by hand.
+- A scan that read only PART of the machine no longer lets a session be reported as over. The rule
+  above covers a root that will not answer at all; one project directory that will not answer is
+  the case in between, and it is the likelier of the two under an `EMFILE`, which arrives while
+  files are being opened. Those failures were swallowed one directory at a time, so the roster came
+  back short and in silence. `scanSessions` now serves the readable part and says `complete: false`
+  beside it, carried on `LivePayload` next to `pidVisible` and for the same reason: it is a property
+  of the SCAN, not of a session. Not folded into the throw, since an `EACCES` on one project is
+  usually permanent and refusing the whole roster for as long as it stands would hide more than it
+  protects. Two consumers act on it, because absence reaches them by different paths: the tab sweep
+  asks before it runs, and `mergeRoster` drops a catalogue entry the payload did not claim instead
+  of reporting it not-live. Everything else reads what a session IS, which a partial scan still
+  states correctly.
 - A scan that cannot be made is no longer reported as an empty machine. The session directory was
   read with every failure swallowed, so an `EMFILE` under load or a home that stops answering
   produced zero sessions rather than an error — indistinguishable from a machine with none, and

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -47,6 +47,28 @@ Everything released before `0.20.0` — including the pre-publication developmen
 
 ### Fixed
 
+- Automated sessions no longer notify. A headless run (`entrypoint` `sdk-cli` or `sdk-py`) has
+  nobody sitting at it, so `Turn finished` on the tray and on the webhook was a request to get up
+  for a machine, and seedeep's own docs-freshness gate raised one on every push. The exclusion had
+  been holding by accident until `0.31.0`: those hosts drive Claude Code over stream-json and
+  publish no session state, so the entry never left `null`, could not transition, and the detector
+  never saw one. Reading their state off the transcript gave them the `busy` to `idle` they had
+  always lacked, and nothing was filtering the detector's input. `isAutomated` moves to
+  `core/types.ts` beside the other session predicates, and the detector drops those entries before
+  it remembers anything about them. The desktop app's Code tab keeps its notifications, which is
+  the distinction `0.31.0` was after: it is driven over the same interface, but somebody is sitting
+  at it. An entrypoint seedeep does not recognise still notifies, since one banner too many is
+  ignored while a session that silently stops being watched is not.
+- A tab whose session left the roster entirely stayed live for the life of the page. The roster
+  listener walks the rows it is handed, so it can only ever visit sessions the roster still lists;
+  a session whose transcript is DELETED, rather than merely closed, was never offered to the end
+  guard at all. The tab kept its live chrome, its turn clock ticking on a session that had ended
+  (one measured at `1h 1m turn` against `6s total`), and a pending-approval banner nothing could
+  clear. The guard's own question already answered this case, absence from the roster counting as
+  gone; it was simply never armed for it, so the tabs the row loop cannot reach are now collected
+  and handed to it. Only a page reload cleared them before. It is reached by any session whose file
+  disappears under it: a driven session in a throwaway working directory, or `~/.claude/projects`
+  pruned by hand.
 - Custom slash commands are read as commands again. Claude Code 2.1.237 began writing
   `origin: {kind:"human"}` on a command defined by a `.md` file (measured over 1046 session files:
   0 of 97 such lines up to 2.1.234, then 25 of 25; built-in commands like `/clear` still carry

--- a/docs/api.md
+++ b/docs/api.md
@@ -141,6 +141,11 @@ Returns `LivePayload` (`core/roster.ts`): `{ total, sessions, pidVisible }`.
 The two halves rejoin client-side: `mergeRoster(catalogue, live)` is the same roster the server
 would have produced whole.
 
+Both roster endpoints answer `500` when the session directory exists but cannot be read. A `200`
+listing zero sessions therefore means the machine has none, never that the scan failed; a client
+must treat the `500` as a reading that did not land and keep the rows it already has, since the
+alternative is reporting every running session as gone.
+
 ### `GET /api/session-stats`
 
 Turn count and token total per session, from the aggregate cache.

--- a/docs/api.md
+++ b/docs/api.md
@@ -141,10 +141,17 @@ Returns `LivePayload` (`core/roster.ts`): `{ total, sessions, pidVisible }`.
 The two halves rejoin client-side: `mergeRoster(catalogue, live)` is the same roster the server
 would have produced whole.
 
-Both roster endpoints answer `500` when the session directory exists but cannot be read. A `200`
-listing zero sessions therefore means the machine has none, never that the scan failed; a client
-must treat the `500` as a reading that did not land and keep the rows it already has, since the
-alternative is reporting every running session as gone.
+Both roster endpoints answer `500` when a session ROOT exists but cannot be read. A `200` listing
+zero sessions therefore means the machine has none, never that the scan failed; a client must treat
+the `500` as a reading that did not land and keep the rows it already has, since the alternative is
+reporting every running session as gone.
+
+One project directory that cannot be read is the case in between, and `LivePayload.complete` is
+where it is stated. The reading still lands, and the sessions it lists are correct; what it cannot
+support is the opposite reading, that a session it does NOT list is over. `false` therefore means
+absence from `sessions` proves nothing. It is not folded into the `500` because an `EACCES` on one
+project directory is usually permanent, and refusing the whole roster for as long as those
+permissions stand would hide more than it protects.
 
 ### `GET /api/session-stats`
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -301,6 +301,13 @@ when it has not it re-arms instead of giving up: dropping the question would lea
 that really ended live for the life of the page, since `gone` is driven by an identity change
 that has already happened.
 
+A session can also stop being live by leaving the roster altogether, which is not the same
+event: its transcript is gone, so no row carries it and no reading of `isOpen` can be taken.
+A throwaway working directory cleaned up under a driven session does this, and so does pruning
+`~/.claude/projects` by hand. The roster listener walks the rows it is handed, so the tabs it
+cannot see are collected separately and offered to the same guard; the guard's own question
+already treats an absent row as gone.
+
 Ending a tab is **reversible**, and has to be: `claude --resume` continues the SAME session id,
 so a resumed session can never be handed a new tab, and nothing auto-opens it
 (`sessionsToAutoOpen` excludes both `known` and the ids on screen) and picking it from the
@@ -975,7 +982,9 @@ own verdict that something is worth interrupting the user for. The transition de
 (`notify-watch.ts`) folds each reading of the digest and the engine (`notify-engine.ts`) gates its
 output per channel: the tray subscribes here, a configured webhook is POSTed to instead. The
 switches filter that output and never the detector's input, so turning one back on announces what
-happens next and not the backlog it slept through. Evaluation is skipped entirely when nobody is
+happens next and not the backlog it slept through. One thing IS filtered on the way in, for the
+opposite reason: an automated run (`isAutomated`, `core/types.ts`) never reaches the detector,
+because a notification asks somebody to get up and nobody is sitting at a `claude -p`. Evaluation is skipped entirely when nobody is
 subscribed and no webhook is configured, which is what keeps an unwatched process idle.
 
 Staying connected is not free, and SSE does not give reconnection for free on its own. Four

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -308,6 +308,17 @@ A throwaway working directory cleaned up under a driven session does this, and s
 cannot see are collected separately and offered to the same guard; the guard's own question
 already treats an absent row as gone.
 
+That inverts what a failed scan costs, so absence has to be trusted before it is acted on, and
+three mechanisms say when it can be. A ROOT that exists and will not be read makes
+`scanSessions` throw, the endpoints answer `500`, and the poll keeps its last rows. One PROJECT
+directory that will not be read is served with the rest and reported through
+`LivePayload.complete`, since an `EACCES` there is usually permanent and refusing the whole roster
+for as long as it stands would hide more than it protects. And on such a reading `mergeRoster`
+DROPS a catalogue entry the payload did not claim rather than passing it through `ended`, because
+that path reaches the row loop, which never sees the flag. Only the sweep is gated on `complete`
+directly: every other consumer acts on what a session IS, which a partial reading still states
+correctly.
+
 Ending a tab is **reversible**, and has to be: `claude --resume` continues the SAME session id,
 so a resumed session can never be handed a new tab, and nothing auto-opens it
 (`sessionsToAutoOpen` excludes both `known` and the ids on screen) and picking it from the

--- a/docs/features.md
+++ b/docs/features.md
@@ -887,3 +887,10 @@ the same title and line, and nothing more.
 A turn that ends says **`Turn finished`**, not "finished", because the session has not
 ended, it has become yours again. A turn **you** interrupted is never announced:
 if you pressed Esc you already know.
+
+An **automated session never notifies at all**, on either channel. A notification asks you to
+get up, and nobody is sitting at a `claude -p`: a git hook that runs one on every push would
+otherwise announce a finished turn every time. The rule is the picker's own Human/Automated split
+(`entrypoint` starting with `sdk`), so the same sessions the picker files under Automated are the
+ones that stay silent. The desktop app's **Code** tab is not one of them, since somebody is
+sitting at it; what it shares with a headless run is only how Claude Code is driven there.

--- a/docs/tray.md
+++ b/docs/tray.md
@@ -219,9 +219,12 @@ transcript, because the tray has no reducer. What it derives is presentation: wh
 is in, and how long it has been there.
 
 Only interactive sessions, and the filter is not in the panel. A headless run (`entrypoint`
-`sdk-cli`/`sdk-py`) is not a session anybody is sitting at. The rule is the browser picker's
-(`client/sessions.ts`, `isAutomated`), applied **where the digest enters the tray** (`client.rs`,
-`only_interactive`), so the rows, the icon and the notifications read one list. An unrecognised
+`sdk-cli`/`sdk-py`) is not a session anybody is sitting at. The rule is `isAutomated`
+(`core/types.ts`), which the browser picker reads too, applied **where the digest enters the tray**
+(`client.rs`, `only_interactive`) so the rows and the icon read one list. Notifications arrive on
+their own channel and carry no `entrypoint`, so the tray cannot filter them: they are excluded in
+the server instead, at the detector (`notify-watch.ts`, `createNotifyWatch`), which is what makes
+the two surfaces of this app agree about which sessions exist. An unrecognised
 entrypoint, and a missing one, are **kept**, since a newer Claude Code renaming one must not make the tray
 silently stop watching, and a payload that is not a list passes through untouched, landing in
 *Unreachable* rather than in "the machine is idle".
@@ -700,6 +703,9 @@ time it could see, and announces only what was not there before, per session and
 one prompt answered and another raised in the same interval still interrupts. Each rule that follows
 is a way of not lying about when something happened:
 
+- An automated run never announces at all. A notification asks somebody to get up, and nobody is
+  sitting at a `claude -p`. It is the one rule applied to the detector's INPUT rather than to its
+  output, so such a session has no remembered state that a later change could make announceable.
 - A failure announces once, and re-arms on recovery. Still-broken is not news on the next tick,
   and only a successful call, which clears the server's `error`, makes the next failure
   announceable. A session that breaks while it was ALSO stopped on the user raises **one** banner,


### PR DESCRIPTION
Two independent defects, both reported from one schema-probe run, both about a session nobody is sitting at being treated as one somebody is. They are fixed together because they were found together; they share no code.

## 1. Automated sessions notified

A headless run (`entrypoint` `sdk-cli` or `sdk-py`) has nobody at it, so `Turn finished` on the tray and on the webhook was a request to get up for a machine. seedeep's own docs-freshness gate is a `claude -p`, so every push raised one.

Not a Claude Code change. Measured over all 1055 local transcripts, `entrypoint` is still written and still separates the species: 2.1.251 alone carries 75 `sdk-cli` and 5 `sdk-py`, and no file lacks the field.

The exclusion had been holding **by accident** until `0.31.0`. Those hosts drive Claude Code over stream-json and publish no session state, so the entry never left `null`, could not transition, and the detector never saw one. Deriving their state from the transcript gave them the `busy` to `idle` they had always lacked, and nothing filtered the detector's input.

`isAutomated` moves to `core/types.ts` beside `isLive`, `isWorking` and `pendingInput`, for the reason those moved: four surfaces answer it and must not disagree. `createNotifyWatch` drops those entries before it remembers anything about them, which is the one thing there that touches the INPUT: a switch turned back on must not replay a backlog, whereas a headless run has no event worth remembering at all.

The desktop app's Code tab keeps its notifications, which is the distinction `0.31.0` was after: same transport, but somebody is sitting at it. An unrecognised entrypoint still notifies, since one banner too many is ignored while a session that silently stops being watched is not.

## 2. A tab whose session left the roster stayed live for the life of the page

`roster.onChange` walks the rows it is handed, so it only ever visits sessions the roster still lists. A session whose transcript is DELETED rather than closed was never offered to the end guard at all: the tab kept its live chrome, a turn clock ticking on a session that had ended (one reported at `1h 1m turn` against `6s total`) and a pending-approval banner nothing could clear.

`stillGone` already answered this case, absence from the roster counting as gone. The window was simply never armed for it, so the tabs the row loop cannot reach are now collected and handed to the same guard.

Reached by any session whose file disappears under it: a driven session in a throwaway working directory, or `~/.claude/projects` pruned by hand. Only a page reload cleared them before.

## Falsified rather than assumed

Both regressions were reproduced before the fix and confirmed red with the fix removed.

- Dropping the session out of the roster left the tab at `tab active`, while the existing not-live path reached `tab active ended`. With the collection removed the new assertion times out.
- With the detector's filter removed, the `sdk-cli` finish announces again.

`deriveStatus` was also run over 400 real `sdk-*` transcripts and answers on every one of them (322 busy, 78 idle), so the notification path was live rather than theoretical.

## Verification

`bun run test` 1785 pass, 0 fail. `bun run lint` and `bun run typecheck` clean. The client bundle is rebuilt and committed, since it is tracked. `docs/architecture.md`, `docs/tray.md`, `docs/features.md`, `README.md` and `docs/CHANGELOG.md` move with the code.

`docs/tray.md` held a claim that was false and is now true: it said the rows, the icon and the notifications read one list, while notifications travel on their own channel and carry no `entrypoint`, which that filter never touched. It now names both filters and why there have to be two.

Not done: no browser was driven. The tab behaviour is asserted through the real composition root against a fake DOM, not through a real click.

## Out of scope, deliberately

The schema probe stays visible. It drives a real interactive CLI in a pty, so it is `entrypoint: cli` and `kind: interactive`, indistinguishable from a session you opened yourself, and that is the point: a probe seedeep could recognise would no longer prove the contract it exists to prove. Keeping its sessions out of the watched corpus is a separate change.
