### PR TITLE
Accept ten fields Claude Code has started writing

### DIFF
--- a/apps/server/data/known-fields.json
+++ b/apps/server/data/known-fields.json
@@ -21,6 +21,7 @@
     ],
     "assistant": [
       "agentId",
+      "apiBlockIndex",
       "apiError",
       "apiErrorStatus",
       "attributionAgent",
@@ -43,6 +44,7 @@
       "session_id",
       "slug",
       "timestamp",
+      "truncatedAfterOutput",
       "type",
       "userType",
       "uuid",
@@ -152,8 +154,21 @@
       "timestamp",
       "type"
     ],
+    "result": [
+      "agentId",
+      "key",
+      "result",
+      "type"
+    ],
+    "started": [
+      "agentId",
+      "key",
+      "type"
+    ],
     "system": [
       "agentId",
+      "apiRefusalCategory",
+      "apiRefusalExplanation",
       "compactMetadata",
       "content",
       "cwd",
@@ -170,10 +185,13 @@
       "level",
       "logicalParentUuid",
       "messageCount",
+      "originalModel",
       "parentUuid",
       "pendingBackgroundAgentCount",
       "pendingWorkflowCount",
       "preventedContinuation",
+      "refusedUserMessageUuid",
+      "requestId",
       "sessionId",
       "session_id",
       "slug",
@@ -222,17 +240,6 @@
       "userType",
       "uuid",
       "version"
-    ],
-    "result": [
-      "agentId",
-      "key",
-      "result",
-      "type"
-    ],
-    "started": [
-      "agentId",
-      "key",
-      "type"
     ],
     "agent-name": [
       "agentName",
@@ -311,6 +318,9 @@
       "filenames",
       "findings",
       "gitOperation",
+      "harnessNoteCount",
+      "harnessSectionHash",
+      "harnessTailCount",
       "interrupted",
       "isAgent",
       "isAsync",


### PR DESCRIPTION
Regenerated `apps/server/data/known-fields.json` from a full scan of the local session root. Nothing reads any of the new fields: this only stops the radar reporting them.

| bucket | fields |
|---|---|
| `types/assistant` | `apiBlockIndex`, `truncatedAfterOutput` |
| `types/system` | `apiRefusalCategory`, `apiRefusalExplanation`, `originalModel`, `refusedUserMessageUuid`, `requestId` |
| `containers/toolUseResult` | `harnessNoteCount`, `harnessSectionHash`, `harnessTailCount` |

The suite reported one of the ten, `apiBlockIndex`, because its scan samples recent sessions while `--update` walks the whole root.

## What apiBlockIndex is

Measured on 1921 transcripts: it first appears in 2.1.257, with 0 occurrences across the 687 assistant lines written by 2.1.252 and earlier. From 2.1.257 on it carries every assistant line whose model is not `<synthetic>` (2.1.257: 2862 present / 2 missing, 2.1.259: 3387 / 3, 2.1.261: 38 / 0); the lines without it are API errors and \"No response requested.\".

Its value is the 0-based index of the content block inside the API response, restarting at each `requestId`:

\`\`\`
[HY6Dop, 0, text]  [HY6Dop, 1, tool_use]  [d4AKAv, 0, thinking]  [d4AKAv, 1, tool_use]
\`\`\`

That is the signal the parser derives today from a change of \`requestId\`. Reading it is a separate decision and is not part of this change.

## Monotonicity

Checked pair by pair rather than by line count: 354 type/field pairs before, 364 after, no removals. The eleven deleted lines are the \`result\` and \`started\` blocks, which the regeneration reordered.

1799 tests pass, lint and typecheck clean.