### PR TITLE
Pin the Bun version instead of taking whatever is latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,13 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
+      # No `bun-version` here on purpose: with none given the action reads `packageManager` from
+      # package.json, so all five setup-bun call sites across this workflow and release.yml take
+      # their version from one line. It has to be pinned somewhere, because the last step of this
+      # job compares the committed bundle byte for byte against a fresh build, and Bun's bundler
+      # renames identifiers differently between releases. A floating `latest` turned that gate red
+      # on an untouched main the day Bun went 1.4.0 → 1.4.2, which renamed `el8` back to `el`.
+      # Raising the pin is therefore a deliberate commit that also rebuilds public/lib/app.js.
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
       - run: bun install --frozen-lockfile

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,7 +58,11 @@ Two expectations beyond it, both about this project's shape rather than about co
 ## Prerequisites
 
 - [Bun](https://bun.sh) (the project is developed against Bun; a Node path
-  exists via `tsx` but is not the primary target).
+  exists via `tsx` but is not the primary target). The version is pinned in
+  `package.json` under `packageManager`, and CI installs exactly that one. Use it
+  locally too: Bun's bundler renames identifiers differently between releases, so
+  a different version rebuilds `apps/server/public/lib/app.js` into bytes CI will
+  reject even when your source change is correct.
 
 That is everything the server and the browser GUI need: no other runtime, no
 global CLIs, no services.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,15 @@ Everything released before `0.20.0` — including the pre-publication developmen
 
 ## Unreleased
 
+### Changed
+
+- The Bun version is pinned, in `package.json` under `packageManager`. CI and the release workflow
+  install Bun through an action that reads that field, so five call sites now take one version.
+  Until now they took whatever was latest on the day, and the last step of the CI suite compares
+  the committed `apps/server/public/lib/app.js` against a fresh build byte for byte. Bun 1.4.2
+  renamed bundled identifiers differently from 1.4.0 and turned that step red on a main nobody had
+  touched. Raising the pin is now a deliberate change that rebuilds the bundle in the same commit.
+
 ## 0.32.0 (2026-08-30)
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "seedeep",
   "version": "0.32.0",
+  "packageManager": "bun@1.3.13",
   "private": true,
   "type": "module",
   "description": "Live context & subagent visualizer for Claude Code",


### PR DESCRIPTION
## The failure

`main` at `8cb1fb0` is red, and so is every PR opened against it. The job is `Tests, types, client bundle`, at its last step:

```
apps/server/public/lib/app.js is stale — run 'bun run build:client' and commit it
```

The diff is entirely bundler identifier renaming: `el8` back to `el`, `card2` back to `card`. No source change is involved.

## The cause

`oven-sh/setup-bun` installs the latest release when given no `bun-version`, and `package.json` declared no `packageManager` or `engines.bun` for it to read. So the version moved on its own:

| when | run | Bun | result |
|---|---|---|---|
| 2026-09-04 07:46 | PR #80 | 1.4.0 | green |
| 2026-09-05 09:56 | main `8cb1fb0` | 1.4.2 | red |
| 2026-09-05 10:03 | PR #82 | 1.4.2 | red |

The two commits on main between those runs are a dependabot lockfile each. Neither touches client source. Locally, on Bun 1.3.13, `bun run build:client` reproduces the committed bundle byte for byte, so the source and the committed artifact were never out of step.

## The change

`"packageManager": "bun@1.3.13"` in `package.json`. The action reads that field when given no version, so one line pins all five setup-bun call sites: two in `ci.yml`, three in `release.yml`. The release ones build the distributed binaries, so this also decides which Bun runtime they embed.

1.3.13 rather than 1.4.2 because it is the version that produces the committed bundle: nothing is regenerated here. Pinning forward would mean recommitting `app.js` and moving the development machine at the same time, in a change whose purpose is to stop the toolchain moving.

A gate that compares the bytes of a committed build artifact cannot hold against a floating bundler. With the pin, raising the Bun version is a deliberate commit that rebuilds the bundle alongside it, which `CONTRIBUTING.md` now states, since a contributor on a different Bun sees the gate fail on a correct change.

Verified locally on 1.3.13: `bun install --frozen-lockfile` clean against the post-dependabot lock, 1799 tests pass, lint and typecheck clean, and the bundle gate passes.